### PR TITLE
ci: add website test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  javascript:
+    name: Build and JS tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Run Jest suite
+        run: npm test -- --runInBand
+
+  python:
+    name: Python and docs tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Python dependencies
+        run: uv sync --extra dev
+
+      - name: Run docs and Python tests
+        run: uv run pytest tests/python tests/docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,18 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build site for dist-backed tests
+        run: npm run build
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI for JavaScript build/tests
- Add Python/docs test job using uv

## Validation
- npm test -- --runInBand: 7 suites passed, 146 tests passed
- uv run pytest -q: 182 passed
- npm run build: 52 pages built

## Notes
- Delivered through PR for repository-rule compliance.