### PR TITLE
Scope repo-local agent memory (epic #3084)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,10 @@
+# aceengineer-website — repo-scoped memory
+
+Session context for THIS repo only (epic #3084 context-flow backbone).
+Keep entries scoped to aceengineer-website; cross-repo facts stay in workspace-hub memory.
+
+## Project
+- (repo mission summary — see config/mission/mission-map.yaml in workspace-hub)
+
+## Feedback
+- (none yet — repo-scoped feedback accrues here instead of the workspace-hub blob)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,3 +6,4 @@
 - Context budget: 16KB max (Global 2KB + Workspace 4KB + Project 8KB + Local 2KB)
 ## Repo Overrides
 <!-- Add repo-specific overrides below without weakening required gates -->
+> Memory: read THIS repo's `.claude/memory/` first; consult workspace-hub memory only for cross-repo concerns


### PR DESCRIPTION
Part of workspace-hub epic #3078 / #3084. Adds .claude/memory/ + CLAUDE.md precedence line for clean per-repo agent context.