### PR TITLE
feat(relaunch): homepage reposition + Deckhand/Platform/Proof + Solutions (7 domains)

### DIFF
--- a/config/seo/standards.yaml
+++ b/config/seo/standards.yaml
@@ -1,0 +1,165 @@
+# Programmatic-SEO manifest — standard landing pages (W8, aceengineer-website#27).
+#
+# Each entry generates content/standards/<slug>.html via
+#   uv run python scripts/seo/generate_standard_pages.py
+# The generator also rebuilds content/standards/index.html (the cluster hub) and
+# the marked <!-- BEGIN/END standards (generated) --> block in sitemap.xml.
+#
+# These pages are the SEO *cluster*; each points up to its Solutions *pillar*
+# page (W5) and, where one exists, the free calculator. Content here is sourced
+# from the digitalmodel engine + llm-wiki corpus — keep claims accurate and the
+# engineer's vocabulary (no software jargon, no "revolutionary AI").
+#
+# Field reference:
+#   slug         url slug under /standards/
+#   code         standard designation (engineer's vocabulary)
+#   name         full title of the standard / what it governs
+#   discipline   topic-cluster label
+#   pillar       {label, href}  -> Solutions page (href relative to /standards/)
+#   calculator   {label, href}  -> free calculator, or omit if none
+#   src_tag      Open Deck source tag (src_web_std_<slug>)
+#   intro        1-2 sentence lede
+#   does         bullet list — what you can ask / what it computes
+#   chips        related codes shown as chips
+#   faqs         list of {q, a} -> FAQPage schema + on-page accordion
+
+schema_version: 1
+
+standards:
+  - slug: dnv-rp-c203-fatigue
+    code: DNV-RP-C203
+    name: Fatigue design of offshore steel structures
+    discipline: Fatigue
+    pillar: { label: "Subsea, Pipelines & Integrity", href: "../solutions/subsea-pipelines-integrity.html" }
+    calculator: { label: "S-N fatigue calculator", href: "../calculators/fatigue-sn-curve.html" }
+    src_tag: src_web_std_dnv-rp-c203-fatigue
+    intro: >-
+      DNV-RP-C203 gives the S-N curves and stress-concentration guidance for fatigue
+      design of welded and bolted offshore steel details. Ask Deckhand to run a check
+      against the right curve and it returns the damage, the life, and the assumptions.
+    does:
+      - Pick the correct S-N curve for a detail (in air, seawater with or without cathodic protection) and estimate fatigue damage from a stress history.
+      - Apply stress-concentration and thickness corrections and report the governing detail.
+      - Compare a detail against DNV-RP-C203, API RP 2A and BS 7608 side by side.
+    chips: ["DNV-RP-C203", "API RP 2A-WSD", "BS 7608", "S-N curves", "Miner's rule"]
+    faqs:
+      - q: What does DNV-RP-C203 cover?
+        a: It is the recommended practice for fatigue design of offshore steel structures — S-N curves for welded, base-material and bolted details, stress-concentration factors, thickness effect, and the environment classes (air, seawater with and without cathodic protection).
+      - q: Which S-N curve should I use?
+        a: The curve depends on the detail geometry, the loading direction, the environment, and whether the weld is ground or as-welded. Deckhand selects the curve from your detail description and states the choice so a checker can verify it.
+      - q: Can you compare fatigue across standards?
+        a: Yes — the same stress history can be assessed by DNV-RP-C203, API RP 2A-WSD or BS 7608 and the results shown together, so you can see how the governing curve changes.
+
+  - slug: dnv-st-f101-wall-thickness
+    code: DNV-ST-F101
+    name: Submarine pipeline systems — pressure containment & wall thickness
+    discipline: Pipelines
+    pillar: { label: "Subsea, Pipelines & Integrity", href: "../solutions/subsea-pipelines-integrity.html" }
+    calculator: { label: "Wall-thickness calculator", href: "../calculators/wall-thickness.html" }
+    src_tag: src_web_std_dnv-st-f101-wall-thickness
+    intro: >-
+      DNV-ST-F101 is the offshore pipeline standard. Ask Deckhand to size a wall for
+      pressure containment and the collapse and combined-loading limits, with every
+      factor and assumption shown.
+    does:
+      - Size a pipeline wall for design pressure (pressure containment) with fabrication and corrosion allowances.
+      - Check system collapse and propagation buckling, and combined-loading utilisation.
+      - Screen the same line across DNV-ST-F101, ASME B31 and PD 8010 in one report.
+    chips: ["DNV-ST-F101", "ASME B31.4 / B31.8", "PD 8010", "Pressure containment", "Collapse"]
+    faqs:
+      - q: What does DNV-ST-F101 govern?
+        a: >-
+          It is the standard for submarine pipeline systems — design, materials, construction
+          and operation. The most-asked part is wall-thickness design — pressure containment,
+          local buckling/collapse, and combined loading.
+      - q: How is the minimum wall thickness determined?
+        a: From the design pressure and the pipe grade for pressure containment, plus fabrication tolerance and corrosion allowance, then verified against collapse and combined-loading limits. Deckhand reports the governing check and the utilisation.
+      - q: Can you compare design codes?
+        a: Yes — wall thickness can be screened across DNV-ST-F101, ASME B31 and PD 8010 together so the code difference is explicit.
+
+  - slug: dnv-rp-f109-on-bottom-stability
+    code: DNV-RP-F109
+    name: On-bottom stability design of submarine pipelines
+    discipline: Pipelines
+    pillar: { label: "Subsea, Pipelines & Integrity", href: "../solutions/subsea-pipelines-integrity.html" }
+    calculator: { label: "On-bottom stability calculator", href: "../calculators/on-bottom-stability.html" }
+    src_tag: src_web_std_dnv-rp-f109-on-bottom-stability
+    intro: >-
+      DNV-RP-F109 covers the stability of a subsea line on the seabed under wave and
+      current loading. Ask Deckhand to check it and get the required submerged weight
+      and the utilisation.
+    does:
+      - Work out hydrodynamic loads on a pipeline from a sea state and current and the submerged weight it needs.
+      - Run the absolute-stability and the generalised (allowed-displacement) checks.
+      - Report the stability utilisation and the concrete-coating or weight needed to pass.
+    chips: ["DNV-RP-F109", "On-bottom stability", "Hydrodynamic loads", "Submerged weight"]
+    faqs:
+      - q: What is on-bottom stability?
+        a: Whether a subsea pipeline stays put on the seabed under wave and current loads, rather than being lifted or pushed sideways. DNV-RP-F109 is the recommended practice for designing it.
+      - q: What drives the result?
+        a: The sea state and current, the pipe's submerged weight (including any concrete coating), the seabed friction, and the allowed displacement. Deckhand reports which governs and the utilisation.
+      - q: Do you size the concrete coating?
+        a: Yes — Deckhand can report the submerged weight, and hence the coating, required to bring the stability utilisation within the criterion.
+
+  - slug: dnv-rp-f105-free-span-viv
+    code: DNV-RP-F105
+    name: Free spanning pipelines — VIV and fatigue
+    discipline: Pipelines
+    pillar: { label: "Subsea, Pipelines & Integrity", href: "../solutions/subsea-pipelines-integrity.html" }
+    src_tag: src_web_std_dnv-rp-f105-free-span-viv
+    intro: >-
+      DNV-RP-F105 governs free-spanning subsea pipelines — the vortex-induced
+      vibration and the fatigue it drives. Ask Deckhand to screen a span for allowable
+      length.
+    does:
+      - Estimate a span's natural frequencies and screen it for cross-flow and in-line vortex-induced vibration.
+      - Work out the allowable free-span length for the seabed and flow conditions.
+      - Flag where a span needs intervention (rock dump, supports) to control fatigue.
+    chips: ["DNV-RP-F105", "Free span", "Vortex-induced vibration", "Span fatigue"]
+    faqs:
+      - q: Why are free spans a problem?
+        a: Where a pipeline crosses a depression it spans unsupported; current over the span sheds vortices that make it vibrate, and the cyclic stress accumulates fatigue. DNV-RP-F105 is the recommended practice for assessing it.
+      - q: What is the allowable span length?
+        a: The longest unsupported length that keeps vortex-induced vibration and the resulting fatigue within limits for the seabed and flow conditions. Deckhand estimates it and flags spans that need intervention.
+
+  - slug: api-579-fitness-for-service
+    code: API 579-1 / ASME FFS-1
+    name: Fitness-for-service assessment of in-service equipment
+    discipline: Asset integrity
+    pillar: { label: "Subsea, Pipelines & Integrity", href: "../solutions/subsea-pipelines-integrity.html" }
+    src_tag: src_web_std_api-579-fitness-for-service
+    intro: >-
+      API 579 / ASME FFS-1 is the fitness-for-service standard for in-service damage.
+      Ask Deckhand to assess a corroded line or vessel from inspection readings and get
+      a remaining-strength verdict.
+    does:
+      - Run a Level 1 / Level 2 general and local metal-loss assessment from wall-thickness readings against the design pressure.
+      - Estimate remaining strength and the maximum allowable working pressure.
+      - State the assumptions and where a Level 3 (detailed) assessment would be needed.
+    chips: ["API 579-1", "ASME FFS-1", "Fitness-for-service", "Metal loss", "Remaining strength"]
+    faqs:
+      - q: What is fitness-for-service?
+        a: A quantitative check of whether equipment with damage — corrosion, cracks, dents — is still fit to operate. API 579-1/ASME FFS-1 gives the assessment levels and acceptance criteria.
+      - q: What can Deckhand assess?
+        a: General and local metal loss at Levels 1 and 2 from wall-thickness readings against the design pressure, returning the remaining strength and the allowable pressure, with the assumptions traced.
+
+  - slug: dnv-rp-b401-cathodic-protection
+    code: DNV-RP-B401
+    name: Cathodic protection design — sacrificial anodes
+    discipline: Asset integrity
+    pillar: { label: "Subsea, Pipelines & Integrity", href: "../solutions/subsea-pipelines-integrity.html" }
+    src_tag: src_web_std_dnv-rp-b401-cathodic-protection
+    intro: >-
+      DNV-RP-B401 is the recommended practice for sacrificial-anode cathodic-protection
+      design. Ask Deckhand to size the anodes for a structure and get the current
+      demand and anode mass.
+    does:
+      - Work out current demand from surface areas, coating breakdown and design life.
+      - Size the sacrificial-anode mass and number, and check the final-current capacity.
+      - Apply it to a jacket, manifold, monopile, FPSO hull or pipeline.
+    chips: ["DNV-RP-B401", "DNV-RP-F103", "Cathodic protection", "Sacrificial anodes", "Coating breakdown"]
+    faqs:
+      - q: What does DNV-RP-B401 cover?
+        a: The design of sacrificial-anode cathodic-protection systems for offshore structures — current-density demand, coating breakdown factors, anode mass and current-capacity checks over the design life.
+      - q: What structures can Deckhand size?
+        a: Jackets, subsea manifolds, offshore-wind monopiles, FPSO hulls and pipelines (the pipeline case uses DNV-RP-F103 for anode spacing and reach).

--- a/content/deckhand.html
+++ b/content/deckhand.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Deckhand is an AI engineering agent you drive from chat. Ask in plain language; it runs the real, standards-traceable calculation and returns deterministic deliverables and pull requests under hard, auditable guardrails.">
+    <meta name="keywords" content="AI engineering agent, engineering chatbot, OrcaFlex AI, fatigue analysis AI, offshore engineering automation, standards-traceable AI, deterministic engineering deliverables, Open Deck">
+
+    <meta property="og:title" content="Deckhand — An AI Engineering Agent You Drive From Chat">
+    <meta property="og:description" content="Real analysis, documentation, issues and pull requests from a chat message — executed by an AI agent under hard, auditable guardrails. Standards-traceable. Deterministic.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/deckhand.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Deckhand — An AI Engineering Agent You Drive From Chat">
+    <meta name="twitter:description" content="AI that does real offshore engineering — and shows its work.">
+
+    <title>Deckhand — AI Engineering Agent for Offshore Energy | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <!-- SoftwareApplication schema -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Deckhand",
+        "applicationCategory": "BusinessApplication",
+        "operatingSystem": "Telegram, WhatsApp, Microsoft Teams",
+        "description": "An AI engineering agent you drive from chat. It runs standards-traceable, deterministic offshore-engineering calculations and returns deliverables and pull requests under hard, auditable guardrails.",
+        "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+            "name": "Open Deck — free tier"
+        },
+        "publisher": { "@id": "https://aceengineer.com/#organization" }
+    }
+    </script>
+
+    <!-- FAQ schema -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": "What can Deckhand do?",
+                "acceptedAnswer": { "@type": "Answer", "text": "Run real offshore / oil & gas engineering calculations from a chat message — wall thickness, on-bottom stability, fatigue, fitness-for-service, vessel motions, mooring, field economics — and return a deliverable with assumptions traced and changes delivered as pull requests." }
+            },
+            {
+                "@type": "Question",
+                "name": "Is Deckhand deterministic?",
+                "acceptedAnswer": { "@type": "Answer", "text": "Yes. Calculations run on the open-source digitalmodel engine, not free-form model output. The same input produces the same output every time — audit-ready, traceable to a DNV / API / ISO / ASME clause." }
+            },
+            {
+                "@type": "Question",
+                "name": "How do I try it?",
+                "acceptedAnswer": { "@type": "Answer", "text": "Join the free Open Deck tier on Telegram and ask a real engineering question on open, MIT-licensed repositories. For confidential client work we run isolated private scopes." }
+            }
+        ]
+    }
+    </script>
+
+    <style>
+        .step-card { background:#fff; border:1px solid #e6e8eb; border-radius:10px; padding:28px; margin-bottom:24px; height:100%; }
+        .step-card .step-num { display:inline-block; width:34px; height:34px; line-height:34px; text-align:center; border-radius:50%; background:#2c3e50; color:#fff; font-weight:700; margin-bottom:10px; }
+        .tier-card { background:#fff; border:1px solid #e6e8eb; border-radius:10px; padding:32px; margin-bottom:24px; }
+        .tier-card.tier-open { border-top:4px solid #1f8a4c; }
+        .tier-card.tier-private { border-top:4px solid #2c3e50; }
+        .tier-card ul { padding-left:18px; }
+        .guardrail-row { background:#f8f9fa; padding:56px 0; }
+        .guardrail-item { padding:14px; }
+        .guardrail-item .g-icon { font-size:1.6em; margin-right:8px; }
+        .domain-chip { display:inline-block; background:#eef1f4; color:#2c3e50; border-radius:16px; padding:6px 14px; margin:5px; font-size:0.92em; }
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:40px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h1 class="hero-title">Deckhand</h1>
+                    <p class="hero-subtitle">An AI engineering agent you drive from chat. Ask a real offshore / oil &amp; gas question in plain language &mdash; Deckhand runs the actual calculation against the right standard and returns a deliverable that shows its work.</p>
+                    <div class="hero-cta">
+                        <!-- OPEN_DECK_CTA: live group invite. Swap to https://t.me/the_deckhand_bot?start=src_web_deckhand_hero once deckhand#432 handler is live. -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_deckhand_hero">Try Open Deck &mdash; free</a>
+                        <a href="proof.html" class="btn btn-default btn-lg">See the proof</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- How it works -->
+    <section style="padding:64px 0;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">How it works</h2>
+                    <p class="section-subtitle text-center">Chat &rarr; action &rarr; result &mdash; with enforcement below the model.</p>
+                    <div class="row">
+                        <div class="col-md-3"><div class="step-card"><span class="step-num">1</span><h3>Ask</h3><p>Send an engineering question in plain language &mdash; no syntax, no software jargon required.</p></div></div>
+                        <div class="col-md-3"><div class="step-card"><span class="step-num">2</span><h3>Run</h3><p>Deckhand picks the right method and standard and runs the real calculation on the digitalmodel engine.</p></div></div>
+                        <div class="col-md-3"><div class="step-card"><span class="step-num">3</span><h3>Show its work</h3><p>You get the number, the governing clause, and the assumption ledger &mdash; nothing hidden.</p></div></div>
+                        <div class="col-md-3"><div class="step-card"><span class="step-num">4</span><h3>Deliver</h3><p>Calculation notes and code changes arrive as pull requests you can review and merge.</p></div></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Guardrails -->
+    <section class="guardrail-row">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">Hard, auditable guardrails</h2>
+                    <p class="section-subtitle text-center">The enforcement sits below the model, not in a prompt.</p>
+                    <div class="row">
+                        <div class="col-md-6"><div class="guardrail-item"><span class="g-icon">&#128274;</span><strong>Scoped access.</strong> Each channel is bound to specific repositories. Everything out of scope returns 404 &mdash; verified, not promised.</div></div>
+                        <div class="col-md-6"><div class="guardrail-item"><span class="g-icon">&#128221;</span><strong>PR-only changes.</strong> No force-push, no history rewrite, no deletes. Every change is a reviewable pull request.</div></div>
+                        <div class="col-md-6"><div class="guardrail-item"><span class="g-icon">&#9878;</span><strong>Standards-traceable.</strong> Every result maps to a DNV / API / ISO / ASME clause.</div></div>
+                        <div class="col-md-6"><div class="guardrail-item"><span class="g-icon">&#128202;</span><strong>Audit trail.</strong> Every action is logged; fine-grained credentials per scope; client data never mixes across scopes.</div></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Tiers -->
+    <section style="padding:64px 0;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">Two ways to run it</h2>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="tier-card tier-open">
+                                <h3>Open Deck &mdash; free</h3>
+                                <p>A Telegram community for engineers trying Deckhand on open, MIT-licensed engineering work.</p>
+                                <ul>
+                                    <li>Reads, analyses, documentation drafts and reviews</li>
+                                    <li>Changes arrive as pull requests to a public sandbox</li>
+                                    <li>No force-push, history rewrite, or deletes</li>
+                                    <li>Scoped to open repos only &mdash; everything else returns 404</li>
+                                </ul>
+                                <!-- OPEN_DECK_CTA -->
+                                <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary" data-cta="open-deck" data-src="src_web_deckhand_tier">Join Open Deck</a>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="tier-card tier-private">
+                                <h3>Private scopes &mdash; for client work</h3>
+                                <p>Confidential, proprietary, and licensed-solver work runs on isolated scopes with their own data, servers, and credentials.</p>
+                                <ul>
+                                    <li>Dedicated repositories and fine-grained credentials</li>
+                                    <li>Full reply visibility within your channel</li>
+                                    <li>Domain-specific knowledge packs</li>
+                                    <li>Nothing client-specific touches the open tier</li>
+                                </ul>
+                                <a href="contact.html" class="btn btn-default">Talk to us</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Domains -->
+    <section style="padding:48px 0; background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1 text-center">
+                    <h2 class="section-title">What it covers</h2>
+                    <p class="section-subtitle">Drawn from ~30 engineering disciplines in the digitalmodel platform.</p>
+                    <div>
+                        <span class="domain-chip">Wall thickness &amp; pipe capacity</span>
+                        <span class="domain-chip">On-bottom stability &amp; free-span / VIV</span>
+                        <span class="domain-chip">Fatigue (S-N, spectral)</span>
+                        <span class="domain-chip">Fitness-for-service (API 579)</span>
+                        <span class="domain-chip">Cathodic protection</span>
+                        <span class="domain-chip">Mooring &amp; riser design</span>
+                        <span class="domain-chip">Vessel motions &amp; seakeeping</span>
+                        <span class="domain-chip">Hydrodynamics (OrcaWave / AQWA)</span>
+                        <span class="domain-chip">OrcaFlex model generation</span>
+                        <span class="domain-chip">Field development economics</span>
+                    </div>
+                    <p style="margin-top:24px;"><a href="platform.html" class="btn btn-info">See the platform</a></p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h2>Bring a real question</h2>
+                    <p>Open Deck is free for known industry contacts. Ask something from your actual work and watch the agent run it, traced to the standard.</p>
+                    <!-- OPEN_DECK_CTA -->
+                    <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_deckhand_footer">Try Open Deck on Telegram</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/index.html
+++ b/content/index.html
@@ -429,6 +429,7 @@
                         <span class="standard-badge">ASME B31.8</span>
                         <span class="standard-badge">API RP 2RD</span>
                     </div>
+                    <p style="margin-top:20px;"><a href="standards/" class="btn btn-default">Explore standards you can run</a></p>
                 </div>
             </div>
         </div>

--- a/content/index.html
+++ b/content/index.html
@@ -342,30 +342,32 @@
             <div class="row">
                 <div class="col-md-10 col-md-offset-1">
                     <h2 class="section-title text-center">Solutions by domain</h2>
+                    <p class="section-subtitle text-center">Each maps to a live Deckhand channel you can try on Open Deck.</p>
 
                     <div class="row vertical-cards">
                         <div class="col-md-4">
                             <div class="vertical-card">
                                 <h3>Subsea, Pipelines &amp; Integrity</h3>
-                                <p class="vertical-problem">Wall thickness, on-bottom stability, free-span / VIV, fitness-for-service.</p>
-                                <a href="engineering.html" class="btn btn-sm btn-info">Explore</a>
+                                <p class="vertical-problem">Wall thickness, on-bottom stability, free-span / VIV, fitness-for-service, cathodic protection.</p>
+                                <a href="solutions/subsea-pipelines-integrity.html" class="btn btn-sm btn-info">Explore</a>
                             </div>
                         </div>
                         <div class="col-md-4">
                             <div class="vertical-card">
                                 <h3>Floating &amp; Marine Systems</h3>
-                                <p class="vertical-problem">Vessel motions, mooring, riser analysis, installation feasibility.</p>
-                                <a href="engineering.html" class="btn btn-sm btn-info">Explore</a>
+                                <p class="vertical-problem">Mooring fatigue, FPSO spread mooring, vessel motions &amp; stability, hydrodynamics.</p>
+                                <a href="solutions/floating-marine.html" class="btn btn-sm btn-info">Explore</a>
                             </div>
                         </div>
                         <div class="col-md-4">
                             <div class="vertical-card">
-                                <h3>Energy Data &amp; Economics</h3>
-                                <p class="vertical-problem">BSEE production data, decline curves, NPV / MIRR field economics.</p>
-                                <a href="energy.html" class="btn btn-sm btn-info">Explore</a>
+                                <h3>Wells &amp; Subsurface</h3>
+                                <p class="vertical-problem">Production forecasting, field NPV / economics, nodal analysis, rod-pump diagnostics.</p>
+                                <a href="solutions/wells-subsurface.html" class="btn btn-sm btn-info">Explore</a>
                             </div>
                         </div>
                     </div>
+                    <p class="text-center" style="margin-top:8px;"><a href="solutions/" class="btn btn-default">View all 7 solution domains</a></p>
                 </div>
             </div>
         </div>

--- a/content/index.html
+++ b/content/index.html
@@ -3,22 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Offshore engineering calculations you can trust. Traceable to 17 international standards. Free interactive calculators, automation services, and consulting for subsea, fatigue, and structural analysis.">
-    <meta name="keywords" content="offshore engineering automation, OrcaFlex automation, AQWA automation, fatigue analysis, mooring design, riser analysis, subsea engineering, offshore wind engineering">
+    <meta name="description" content="The AI engineering firm for offshore energy. Deckhand drives real analysis, documentation, and pull requests from chat — under hard, auditable guardrails. Standards-traceable, deterministic deliverables.">
+    <meta name="keywords" content="AI engineering, offshore energy AI, OrcaFlex automation, fatigue analysis, mooring design, riser analysis, subsea engineering, deterministic engineering, standards-traceable calculations, engineering AI agent">
 
     <!-- Open Graph meta tags -->
-    <meta property="og:title" content="AceEngineer - Engineering Calculations Traceable to International Standards">
-    <meta property="og:description" content="Free offshore engineering calculators and automation services. Every calculation traces to its standard. DNV, API, ASME, BS compliance.">
+    <meta property="og:title" content="AceEngineer — The AI Engineering Firm for Offshore Energy">
+    <meta property="og:description" content="Deckhand drives real engineering work from a chat message — analysis, documentation, issues and pull requests — executed by an AI agent under hard, auditable guardrails. Standards-traceable. Deterministic.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://aceengineer.com">
     <meta property="og:site_name" content="Analytical & Computational Engineering">
 
     <!-- Twitter Card meta tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="AceEngineer - Engineering Calculations Traceable to International Standards">
-    <meta name="twitter:description" content="Free offshore engineering calculators and automation services. Every calculation traces to its standard.">
+    <meta name="twitter:title" content="AceEngineer — The AI Engineering Firm for Offshore Energy">
+    <meta name="twitter:description" content="An AI agent that does real offshore engineering — and shows its work. Standards-traceable, deterministic deliverables.">
 
-    <title>Offshore Engineering Calculations & Automation | AceEngineer</title>
+    <title>The AI Engineering Firm for Offshore Energy | AceEngineer</title>
 
     <include src="partials/head-common.html"></include>
 
@@ -32,7 +32,7 @@
         "alternateName": "AceEngineer",
         "url": "https://aceengineer.com",
         "logo": "https://aceengineer.com/assets/img/logo.png",
-        "description": "Engineering automation for offshore and energy industries. OrcaFlex automation, AQWA integration, fatigue analysis, and mooring design.",
+        "description": "The AI engineering firm for offshore energy. Deckhand, an AI engineering agent, runs standards-traceable, deterministic analysis for subsea, mooring, fatigue, hydrodynamics, and field development — built on the open-source digitalmodel library.",
         "foundingDate": "2010",
         "areaServed": ["United States", "United Kingdom", "Norway", "Brazil"],
         "sameAs": [
@@ -52,13 +52,15 @@
             "availableLanguage": "English"
         },
         "knowsAbout": [
+            "AI engineering agents",
             "OrcaFlex automation",
-            "AQWA hydrodynamic analysis",
+            "OrcaWave and AQWA hydrodynamic analysis",
             "Fatigue analysis",
             "Mooring system design",
             "Riser engineering",
-            "Offshore wind foundations",
-            "Subsea engineering"
+            "Fitness-for-service (API 579)",
+            "Subsea pipelines",
+            "Offshore field development economics"
         ]
     }
     </script>
@@ -68,37 +70,37 @@
     {
         "@context": "https://schema.org",
         "@type": "Service",
-        "serviceType": "Engineering Automation Services",
+        "serviceType": "AI Engineering Services for Offshore Energy",
         "provider": {
             "@id": "https://aceengineer.com/#organization"
         },
         "areaServed": "Worldwide",
         "hasOfferCatalog": {
             "@type": "OfferCatalog",
-            "name": "Engineering Automation Solutions",
+            "name": "AI Engineering Solutions",
             "itemListElement": [
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "OrcaFlex Automation",
-                        "description": "Batch processing for riser, mooring, and dynamic analysis"
+                        "name": "Deckhand — AI Engineering Agent",
+                        "description": "Drive real engineering work — analysis, documentation, issues and pull requests — from a chat message, executed by an AI agent under hard, auditable guardrails."
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "Fatigue Analysis Automation",
-                        "description": "221 S-N curves from DNV, API, BS standards with batch processing"
+                        "name": "Engineering Platform (digitalmodel)",
+                        "description": "7,000+ standard-mapped functions across ~30 engineering disciplines; every result traces to a DNV, API, ISO, or ASME clause."
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "AQWA Automation",
-                        "description": "Hydrodynamic model generation and post-processing"
+                        "name": "Fatigue & Hydrodynamics Automation",
+                        "description": "221 S-N curves from 17 standards; OrcaFlex / OrcaWave / AQWA model generation and post-processing."
                     }
                 }
             ]
@@ -126,6 +128,26 @@
             margin-top: 0;
             color: #2c3e50;
         }
+        /* Deckhand intro */
+        .deckhand-section { padding: 72px 0; background: #fff; }
+        .chat-demo {
+            max-width: 520px; margin: 0 auto;
+            border: 1px solid #e0e0e0; border-radius: 12px; overflow: hidden;
+            box-shadow: 0 6px 24px rgba(0,0,0,0.08); background: #fbfcfd;
+        }
+        .chat-demo .chat-head {
+            background: #2c3e50; color: #fff; padding: 12px 16px; font-size: 0.95em; font-weight: 600;
+        }
+        .chat-demo .bubble { margin: 14px 16px; padding: 10px 14px; border-radius: 14px; line-height: 1.45; }
+        .chat-demo .from-user { background: #d9eafc; margin-left: 60px; }
+        .chat-demo .from-bot  { background: #eef1f4; margin-right: 40px; }
+        .chat-demo .bubble code { background: rgba(0,0,0,0.06); padding: 1px 5px; border-radius: 4px; }
+        .chat-demo .meta { font-size: 0.82em; color: #6b7785; }
+        .deterministic-strip { background: #2c3e50; color: #fff; padding: 56px 0; }
+        .deterministic-strip .pillar { text-align: center; padding: 12px; }
+        .deterministic-strip .pillar h3 { color: #fff; margin: 8px 0; }
+        .deterministic-strip .pillar p { color: rgba(255,255,255,0.78); }
+        .deterministic-strip .pill-emoji { font-size: 2em; }
     </style>
 </head>
 <body>
@@ -137,12 +159,73 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-8 col-md-offset-2 text-center">
-                    <h1 class="hero-title">Engineering Calculations You Can Trust.<br>Traceable to International Standards.</h1>
-                    <p class="hero-subtitle">Tethering timeless engineering to a single source of truth. Every calculation traces to its standard, every standard to its implementation. Powered by open-source digitalmodel.</p>
-                    <p class="hero-identity">Analytical &amp; Computational Engineering &mdash; 15+ years of offshore engineering, 17 international standards, 704+ production-tested Python modules</p>
+                    <h1 class="hero-title">The AI engineering firm<br>for offshore energy.</h1>
+                    <p class="hero-subtitle">Deckhand drives real engineering work &mdash; analysis, documentation, issues and pull requests &mdash; straight from a chat message, executed by an AI agent under hard, auditable guardrails. Standards-traceable. Deterministic. It shows its work.</p>
+                    <p class="hero-identity">Built on the open-source <strong>digitalmodel</strong> library &mdash; 7,000+ standard-mapped functions, 42 standards implemented, ~30 engineering disciplines.</p>
                     <div class="hero-cta">
-                        <a href="contact.html" class="btn btn-primary btn-lg">Get a Free Assessment</a>
-                        <a href="case-studies/" class="btn btn-default btn-lg">See Case Studies</a>
+                        <!-- OPEN_DECK_CTA: live group invite. Swap to https://t.me/the_deckhand_bot?start=src_web_home_hero once deckhand#432 handler is live. -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_home_hero">Try Open Deck &mdash; free</a>
+                        <a href="proof.html" class="btn btn-default btn-lg">See the proof</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Meet Deckhand -->
+    <section class="deckhand-section">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-5">
+                    <h2 class="section-title">Meet Deckhand</h2>
+                    <p class="section-subtitle" style="text-align:left;">Ask an engineering question in plain language. Deckhand runs the real calculation &mdash; against the right standard &mdash; and returns a deliverable with every assumption traced. Changes to code or docs arrive as pull requests, never silent edits.</p>
+                    <ul>
+                        <li><strong>AI that shows its work</strong> &mdash; assumptions, standards, and scope limits on every result.</li>
+                        <li><strong>Deterministic</strong> &mdash; same input, same output, audit-ready.</li>
+                        <li><strong>Governed</strong> &mdash; PR-only, no force-push or deletes; everything out of scope returns 404.</li>
+                    </ul>
+                    <p>
+                        <a href="deckhand.html" class="btn btn-info">How Deckhand works</a>
+                        <!-- OPEN_DECK_CTA -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-default" data-cta="open-deck" data-src="src_web_home_meet">Try it on Telegram</a>
+                    </p>
+                </div>
+                <div class="col-md-6 col-md-offset-1">
+                    <div class="chat-demo" aria-label="Example Deckhand conversation">
+                        <div class="chat-head">Open Deck &middot; @the_deckhand_bot</div>
+                        <div class="bubble from-user">Wall thickness for a 12" pipeline, 10 MPa design pressure, X65 &mdash; DNV-ST-F101?</div>
+                        <div class="bubble from-bot">Minimum wall <strong>9.5 mm</strong> (incl. 1.0 mm corrosion allowance). Governing check: pressure containment, DNV-ST-F101 (2021) §5.4.2. Utilisation 0.81.<br><span class="meta">Assumptions: SMYS 450 MPa, t<sub>fab</sub> −12.5%, no buckling check requested. Full note &amp; PR ready on request.</span></div>
+                        <div class="bubble from-user">Add the local buckling check.</div>
+                        <div class="bubble from-bot">Done &mdash; combined loading per §5.4.4 passes (utilisation 0.88). Opened <code>PR #42</code> with the calculation note + inputs.</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Deterministic by design strip -->
+    <section class="deterministic-strip">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1 text-center">
+                    <h2 class="section-title" style="color:#fff;">Deterministic by design</h2>
+                    <p class="section-subtitle" style="color:rgba(255,255,255,0.8);">The thing practising engineers actually need from AI: the same answer every time, traceable to a clause, defensible in review.</p>
+                    <div class="row" style="margin-top:24px;">
+                        <div class="col-md-4 pillar">
+                            <div class="pill-emoji">&#9878;</div>
+                            <h3>Standards-traceable</h3>
+                            <p>Every result maps to a DNV / API / ISO / ASME clause. 42 standards implemented.</p>
+                        </div>
+                        <div class="col-md-4 pillar">
+                            <div class="pill-emoji">&#128290;</div>
+                            <h3>680 byte-identical cases</h3>
+                            <p>Reproducible by construction &mdash; same input, same output, no model drift.</p>
+                        </div>
+                        <div class="col-md-4 pillar">
+                            <div class="pill-emoji">&#128221;</div>
+                            <h3>Assumption ledger</h3>
+                            <p>It states what it assumed and where the scope ends &mdash; AI that shows its work.</p>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -155,7 +238,7 @@
             <div class="row">
                 <div class="col-md-10 col-md-offset-1">
                     <h2 class="section-title text-center">Try Our Engineering Calculators</h2>
-                    <p class="section-subtitle text-center">Free, browser-based tools built on international standards. No signup required.</p>
+                    <p class="section-subtitle text-center">Free, browser-based tools built on international standards &mdash; the same engine Deckhand runs. No signup required.</p>
                     <div class="row">
                         <div class="col-md-4">
                             <div class="showcase-card text-center">
@@ -203,113 +286,16 @@
                         </div>
                         <div class="col-md-4">
                             <div class="pain-card">
-                                <div class="pain-icon">&#128203;</div>
-                                <h3>Standards Compliance Burden</h3>
-                                <p>Keeping up with DNV, API, and ABS requirements is a full-time job. S-N curve updates, SCF calculations, documentation&mdash;it never ends.</p>
+                                <div class="pain-icon">&#129302;</div>
+                                <h3>AI You Can't Defend</h3>
+                                <p>Generic chatbots give a different answer every time and cite nothing. You can't put that in a calculation note or hand it to a checker.</p>
                             </div>
                         </div>
                         <div class="col-md-4">
                             <div class="pain-card">
                                 <div class="pain-icon">&#128101;</div>
                                 <h3>Knowledge Concentration Risk</h3>
-                                <p>Your OrcaFlex expertise lives in the heads of 1-2 senior engineers. When they're unavailable, projects stall.</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Why AceEngineer Section -->
-    <section class="why-section">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-10 col-md-offset-1">
-                    <h2 class="section-title text-center">Why AceEngineer</h2>
-                    <div class="row">
-                        <div class="col-md-4">
-                            <div class="why-card text-center">
-                                <div class="why-number">704+</div>
-                                <h3>Production Modules</h3>
-                                <p>Validated, tested, production-grade Python code covering fatigue, mooring, riser analysis, and more. Not prototypes&mdash;battle-tested tools used on real projects.</p>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="why-card text-center">
-                                <div class="why-number">15+</div>
-                                <h3>Years Offshore Experience</h3>
-                                <p>Deep expertise in DNV, API, ABS, and Norsok standards. Gulf of Mexico, North Sea, and global deepwater projects. We speak your engineering language.</p>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="why-card text-center">
-                                <div class="why-number">60-80%</div>
-                                <h3>Automated Time Savings</h3>
-                                <p>We deliver automated workflows, not consulting hours. You send a design matrix, we return validated results&mdash;often overnight.</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Solution Section -->
-    <section class="solution-section">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-10 col-md-offset-1">
-                    <h2 class="section-title text-center">Engineering Automation That Actually Works</h2>
-                    <p class="section-subtitle text-center">We don't sell consulting hours. We deliver automated engineering pipelines that run while you sleep.</p>
-
-                    <div class="row solution-features">
-                        <div class="col-md-6">
-                            <div class="solution-feature">
-                                <h3>OrcaFlex Automation</h3>
-                                <ul>
-                                    <li>Batch model generation from design matrices</li>
-                                    <li>Automated sensitivity studies (50+ cases overnight)</li>
-                                    <li>Results extraction to standardized reports</li>
-                                    <li>VIV analysis and fatigue post-processing</li>
-                                </ul>
-                                <p class="feature-result"><strong>Result:</strong> 50 riser configurations in 4 hours, not 50 hours</p>
-                            </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="solution-feature">
-                                <h3>Fatigue Analysis Library</h3>
-                                <ul>
-                                    <li>221 S-N curves from 17 international standards</li>
-                                    <li>DNV-RP-C203, API RP 2A, BS 7608, ABS, Norsok</li>
-                                    <li>Automated SCF calculation and damage assessment</li>
-                                    <li>Batch processing for 200+ joint inventories</li>
-                                </ul>
-                                <p class="feature-result"><strong>Result:</strong> Platform fatigue assessment in days, not weeks</p>
-                            </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="solution-feature">
-                                <h3>AQWA Integration</h3>
-                                <ul>
-                                    <li>Hydrodynamic model generation</li>
-                                    <li>RAO processing and response analysis</li>
-                                    <li>Vessel operability studies</li>
-                                    <li>Weather window analysis</li>
-                                </ul>
-                                <p class="feature-result"><strong>Result:</strong> 100+ sea state combinations analyzed automatically</p>
-                            </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="solution-feature">
-                                <h3>Mooring & Riser Design</h3>
-                                <ul>
-                                    <li>Catenary and lazy wave riser analysis</li>
-                                    <li>SALM and taut mooring systems</li>
-                                    <li>Anchor design and verification</li>
-                                    <li>Installation engineering</li>
-                                </ul>
-                                <p class="feature-result"><strong>Result:</strong> Mooring sensitivity studies with full documentation</p>
+                                <p>Your OrcaFlex and standards expertise lives in the heads of 1-2 senior engineers. When they're unavailable, projects stall.</p>
                             </div>
                         </div>
                     </div>
@@ -325,24 +311,24 @@
                 <div class="col-md-10 col-md-offset-1">
                     <div class="metrics-row">
                         <div class="metric-box">
+                            <div class="metric-value">7,000+</div>
+                            <div class="metric-label">Standard-Mapped Functions</div>
+                            <div class="metric-detail">Across ~30 disciplines</div>
+                        </div>
+                        <div class="metric-box">
+                            <div class="metric-value">42</div>
+                            <div class="metric-label">Standards</div>
+                            <div class="metric-detail">DNV, API, ISO, ASME, BS&hellip;</div>
+                        </div>
+                        <div class="metric-box">
                             <div class="metric-value">221</div>
                             <div class="metric-label">S-N Curves</div>
-                            <div class="metric-detail">From DNV, API, BS, ABS, Norsok</div>
+                            <div class="metric-detail">From 17 fatigue standards</div>
                         </div>
                         <div class="metric-box">
-                            <div class="metric-value">60-80%</div>
-                            <div class="metric-label">Time Savings</div>
-                            <div class="metric-detail">vs. manual analysis</div>
-                        </div>
-                        <div class="metric-box">
-                            <div class="metric-value">704+</div>
-                            <div class="metric-label">Python Modules</div>
-                            <div class="metric-detail">Production-tested code</div>
-                        </div>
-                        <div class="metric-box">
-                            <div class="metric-value">17</div>
-                            <div class="metric-label">Standards</div>
-                            <div class="metric-detail">International compliance</div>
+                            <div class="metric-value">680</div>
+                            <div class="metric-label">Byte-Identical Cases</div>
+                            <div class="metric-detail">Deterministic by construction</div>
                         </div>
                     </div>
                 </div>
@@ -350,36 +336,33 @@
         </div>
     </section>
 
-    <!-- Verticals Section -->
+    <!-- Solutions / Verticals Section -->
     <section class="verticals-section">
         <div class="container">
             <div class="row">
                 <div class="col-md-10 col-md-offset-1">
-                    <h2 class="section-title text-center">Who We Help</h2>
+                    <h2 class="section-title text-center">Solutions by domain</h2>
 
                     <div class="row vertical-cards">
                         <div class="col-md-4">
                             <div class="vertical-card">
-                                <h3>Offshore Engineering Firms</h3>
-                                <p class="vertical-problem"><strong>Problem:</strong> Engineers drowning in repetitive OrcaFlex tasks</p>
-                                <p class="vertical-solution"><strong>Solution:</strong> Batch automation that runs 50+ cases overnight</p>
-                                <a href="engineering.html#offshore" class="btn btn-sm btn-info" aria-label="Learn more about offshore engineering automation">Learn More<span class="sr-only"> about offshore engineering automation</span></a>
+                                <h3>Subsea, Pipelines &amp; Integrity</h3>
+                                <p class="vertical-problem">Wall thickness, on-bottom stability, free-span / VIV, fitness-for-service.</p>
+                                <a href="engineering.html" class="btn btn-sm btn-info">Explore</a>
                             </div>
                         </div>
                         <div class="col-md-4">
                             <div class="vertical-card">
-                                <h3>Offshore Wind Developers</h3>
-                                <p class="vertical-problem"><strong>Problem:</strong> Monopile fatigue analysis bottleneck (200+ joints)</p>
-                                <p class="vertical-solution"><strong>Solution:</strong> Pre-validated DNV curves with batch processing</p>
-                                <a href="engineering.html#wind" class="btn btn-sm btn-info" aria-label="Learn more about offshore wind foundation analysis">Learn More<span class="sr-only"> about offshore wind analysis</span></a>
+                                <h3>Floating &amp; Marine Systems</h3>
+                                <p class="vertical-problem">Vessel motions, mooring, riser analysis, installation feasibility.</p>
+                                <a href="engineering.html" class="btn btn-sm btn-info">Explore</a>
                             </div>
                         </div>
                         <div class="col-md-4">
                             <div class="vertical-card">
-                                <h3>EPC Contractors</h3>
-                                <p class="vertical-problem"><strong>Problem:</strong> Weather window analysis delays installation</p>
-                                <p class="vertical-solution"><strong>Solution:</strong> Automated operability studies in real-time</p>
-                                <a href="engineering.html#epc" class="btn btn-sm btn-info" aria-label="Learn more about EPC contractor automation">Learn More<span class="sr-only"> about EPC contractor solutions</span></a>
+                                <h3>Energy Data &amp; Economics</h3>
+                                <p class="vertical-problem">BSEE production data, decline curves, NPV / MIRR field economics.</p>
+                                <a href="energy.html" class="btn btn-sm btn-info">Explore</a>
                             </div>
                         </div>
                     </div>
@@ -419,39 +402,9 @@
                             </div>
                         </div>
                     </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Integration Badges -->
-    <section class="badges-section">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-10 col-md-offset-1 text-center">
-                    <h2 class="section-title">Software & Standards Integration</h2>
-                    <div class="badges-row">
-                        <div class="badge-item">
-                            <div class="badge-icon">OrcaFlex</div>
-                            <div class="badge-label">Full API Integration</div>
-                        </div>
-                        <div class="badge-item">
-                            <div class="badge-icon">AQWA</div>
-                            <div class="badge-label">Automation Ready</div>
-                        </div>
-                        <div class="badge-item">
-                            <div class="badge-icon">DNV</div>
-                            <div class="badge-label">RP-C203 Validated</div>
-                        </div>
-                        <div class="badge-item">
-                            <div class="badge-icon">API</div>
-                            <div class="badge-label">RP 2A Compliant</div>
-                        </div>
-                        <div class="badge-item">
-                            <div class="badge-icon">Python</div>
-                            <div class="badge-label">Open Source Tools</div>
-                        </div>
-                    </div>
+                    <p class="text-center" style="margin-top: 24px;">
+                        <a href="proof.html" class="btn btn-default">See how we prove it</a>
+                    </p>
                 </div>
             </div>
         </div>
@@ -463,36 +416,16 @@
             <div class="row">
                 <div class="col-md-10 col-md-offset-1 text-center">
                     <h2 class="section-title">Standards Compliance You Can Trust</h2>
-                    <p class="section-subtitle">17 international standards codified into automated, auditable workflows</p>
+                    <p class="section-subtitle">International standards codified into automated, auditable workflows</p>
                     <div class="standards-badges">
                         <span class="standard-badge">DNV-RP-C203</span>
+                        <span class="standard-badge">DNV-ST-F101</span>
                         <span class="standard-badge">API RP 2A</span>
+                        <span class="standard-badge">API 579</span>
                         <span class="standard-badge">BS 7608</span>
-                        <span class="standard-badge">ABS</span>
-                        <span class="standard-badge">Norsok</span>
-                        <span class="standard-badge">IEC 61400-3</span>
+                        <span class="standard-badge">DNV-RP-F109</span>
                         <span class="standard-badge">ASME B31.8</span>
                         <span class="standard-badge">API RP 2RD</span>
-                    </div>
-                    <div class="row" style="margin-top: 30px;">
-                        <div class="col-md-4">
-                            <div class="proof-item">
-                                <strong>221 S-N Curves</strong>
-                                <p>From 17 international fatigue standards</p>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="proof-item">
-                                <strong>8 Design Codes</strong>
-                                <p>Wall thickness, riser, and pressure vessel</p>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="proof-item">
-                                <strong>245 Curated Datasets</strong>
-                                <p>BSEE, metocean, production, and HSE data</p>
-                            </div>
-                        </div>
                     </div>
                 </div>
             </div>
@@ -504,10 +437,11 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-8 col-md-offset-2 text-center">
-                    <h2>Stop Paying for Manual Work</h2>
-                    <p>Get a free assessment of how much time and cost automation could save your team.</p>
-                    <a href="contact.html" class="btn btn-primary btn-lg">Request Free Assessment</a>
-                    <p class="cta-note">We'll analyze your typical workflow and provide a custom automation proposal.</p>
+                    <h2>Put an AI engineer to work &mdash; free</h2>
+                    <p>Open Deck is the free tier: bring a real offshore / oil &amp; gas question and watch Deckhand run it, traced to the standard, on open repos.</p>
+                    <!-- OPEN_DECK_CTA -->
+                    <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_home_footer">Join Open Deck on Telegram</a>
+                    <p class="cta-note">For private, client-confidential work we run isolated scopes &mdash; <a href="contact.html">talk to us</a>.</p>
                 </div>
             </div>
         </div>

--- a/content/partials/footer.html
+++ b/content/partials/footer.html
@@ -12,6 +12,7 @@
                     <li><a href="{{ rootPath }}deckhand.html">Deckhand</a></li>
                     <li><a href="{{ rootPath }}platform.html">Platform</a></li>
                     <li><a href="{{ rootPath }}solutions/">Solutions</a></li>
+                    <li><a href="{{ rootPath }}engineering.html">Services</a></li>
                     <li><a href="{{ rootPath }}proof.html">Proof</a></li>
                     <li><a href="{{ rootPath }}calculators/">Free Calculators</a></li>
                     <li><a href="{{ rootPath }}energy.html">Energy Data</a></li>

--- a/content/partials/footer.html
+++ b/content/partials/footer.html
@@ -9,11 +9,14 @@
             <div class="col-md-4">
                 <h3>Quick Links</h3>
                 <ul class="footer-links">
-                    <li><a href="{{ rootPath }}engineering.html">Services</a></li>
+                    <li><a href="{{ rootPath }}deckhand.html">Deckhand</a></li>
+                    <li><a href="{{ rootPath }}platform.html">Platform</a></li>
+                    <li><a href="{{ rootPath }}engineering.html">Solutions</a></li>
+                    <li><a href="{{ rootPath }}proof.html">Proof</a></li>
+                    <li><a href="{{ rootPath }}calculators/">Free Calculators</a></li>
                     <li><a href="{{ rootPath }}energy.html">Energy Data</a></li>
                     <li><a href="{{ rootPath }}case-studies/">Case Studies</a></li>
                     <li><a href="{{ rootPath }}blog/">Technical Blog</a></li>
-                    <li><a href="{{ rootPath }}calculators/">Free Calculators</a></li>
                     <li><a href="{{ rootPath }}pricing.html">Pricing</a></li>
                     <li><a href="{{ rootPath }}contact.html">Contact</a></li>
                 </ul>

--- a/content/partials/footer.html
+++ b/content/partials/footer.html
@@ -15,6 +15,7 @@
                     <li><a href="{{ rootPath }}engineering.html">Services</a></li>
                     <li><a href="{{ rootPath }}proof.html">Proof</a></li>
                     <li><a href="{{ rootPath }}calculators/">Free Calculators</a></li>
+                    <li><a href="{{ rootPath }}standards/">Standards</a></li>
                     <li><a href="{{ rootPath }}energy.html">Energy Data</a></li>
                     <li><a href="{{ rootPath }}case-studies/">Case Studies</a></li>
                     <li><a href="{{ rootPath }}blog/">Technical Blog</a></li>

--- a/content/partials/footer.html
+++ b/content/partials/footer.html
@@ -11,7 +11,7 @@
                 <ul class="footer-links">
                     <li><a href="{{ rootPath }}deckhand.html">Deckhand</a></li>
                     <li><a href="{{ rootPath }}platform.html">Platform</a></li>
-                    <li><a href="{{ rootPath }}engineering.html">Solutions</a></li>
+                    <li><a href="{{ rootPath }}solutions/">Solutions</a></li>
                     <li><a href="{{ rootPath }}proof.html">Proof</a></li>
                     <li><a href="{{ rootPath }}calculators/">Free Calculators</a></li>
                     <li><a href="{{ rootPath }}energy.html">Energy Data</a></li>

--- a/content/partials/nav.html
+++ b/content/partials/nav.html
@@ -13,16 +13,16 @@
         <div class="collapse navbar-collapse" id="myNavbar">
             <ul class="nav navbar-nav">
                 <li><a href="{{ rootPath }}index.html">Home</a></li>
-                <li><a href="{{ rootPath }}about.html">About</a></li>
-                <li><a href="{{ rootPath }}engineering.html">Services</a></li>
-                <li><a href="{{ rootPath }}energy.html">Energy Data</a></li>
+                <li><a href="{{ rootPath }}deckhand.html">Deckhand</a></li>
+                <li><a href="{{ rootPath }}platform.html">Platform</a></li>
+                <li><a href="{{ rootPath }}engineering.html">Solutions</a></li>
+                <li><a href="{{ rootPath }}proof.html">Proof</a></li>
                 <li><a href="{{ rootPath }}calculators/">Calculators</a></li>
-                <li><a href="{{ rootPath }}case-studies/">Case Studies</a></li>
-                <li><a href="{{ rootPath }}blog/">Blog</a></li>
-                <li><a href="{{ rootPath }}contact.html">Contact</a></li>
+                <li><a href="{{ rootPath }}about.html">Company</a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="{{ rootPath }}pricing.html" class="btn-nav-cta">Request Pricing</a></li>
+                <!-- OPEN_DECK_CTA: live group invite. Swap to https://t.me/the_deckhand_bot?start=src_web_nav once deckhand#432 handler is live. -->
+                <li><a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn-nav-cta" data-cta="open-deck" data-src="src_web_nav">Try Open Deck</a></li>
             </ul>
         </div>
     </div>

--- a/content/partials/nav.html
+++ b/content/partials/nav.html
@@ -15,7 +15,7 @@
                 <li><a href="{{ rootPath }}index.html">Home</a></li>
                 <li><a href="{{ rootPath }}deckhand.html">Deckhand</a></li>
                 <li><a href="{{ rootPath }}platform.html">Platform</a></li>
-                <li><a href="{{ rootPath }}engineering.html">Solutions</a></li>
+                <li><a href="{{ rootPath }}solutions/">Solutions</a></li>
                 <li><a href="{{ rootPath }}proof.html">Proof</a></li>
                 <li><a href="{{ rootPath }}calculators/">Calculators</a></li>
                 <li><a href="{{ rootPath }}about.html">Company</a></li>

--- a/content/platform.html
+++ b/content/platform.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="The digitalmodel platform: 7,000+ standard-mapped engineering functions across ~30 disciplines, 42 standards implemented. Library-first, importable, deterministic — the engine behind Deckhand and our calculators.">
+    <meta name="keywords" content="digitalmodel, offshore engineering library, standards-traceable calculations, OrcaFlex automation, OrcaWave, fatigue analysis library, API 579, DNV calculations, Python engineering library">
+
+    <meta property="og:title" content="The Platform — digitalmodel | AceEngineer">
+    <meta property="og:description" content="7,000+ standard-mapped functions across ~30 engineering disciplines. Every result traces to a DNV / API / ISO / ASME clause. The deterministic engine behind Deckhand.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/platform.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="The Platform — digitalmodel | AceEngineer">
+    <meta name="twitter:description" content="The deterministic, standards-traceable engine behind Deckhand.">
+
+    <title>The Platform — digitalmodel Engineering Engine | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <style>
+        .cap-card { background:#fff; border:1px solid #e6e8eb; border-radius:10px; padding:26px; margin-bottom:24px; height:100%; }
+        .cap-card h3 { margin-top:0; color:#2c3e50; }
+        .cap-card ul { padding-left:18px; margin-bottom:0; }
+        .tier-bar { background:#f8f9fa; padding:48px 0; }
+        .tier-step { text-align:center; padding:18px; }
+        .tier-step .tier-now { color:#1f8a4c; font-weight:700; }
+        .tier-step .tier-next { color:#6b7785; }
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:40px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h1 class="hero-title">The platform</h1>
+                    <p class="hero-subtitle">Deckhand and our free calculators run on <strong>digitalmodel</strong> &mdash; an open-source library of 7,000+ standard-mapped engineering functions across ~30 disciplines. Library-first, importable, deterministic.</p>
+                    <p class="hero-identity">42 standards implemented &middot; 221 S-N curves &middot; every function traces to a clause</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">What it computes</h2>
+                    <div class="row">
+                        <div class="col-md-4"><div class="cap-card"><h3>Structural &amp; Fatigue</h3><ul><li>S-N fatigue (221 curves, 17 standards)</li><li>Spectral fatigue (Dirlik, Wirsching-Light)</li><li>Rainflow counting, SCF</li></ul></div></div>
+                        <div class="col-md-4"><div class="cap-card"><h3>Asset Integrity / FFS</h3><ul><li>API 579 Level 1/2 (GML, LML)</li><li>B31G remaining strength</li><li>Cathodic protection (DNV-RP-B401)</li></ul></div></div>
+                        <div class="col-md-4"><div class="cap-card"><h3>Subsea Pipeline</h3><ul><li>On-bottom stability (DNV-RP-F109)</li><li>Wall thickness (DNV-ST-F101)</li><li>Burst, collapse, combined loading</li></ul></div></div>
+                        <div class="col-md-4"><div class="cap-card"><h3>Hydrodynamics</h3><ul><li>Wave spectra (JONSWAP, Bretschneider&hellip;)</li><li>RAO processing, seakeeping</li><li>OrcaWave / AQWA bridges</li></ul></div></div>
+                        <div class="col-md-4"><div class="cap-card"><h3>Mooring, Riser &amp; OrcaFlex</h3><ul><li>Catenary &amp; lazy-wave risers</li><li>VIV and free-span screening</li><li>OrcaFlex model generation from YAML</li></ul></div></div>
+                        <div class="col-md-4"><div class="cap-card"><h3>Energy Data &amp; Economics</h3><ul><li>BSEE production data &amp; reporting</li><li>Arps decline curves, EUR</li><li>NPV / MIRR / IRR field economics</li></ul></div></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Honest tier framing -->
+    <section class="tier-bar">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">Where it is &mdash; and where it's going</h2>
+                    <p class="section-subtitle text-center">We're specific about what's production-ready today versus on the roadmap.</p>
+                    <div class="row">
+                        <div class="col-md-4"><div class="tier-step"><p class="tier-now">Today</p><h3>Engineering engine</h3><p>Typed functions with worked examples and tests from real standard clauses. Same inputs, same outputs.</p></div></div>
+                        <div class="col-md-4"><div class="tier-step"><p class="tier-next">Next</p><h3>Agent routing</h3><p>Natural-language question &rarr; correct module, with gap detection. This is what Deckhand is growing into.</p></div></div>
+                        <div class="col-md-4"><div class="tier-step"><p class="tier-next">Later</p><h3>Design iteration</h3><p>Brief &rarr; calculation package &rarr; checks &rarr; refinement. On the roadmap, not claimed as shipped.</p></div></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0; text-align:center;">
+        <div class="container">
+            <h2 class="section-title">Library-first, not locked in a UI</h2>
+            <p class="section-subtitle" style="max-width:720px; margin:0 auto 24px;">The calculations are functions, not a SaaS login. Agents and automation can import them directly &mdash; which is exactly why Deckhand can run them deterministically and trace every result to its source.</p>
+            <p>
+                <a href="https://github.com/vamseeachanta/digitalmodel" target="_blank" rel="noopener" class="btn btn-info">View digitalmodel on GitHub</a>
+                <a href="deckhand.html" class="btn btn-default">See Deckhand</a>
+            </p>
+        </div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/proof.html
+++ b/content/proof.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Proof, not adjectives. How AceEngineer makes AI engineering defensible: 680 byte-identical cases, every result traced to a standard clause, and an assumption ledger on every deliverable.">
+    <meta name="keywords" content="deterministic engineering, standards traceability, auditable AI, defensible calculations, assumption ledger, reproducible engineering analysis, offshore engineering QA">
+
+    <meta property="og:title" content="Proof — Deterministic, Standards-Traceable AI Engineering | AceEngineer">
+    <meta property="og:description" content="680 byte-identical cases. Every result traced to a clause. An assumption ledger on every deliverable. The proof behind 'AI that shows its work'.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/proof.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Proof — Deterministic, Standards-Traceable AI Engineering">
+    <meta name="twitter:description" content="Proof, not adjectives — determinism, traceability, and an assumption ledger.">
+
+    <title>Proof — Deterministic, Standards-Traceable Engineering | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <style>
+        .proof-pillar { background:#fff; border:1px solid #e6e8eb; border-radius:10px; padding:30px; margin-bottom:24px; height:100%; }
+        .proof-pillar .big { font-size:2.4em; font-weight:800; color:#2c3e50; }
+        .ledger { background:#fbfcfd; border:1px solid #e6e8eb; border-radius:10px; padding:24px; font-family:Menlo,Consolas,monospace; font-size:0.92em; }
+        .ledger .k { color:#6b7785; }
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:40px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h1 class="hero-title">Proof, not adjectives.</h1>
+                    <p class="hero-subtitle">Practising engineers can't sign off on an AI answer that changes every time and cites nothing. So we built the opposite: deterministic results, traceable to a clause, with every assumption on the table.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <div class="row">
+                        <div class="col-md-4"><div class="proof-pillar"><div class="big">680</div><h3>Byte-identical cases</h3><p>Determinism is verified, not asserted: a regression suite runs hundreds of cases and checks the outputs are byte-for-byte identical, every build. Same input, same output &mdash; no model drift.</p></div></div>
+                        <div class="col-md-4"><div class="proof-pillar"><div class="big">42</div><h3>Standards implemented</h3><p>Every result maps to a clause in DNV, API, ISO, ASME, BS and more. The standard reference travels with the number, so a checker can verify it against source.</p></div></div>
+                        <div class="col-md-4"><div class="proof-pillar"><div class="big">100%</div><h3>Shows its work</h3><p>Every deliverable carries an assumption ledger and explicit scope limits. If something wasn't checked, it says so.</p></div></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Assumption ledger example -->
+    <section style="padding:48px 0; background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-5">
+                    <h2 class="section-title" style="text-align:left;">The assumption ledger</h2>
+                    <p class="section-subtitle" style="text-align:left;">Every Deckhand deliverable ends with the inputs it used, the governing clause, and what it did <em>not</em> check. No silent defaults; no hidden scope.</p>
+                    <p>This is what makes a result defensible in review &mdash; and what generic chatbots can't give you.</p>
+                </div>
+                <div class="col-md-6 col-md-offset-1">
+                    <div class="ledger">
+                        <div><span class="k">result:</span> min wall = 9.5 mm (util 0.81)</div>
+                        <div><span class="k">standard:</span> DNV-ST-F101 (2021) &sect;5.4.2</div>
+                        <div><span class="k">inputs:</span> OD 12.75", P_d 10 MPa, X65</div>
+                        <div><span class="k">assumed:</span> SMYS 450 MPa; t_fab &minus;12.5%;</div>
+                        <div style="padding-left:64px;">corrosion allowance 1.0 mm</div>
+                        <div><span class="k">not checked:</span> local buckling, fatigue</div>
+                        <div><span class="k">reproducible:</span> yes &mdash; hash-stable</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Case studies -->
+    <section style="padding:56px 0;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">From real projects</h2>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="case-highlight-card">
+                                <h3>Computational Fatigue Assessment</h3>
+                                <p>Gulf of Mexico platform life extension</p>
+                                <div class="case-metrics"><span class="case-metric"><strong>85%</strong> time reduction</span> <span class="case-metric"><strong>23%</strong> accuracy improvement</span></div>
+                                <a href="case-studies/offshore-platform-fatigue-optimization.html" class="btn btn-primary">Read Case Study</a>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="case-highlight-card">
+                                <h3>Automated FEA Post-Processing</h3>
+                                <p>Subsea equipment qualification pipeline</p>
+                                <div class="case-metrics"><span class="case-metric"><strong>90%</strong> time reduction</span> <span class="case-metric"><strong>50+</strong> reports/week</span></div>
+                                <a href="case-studies/subsea-fea-automation.html" class="btn btn-primary">Read Case Study</a>
+                            </div>
+                        </div>
+                    </div>
+                    <p class="text-center" style="margin-top:24px;"><a href="case-studies/" class="btn btn-default">All case studies</a></p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h2>See it on your own question</h2>
+                    <p>Bring something from your real work to Open Deck and check the result against your own methods.</p>
+                    <!-- OPEN_DECK_CTA -->
+                    <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_proof_footer">Try Open Deck &mdash; free</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/solutions/codes-standards-maritime-law.html
+++ b/content/solutions/codes-standards-maritime-law.html
@@ -1,0 +1,94 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Codes, standards & maritime law advisory channel: standards interpretation across DNV, API, ASME, ISO and ABS, code-compliance gap reviews, and maritime liability questions.">
+    <meta name="keywords" content="engineering standards interpretation, DNV API ASME ISO compliance, code compliance review, maritime law, offshore liability, classification society standards">
+
+    <meta property="og:title" content="Codes, Standards & Maritime Law | AceEngineer Solutions">
+    <meta property="og:description" content="Advisory channel for standards interpretation, compliance gaps, and maritime liability. Bring the question; an engineer engages.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/solutions/codes-standards-maritime-law.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Codes, Standards & Maritime Law | AceEngineer">
+    <meta name="twitter:description" content="Advisory channel for standards and maritime law.">
+
+    <title>Codes, Standards &amp; Maritime Law | AceEngineer Solutions</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <script type="application/ld+json">
+    { "@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Solutions","item":"https://aceengineer.com/solutions/"},
+      {"@type":"ListItem","position":2,"name":"Codes, Standards & Maritime Law","item":"https://aceengineer.com/solutions/codes-standards-maritime-law.html"}]}
+    </script>
+
+    <style>
+        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
+        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
+        .advisory-note{background:#eef1f4;border-left:4px solid #52606d;padding:16px 20px;border-radius:6px;max-width:820px;margin:0 auto;color:#3a4654;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Solutions</a> &rsaquo; Advisory</p>
+                    <h1 class="hero-title" style="text-align:left;">Codes, Standards &amp; Maritime Law</h1>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">Interpreting the codes, finding the compliance gaps, and the maritime-law questions that sit alongside them &mdash; grounded in our standards knowledge base.</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start=src_web_codes-standards-maritime-law once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_codes-standards-maritime-law">Ask on Open Deck</a>
+                        <a href="index.html" class="btn btn-default btn-lg">All solutions</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">Bring questions like</h2>
+                    <ul class="ask-list">
+                        <li>Which clause of DNV / API / ASME / ISO / ABS governs this, and what does it require?</li>
+                        <li>A compliance-gap review of a calculation note or specification against a named standard.</li>
+                        <li>Reconciling conflicting requirements across two codes for the same component.</li>
+                        <li>Maritime-law and liability framing for an offshore incident or contract question.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:40px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <p class="advisory-note"><strong>How this channel works.</strong> Advisory: an engineer engages with your question, grounded in our standards knowledge base. It is guidance, not a substitute for the governing standard or for legal advice. Runnable, standards-traced calculations live in the <a href="subsea-pipelines-integrity.html">Subsea</a>, <a href="floating-marine.html">Floating &amp; Marine</a> and <a href="wells-subsurface.html">Wells</a> channels.</p>
+            </div></div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container"><div class="row"><div class="col-md-8 col-md-offset-2 text-center">
+            <h2>Ask a standards question</h2>
+            <p>Join Open Deck and bring the clause or compliance question you're wrestling with.</p>
+            <!-- OPEN_DECK_CTA -->
+            <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_codes-standards-maritime-law_footer">Ask on Open Deck</a>
+        </div></div></div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/solutions/design-cad.html
+++ b/content/solutions/design-cad.html
@@ -1,0 +1,94 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Design & CAD advisory channel: CAD modelling, drawing production, and parametric design automation for offshore and marine components.">
+    <meta name="keywords" content="CAD automation, parametric design, engineering drawings, design automation offshore, CAD advisory">
+
+    <meta property="og:title" content="Design & CAD | AceEngineer Solutions">
+    <meta property="og:description" content="Advisory channel for CAD modelling, drawings, and parametric design automation. Bring the problem; an engineer engages.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/solutions/design-cad.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Design & CAD | AceEngineer">
+    <meta name="twitter:description" content="Advisory channel for CAD and parametric design.">
+
+    <title>Design &amp; CAD | AceEngineer Solutions</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <script type="application/ld+json">
+    { "@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Solutions","item":"https://aceengineer.com/solutions/"},
+      {"@type":"ListItem","position":2,"name":"Design & CAD","item":"https://aceengineer.com/solutions/design-cad.html"}]}
+    </script>
+
+    <style>
+        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
+        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
+        .advisory-note{background:#eef1f4;border-left:4px solid #52606d;padding:16px 20px;border-radius:6px;max-width:820px;margin:0 auto;color:#3a4654;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Solutions</a> &rsaquo; Advisory</p>
+                    <h1 class="hero-title" style="text-align:left;">Design &amp; CAD</h1>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">Turning engineering intent into models and drawings &mdash; and automating the repetitive parts. Describe the design task and an engineer engages.</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start=src_web_cad once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_cad">Ask on Open Deck</a>
+                        <a href="index.html" class="btn btn-default btn-lg">All solutions</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">Bring questions like</h2>
+                    <ul class="ask-list">
+                        <li>3D modelling and general-arrangement drawings for an offshore or marine component.</li>
+                        <li>Parametric models that regenerate as inputs change &mdash; less manual redraw.</li>
+                        <li>Design automation linking CAD geometry to the engineering calculation behind it.</li>
+                        <li>Drawing-set clean-up, standardisation, and revision control.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:40px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <p class="advisory-note"><strong>How this channel works.</strong> Advisory: bring the design task and an engineer scopes it. Where geometry ties to a calculation, it connects to the same standards-traced engine behind our runnable channels &mdash; <a href="subsea-pipelines-integrity.html">Subsea</a>, <a href="floating-marine.html">Floating &amp; Marine</a> and <a href="wells-subsurface.html">Wells</a>.</p>
+            </div></div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container"><div class="row"><div class="col-md-8 col-md-offset-2 text-center">
+            <h2>Describe a design task</h2>
+            <p>Join Open Deck and tell us what you need modelled or automated.</p>
+            <!-- OPEN_DECK_CTA -->
+            <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_cad_footer">Ask on Open Deck</a>
+        </div></div></div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/solutions/floating-marine.html
+++ b/content/solutions/floating-marine.html
@@ -1,0 +1,130 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Floating & marine systems analysis from chat: mooring fatigue, FPSO spread mooring, vessel seakeeping & stability, OCIMF wind/current loads, and hydrodynamics (OrcaWave / AQWA). Standards-traceable, deterministic.">
+    <meta name="keywords" content="mooring fatigue analysis, FPSO spread mooring, vessel seakeeping, OCIMF mooring loads, platform stability, OrcaWave AQWA hydrodynamics, synthetic rope mooring, floating offshore">
+
+    <meta property="og:title" content="Floating & Marine Systems | AceEngineer Solutions">
+    <meta property="og:description" content="Run mooring fatigue, FPSO spread mooring, vessel motions, OCIMF loads and hydrodynamics from a chat message — traced to the standard.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/solutions/floating-marine.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Floating & Marine Systems | AceEngineer">
+    <meta name="twitter:description" content="Standards-traceable mooring, motions and hydrodynamics, run from chat.">
+
+    <title>Floating &amp; Marine Systems Analysis | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Service",
+        "serviceType": "Floating and Marine Systems Engineering",
+        "provider": { "@id": "https://aceengineer.com/#organization" },
+        "areaServed": "Worldwide",
+        "hasOfferCatalog": {
+            "@type": "OfferCatalog",
+            "name": "Floating & Marine Analyses",
+            "itemListElement": [
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Mooring line fatigue" } },
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "FPSO spread mooring screening" } },
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Vessel seakeeping and stability" } },
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "OCIMF wind and current mooring loads" } },
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Hydrodynamics (OrcaWave / AQWA model prep)" } }
+            ]
+        }
+    }
+    </script>
+    <script type="application/ld+json">
+    { "@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Solutions","item":"https://aceengineer.com/solutions/"},
+      {"@type":"ListItem","position":2,"name":"Floating & Marine Systems","item":"https://aceengineer.com/solutions/floating-marine.html"}]}
+    </script>
+
+    <style>
+        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
+        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
+        .ask-list li b{color:#2c3e50;}
+        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Solutions</a> &rsaquo; Runnable</p>
+                    <h1 class="hero-title" style="text-align:left;">Floating &amp; Marine Systems</h1>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">Mooring, motions and hydrodynamics for FPSOs, floaters and vessels &mdash; ask in plain language and Deckhand runs the analysis and returns a deliverable that shows its work.</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start=src_web_floating-marine once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_floating-marine">Try it on Open Deck</a>
+                        <a href="../proof.html" class="btn btn-default btn-lg">See the proof</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">What you can ask it to do</h2>
+                    <ul class="ask-list">
+                        <li><b>Mooring fatigue.</b> Estimate the fatigue life of a chain or wire mooring line from its tension cycles.</li>
+                        <li><b>FPSO spread mooring.</b> Screen a spread-mooring system for line safety factors, or run the full environmental-load equilibrium.</li>
+                        <li><b>Synthetic rope mooring.</b> Screen a polyester fibre-rope mooring for service life &mdash; fatigue, creep and minimum tension.</li>
+                        <li><b>Vessel motions.</b> Estimate a vessel's motions, natural periods and motion comfort (seakeeping).</li>
+                        <li><b>Stability.</b> Check a floating platform's intact stability &mdash; GM, righting arm, wind heel.</li>
+                        <li><b>OCIMF loads.</b> Work out wind and current mooring loads on a moored tanker.</li>
+                        <li><b>Hydrodynamics.</b> Set up a diffraction and radiation model for a floating hull (OrcaWave / AQWA prep).</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;text-align:center;">
+        <div class="container">
+            <h2 class="section-title">Standards &amp; tools it works to</h2>
+            <div style="margin:18px 0;">
+                <span class="domain-chip">OCIMF</span>
+                <span class="domain-chip">DNV mooring</span>
+                <span class="domain-chip">API RP 2SK</span>
+                <span class="domain-chip">IMO stability</span>
+                <span class="domain-chip">OrcaFlex</span>
+                <span class="domain-chip">OrcaWave</span>
+                <span class="domain-chip">AQWA</span>
+            </div>
+            <p><a href="../platform.html" class="btn btn-info">See the platform engine</a> <a href="../calculators/" class="btn btn-default">Free calculators</a></p>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h2>Bring a real mooring or hull</h2>
+                    <p>Open Deck is free &mdash; ask a floating or marine question from your actual project.</p>
+                    <!-- OPEN_DECK_CTA -->
+                    <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_floating-marine_footer">Try Open Deck on Telegram</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/solutions/index.html
+++ b/content/solutions/index.html
@@ -1,0 +1,93 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Engineering solutions by domain — subsea & pipelines, floating & marine, wells & subsurface, plus advisory channels for power, codes & standards, CAD, and manufacturing. Each maps to a live Deckhand channel.">
+    <meta name="keywords" content="offshore engineering solutions, subsea pipeline analysis, floating marine systems, mooring analysis, wells subsurface, field economics, engineering by domain">
+
+    <meta property="og:title" content="Solutions by Domain | AceEngineer">
+    <meta property="og:description" content="Pick your domain. Each maps to a live Deckhand channel you can try on Open Deck — runnable analysis for subsea, floating & marine, and wells; advisory for power, codes, CAD, and manufacturing.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/solutions/">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Solutions by Domain | AceEngineer">
+    <meta name="twitter:description" content="Engineering solutions by domain, each backed by a live Deckhand channel.">
+
+    <title>Solutions by Domain | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <style>
+        .sol-card { background:#fff; border:1px solid #e6e8eb; border-radius:10px; padding:26px; margin-bottom:24px; height:100%; }
+        .sol-card h3 { margin-top:6px; color:#2c3e50; }
+        .sol-card p { color:#4a5568; }
+        .tier-flag { display:inline-block; border-radius:14px; padding:3px 12px; font-size:.78em; font-weight:700; letter-spacing:.02em; }
+        .flag-a { background:#e3f3ea; color:#1f8a4c; }
+        .flag-b { background:#eef1f4; color:#52606d; }
+        .sol-group-title { margin:36px 0 8px; }
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:32px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h1 class="hero-title">Solutions by domain</h1>
+                    <p class="hero-subtitle">Each domain maps 1:1 to a live Deckhand channel. <strong>Runnable</strong> channels execute the analysis on Open Deck and return a deliverable; <strong>advisory</strong> channels connect you to an engineer.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:24px 0 64px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+
+                    <h2 class="section-title sol-group-title">Runnable analysis</h2>
+                    <p class="section-subtitle" style="text-align:left;">Ask in plain language; Deckhand runs the real calculation, traced to the standard.</p>
+                    <div class="row">
+                        <div class="col-md-4"><div class="sol-card"><span class="tier-flag flag-a">RUNNABLE</span><h3>Subsea, Pipelines &amp; Integrity</h3><p>Wall thickness, on-bottom stability, free-span / VIV, fitness-for-service, cathodic protection.</p><a href="subsea-pipelines-integrity.html" class="btn btn-info">Explore</a></div></div>
+                        <div class="col-md-4"><div class="sol-card"><span class="tier-flag flag-a">RUNNABLE</span><h3>Floating &amp; Marine Systems</h3><p>Mooring fatigue, FPSO spread mooring, vessel seakeeping &amp; stability, OCIMF loads, hydrodynamics.</p><a href="floating-marine.html" class="btn btn-info">Explore</a></div></div>
+                        <div class="col-md-4"><div class="sol-card"><span class="tier-flag flag-a">RUNNABLE</span><h3>Wells &amp; Subsurface</h3><p>Production forecasting &amp; decline, field NPV / economics, nodal analysis, rod-pump diagnostics.</p><a href="wells-subsurface.html" class="btn btn-info">Explore</a></div></div>
+                    </div>
+
+                    <h2 class="section-title sol-group-title">Advisory channels</h2>
+                    <p class="section-subtitle" style="text-align:left;">Bring the problem; an engineer scopes it. Runnable workflows are on the roadmap.</p>
+                    <div class="row">
+                        <div class="col-md-3"><div class="sol-card"><span class="tier-flag flag-b">ADVISORY</span><h3>Power, Electrical &amp; Controls</h3><p>Power-system studies, protection, generator &amp; microgrid controls.</p><a href="power-electrical-controls.html" class="btn btn-default">Explore</a></div></div>
+                        <div class="col-md-3"><div class="sol-card"><span class="tier-flag flag-b">ADVISORY</span><h3>Codes, Standards &amp; Maritime Law</h3><p>Standards interpretation, compliance gaps, maritime liability.</p><a href="codes-standards-maritime-law.html" class="btn btn-default">Explore</a></div></div>
+                        <div class="col-md-3"><div class="sol-card"><span class="tier-flag flag-b">ADVISORY</span><h3>Design &amp; CAD</h3><p>CAD modelling, drawings, parametric design automation.</p><a href="design-cad.html" class="btn btn-default">Explore</a></div></div>
+                        <div class="col-md-3"><div class="sol-card"><span class="tier-flag flag-b">ADVISORY</span><h3>Manufacturing &amp; Fabrication</h3><p>Fabrication sequencing, weld/NDT planning, manufacturability.</p><a href="manufacturing-fabrication.html" class="btn btn-default">Explore</a></div></div>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h2>Try any of them on Open Deck &mdash; free</h2>
+                    <p>Join the open community and ask a real question from your domain.</p>
+                    <!-- OPEN_DECK_CTA -->
+                    <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_solutions">Join Open Deck on Telegram</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/solutions/index.html
+++ b/content/solutions/index.html
@@ -69,6 +69,8 @@ rootPath: "../"
                         <div class="col-md-3"><div class="sol-card"><span class="tier-flag flag-b">ADVISORY</span><h3>Manufacturing &amp; Fabrication</h3><p>Fabrication sequencing, weld/NDT planning, manufacturability.</p><a href="manufacturing-fabrication.html" class="btn btn-default">Explore</a></div></div>
                     </div>
 
+                    <p style="margin-top:28px;color:#52606d;">Looking for something else? See <a href="../engineering.html">how we engage (services &amp; automation)</a> or the <a href="../energy.html">energy data platform</a>.</p>
+
                 </div>
             </div>
         </div>

--- a/content/solutions/manufacturing-fabrication.html
+++ b/content/solutions/manufacturing-fabrication.html
@@ -1,0 +1,94 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Manufacturing & fabrication advisory channel: fabrication sequencing, weld and NDT planning, and manufacturability review for offshore and marine structures.">
+    <meta name="keywords" content="fabrication sequencing, weld planning, NDT planning, manufacturability review, offshore fabrication advisory, design for manufacturing">
+
+    <meta property="og:title" content="Manufacturing & Fabrication | AceEngineer Solutions">
+    <meta property="og:description" content="Advisory channel for fabrication sequencing, weld/NDT planning, and manufacturability. Bring the problem; an engineer engages.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/solutions/manufacturing-fabrication.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Manufacturing & Fabrication | AceEngineer">
+    <meta name="twitter:description" content="Advisory channel for fabrication and manufacturability.">
+
+    <title>Manufacturing &amp; Fabrication | AceEngineer Solutions</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <script type="application/ld+json">
+    { "@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Solutions","item":"https://aceengineer.com/solutions/"},
+      {"@type":"ListItem","position":2,"name":"Manufacturing & Fabrication","item":"https://aceengineer.com/solutions/manufacturing-fabrication.html"}]}
+    </script>
+
+    <style>
+        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
+        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
+        .advisory-note{background:#eef1f4;border-left:4px solid #52606d;padding:16px 20px;border-radius:6px;max-width:820px;margin:0 auto;color:#3a4654;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Solutions</a> &rsaquo; Advisory</p>
+                    <h1 class="hero-title" style="text-align:left;">Manufacturing &amp; Fabrication</h1>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">Getting a design built &mdash; sequencing, welding, inspection, and the manufacturability checks that save rework. Describe the scope and an engineer engages.</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start=src_web_manufacturing once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_manufacturing">Ask on Open Deck</a>
+                        <a href="index.html" class="btn btn-default btn-lg">All solutions</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">Bring questions like</h2>
+                    <ul class="ask-list">
+                        <li>Fabrication sequencing and build strategy for a structure or skid.</li>
+                        <li>Weld procedure and NDT planning aligned to the governing code.</li>
+                        <li>Manufacturability review &mdash; where a design will be hard or costly to build.</li>
+                        <li>Tolerance, fit-up and dimensional-control questions on an assembly.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:40px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <p class="advisory-note"><strong>How this channel works.</strong> Advisory: bring the fabrication scope and an engineer scopes it. Runnable, standards-traced calculations live in the <a href="subsea-pipelines-integrity.html">Subsea</a>, <a href="floating-marine.html">Floating &amp; Marine</a> and <a href="wells-subsurface.html">Wells</a> channels.</p>
+            </div></div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container"><div class="row"><div class="col-md-8 col-md-offset-2 text-center">
+            <h2>Describe a fabrication scope</h2>
+            <p>Join Open Deck and tell us what you're building.</p>
+            <!-- OPEN_DECK_CTA -->
+            <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_manufacturing_footer">Ask on Open Deck</a>
+        </div></div></div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/solutions/power-electrical-controls.html
+++ b/content/solutions/power-electrical-controls.html
@@ -1,0 +1,94 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Power, electrical & controls advisory channel: power-system studies, protection coordination, generator and microgrid controls, and electrical area classification for offshore and energy facilities.">
+    <meta name="keywords" content="offshore power systems, protection coordination, microgrid controls, generator controls, electrical area classification, power study advisory">
+
+    <meta property="og:title" content="Power, Electrical & Controls | AceEngineer Solutions">
+    <meta property="og:description" content="Advisory channel for offshore power systems, protection, and controls. Bring the problem; an engineer scopes it.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/solutions/power-electrical-controls.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Power, Electrical & Controls | AceEngineer">
+    <meta name="twitter:description" content="Advisory channel for offshore power, protection and controls.">
+
+    <title>Power, Electrical &amp; Controls | AceEngineer Solutions</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <script type="application/ld+json">
+    { "@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Solutions","item":"https://aceengineer.com/solutions/"},
+      {"@type":"ListItem","position":2,"name":"Power, Electrical & Controls","item":"https://aceengineer.com/solutions/power-electrical-controls.html"}]}
+    </script>
+
+    <style>
+        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
+        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
+        .advisory-note{background:#eef1f4;border-left:4px solid #52606d;padding:16px 20px;border-radius:6px;max-width:820px;margin:0 auto;color:#3a4654;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Solutions</a> &rsaquo; Advisory</p>
+                    <h1 class="hero-title" style="text-align:left;">Power, Electrical &amp; Controls</h1>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">An advisory channel for offshore and energy electrical systems &mdash; power studies, protection, and controls. Describe the problem and an engineer engages.</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start=src_web_electrical once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_electrical">Ask on Open Deck</a>
+                        <a href="index.html" class="btn btn-default btn-lg">All solutions</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">Bring questions like</h2>
+                    <ul class="ask-list">
+                        <li>Power-system load flow, short-circuit and protection-coordination studies.</li>
+                        <li>Generator, switchgear and microgrid control philosophy and EMS logic.</li>
+                        <li>Electrical area classification and equipment suitability for hazardous zones.</li>
+                        <li>Standards alignment (IEC / IEEE / NFPA) for an offshore electrical scope.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:40px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <p class="advisory-note"><strong>How this channel works.</strong> This is an advisory channel: you bring the problem, an engineer scopes it, and where it fits we turn it into a deliverable. Runnable, standards-traced workflows for this domain are on the roadmap &mdash; the runnable channels today are <a href="subsea-pipelines-integrity.html">Subsea</a>, <a href="floating-marine.html">Floating &amp; Marine</a> and <a href="wells-subsurface.html">Wells</a>.</p>
+            </div></div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container"><div class="row"><div class="col-md-8 col-md-offset-2 text-center">
+            <h2>Start a conversation</h2>
+            <p>Join Open Deck and describe your electrical or controls problem.</p>
+            <!-- OPEN_DECK_CTA -->
+            <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_electrical_footer">Ask on Open Deck</a>
+        </div></div></div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/solutions/subsea-pipelines-integrity.html
+++ b/content/solutions/subsea-pipelines-integrity.html
@@ -1,0 +1,129 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Subsea, pipelines & integrity analysis you can run from chat: wall thickness (DNV-ST-F101, ASME B31, PD 8010), on-bottom stability (DNV-RP-F109), free-span VIV (DNV-RP-F105), fitness-for-service, and cathodic protection. Standards-traceable, deterministic.">
+    <meta name="keywords" content="pipeline wall thickness calculator, on-bottom stability DNV-RP-F109, free span VIV DNV-RP-F105, pipeline fitness for service, cathodic protection design, DNV-ST-F101, subsea integrity analysis">
+
+    <meta property="og:title" content="Subsea, Pipelines & Integrity | AceEngineer Solutions">
+    <meta property="og:description" content="Run wall thickness, on-bottom stability, free-span VIV, fitness-for-service and cathodic protection from a chat message — traced to DNV / ASME / PD clauses.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/solutions/subsea-pipelines-integrity.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Subsea, Pipelines & Integrity | AceEngineer">
+    <meta name="twitter:description" content="Standards-traceable subsea & pipeline analysis, run from chat.">
+
+    <title>Subsea, Pipelines &amp; Integrity Analysis | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Service",
+        "serviceType": "Subsea, Pipelines and Integrity Engineering",
+        "provider": { "@id": "https://aceengineer.com/#organization" },
+        "areaServed": "Worldwide",
+        "hasOfferCatalog": {
+            "@type": "OfferCatalog",
+            "name": "Subsea & Pipeline Analyses",
+            "itemListElement": [
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Pipeline wall thickness (DNV-ST-F101, ASME B31, PD 8010)" } },
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "On-bottom stability (DNV-RP-F109)" } },
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Free-span VIV screening (DNV-RP-F105)" } },
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Pipeline fitness-for-service" } },
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Cathodic protection design (DNV-RP-B401 / F103)" } }
+            ]
+        }
+    }
+    </script>
+    <script type="application/ld+json">
+    { "@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Solutions","item":"https://aceengineer.com/solutions/"},
+      {"@type":"ListItem","position":2,"name":"Subsea, Pipelines & Integrity","item":"https://aceengineer.com/solutions/subsea-pipelines-integrity.html"}]}
+    </script>
+
+    <style>
+        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
+        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
+        .ask-list li b{color:#2c3e50;}
+        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Solutions</a> &rsaquo; Runnable</p>
+                    <h1 class="hero-title" style="text-align:left;">Subsea, Pipelines &amp; Integrity</h1>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">From line sizing to end-of-life integrity &mdash; ask in plain language and Deckhand runs the real calculation against DNV, ASME and PD codes, with every assumption traced.</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start=src_web_subsea-pipelines-integrity once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_subsea-pipelines-integrity">Try it on Open Deck</a>
+                        <a href="../proof.html" class="btn btn-default btn-lg">See the proof</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">What you can ask it to do</h2>
+                    <ul class="ask-list">
+                        <li><b>Wall thickness.</b> Screen a pipeline wall across the design codes (DNV-ST-F101, ASME B31, PD 8010) and get a one-page report.</li>
+                        <li><b>On-bottom stability.</b> Check stability of a subsea line in waves and current (DNV-RP-F109).</li>
+                        <li><b>Free-span / VIV.</b> Screen a free span for vortex-induced vibration and allowable length (DNV-RP-F105).</li>
+                        <li><b>Lateral &amp; upheaval buckling.</b> Check a line for snake buckling under pressure and temperature, and the cover a buried line needs.</li>
+                        <li><b>Fitness-for-service.</b> Assess a corroded line from wall-thickness readings against its design pressure.</li>
+                        <li><b>Cathodic protection.</b> Size sacrificial-anode protection for a pipeline, jacket, manifold, monopile or FPSO hull (DNV-RP-B401 / F103).</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;text-align:center;">
+        <div class="container">
+            <h2 class="section-title">Standards it works to</h2>
+            <div style="margin:18px 0;">
+                <span class="domain-chip">DNV-ST-F101</span>
+                <span class="domain-chip">DNV-RP-F109</span>
+                <span class="domain-chip">DNV-RP-F105</span>
+                <span class="domain-chip">DNV-RP-F103</span>
+                <span class="domain-chip">DNV-RP-B401</span>
+                <span class="domain-chip">ASME B31.4 / B31.8</span>
+                <span class="domain-chip">PD 8010</span>
+            </div>
+            <p><a href="../platform.html" class="btn btn-info">See the platform engine</a> <a href="../calculators/" class="btn btn-default">Free calculators</a></p>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h2>Bring a real line</h2>
+                    <p>Open Deck is free &mdash; ask a subsea or pipeline question from your actual scope and check the result against your own methods.</p>
+                    <!-- OPEN_DECK_CTA -->
+                    <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_subsea-pipelines-integrity_footer">Try Open Deck on Telegram</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/solutions/subsea-pipelines-integrity.html
+++ b/content/solutions/subsea-pipelines-integrity.html
@@ -97,16 +97,18 @@ rootPath: "../"
     <section style="padding:48px 0;text-align:center;">
         <div class="container">
             <h2 class="section-title">Standards it works to</h2>
+            <p class="section-subtitle">Explore the standard, then run the check on Open Deck.</p>
             <div style="margin:18px 0;">
-                <span class="domain-chip">DNV-ST-F101</span>
-                <span class="domain-chip">DNV-RP-F109</span>
-                <span class="domain-chip">DNV-RP-F105</span>
-                <span class="domain-chip">DNV-RP-F103</span>
-                <span class="domain-chip">DNV-RP-B401</span>
+                <a class="domain-chip" href="../standards/dnv-st-f101-wall-thickness.html">DNV-ST-F101</a>
+                <a class="domain-chip" href="../standards/dnv-rp-f109-on-bottom-stability.html">DNV-RP-F109</a>
+                <a class="domain-chip" href="../standards/dnv-rp-f105-free-span-viv.html">DNV-RP-F105</a>
+                <a class="domain-chip" href="../standards/api-579-fitness-for-service.html">API 579</a>
+                <a class="domain-chip" href="../standards/dnv-rp-b401-cathodic-protection.html">DNV-RP-B401</a>
+                <a class="domain-chip" href="../standards/dnv-rp-c203-fatigue.html">DNV-RP-C203</a>
                 <span class="domain-chip">ASME B31.4 / B31.8</span>
                 <span class="domain-chip">PD 8010</span>
             </div>
-            <p><a href="../platform.html" class="btn btn-info">See the platform engine</a> <a href="../calculators/" class="btn btn-default">Free calculators</a></p>
+            <p><a href="../standards/" class="btn btn-info">All standards</a> <a href="../calculators/" class="btn btn-default">Free calculators</a></p>
         </div>
     </section>
 

--- a/content/solutions/wells-subsurface.html
+++ b/content/solutions/wells-subsurface.html
@@ -1,0 +1,127 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Wells & subsurface analysis from chat: production forecasting and decline (Arps), field-development economics (NPV / IRR / payback), nodal analysis, and sucker-rod-pump diagnostics. Built on public production data.">
+    <meta name="keywords" content="Arps decline curve, production forecast, field development economics NPV, nodal analysis, dynacard diagnostics, BSEE production data, well economics, EUR estimation">
+
+    <meta property="og:title" content="Wells & Subsurface | AceEngineer Solutions">
+    <meta property="og:description" content="Run decline forecasting, field NPV, nodal analysis and rod-pump diagnostics from a chat message — grounded in public production data.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/solutions/wells-subsurface.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Wells & Subsurface | AceEngineer">
+    <meta name="twitter:description" content="Decline, economics and well diagnostics, run from chat.">
+
+    <title>Wells &amp; Subsurface Analysis &amp; Economics | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Service",
+        "serviceType": "Wells, Subsurface and Field Economics",
+        "provider": { "@id": "https://aceengineer.com/#organization" },
+        "areaServed": "Worldwide",
+        "hasOfferCatalog": {
+            "@type": "OfferCatalog",
+            "name": "Wells & Subsurface Analyses",
+            "itemListElement": [
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Production forecasting and decline (Arps)" } },
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Field-development economics (NPV / IRR / payback)" } },
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Nodal analysis" } },
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Sucker-rod pump (dynacard) diagnostics" } },
+                { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Public production-data summaries (BSEE, Texas RRC, SODIR)" } }
+            ]
+        }
+    }
+    </script>
+    <script type="application/ld+json">
+    { "@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Solutions","item":"https://aceengineer.com/solutions/"},
+      {"@type":"ListItem","position":2,"name":"Wells & Subsurface","item":"https://aceengineer.com/solutions/wells-subsurface.html"}]}
+    </script>
+
+    <style>
+        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
+        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
+        .ask-list li b{color:#2c3e50;}
+        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Solutions</a> &rsaquo; Runnable</p>
+                    <h1 class="hero-title" style="text-align:left;">Wells &amp; Subsurface</h1>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">From decline curves to field economics &mdash; ask in plain language and Deckhand runs the analysis on public production data and returns a deliverable you can defend.</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start=src_web_wells-subsurface once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_wells-subsurface">Try it on Open Deck</a>
+                        <a href="../energy.html" class="btn btn-default btn-lg">Energy data</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">What you can ask it to do</h2>
+                    <ul class="ask-list">
+                        <li><b>Decline &amp; EUR.</b> Forecast a well's decline and estimate ultimate recovery (Arps).</li>
+                        <li><b>Field economics.</b> Run a field-development case &mdash; net present value, rate of return, payback &mdash; and a price / rate sensitivity.</li>
+                        <li><b>Nodal analysis.</b> Find a well's operating point from inflow and outflow.</li>
+                        <li><b>Rod-pump diagnostics.</b> Diagnose a sucker-rod pump from its dynamometer card and get a report.</li>
+                        <li><b>Production summaries.</b> Summarise lease, well and field production from public data (BSEE, Texas RRC, SODIR), and compare wells across a block.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;text-align:center;">
+        <div class="container">
+            <h2 class="section-title">Data &amp; methods it works to</h2>
+            <div style="margin:18px 0;">
+                <span class="domain-chip">Arps decline</span>
+                <span class="domain-chip">NPV / IRR / MIRR</span>
+                <span class="domain-chip">BSEE (Gulf of Mexico)</span>
+                <span class="domain-chip">Texas RRC</span>
+                <span class="domain-chip">SODIR (Norway)</span>
+                <span class="domain-chip">Nodal / VLP</span>
+            </div>
+            <p><a href="../energy.html" class="btn btn-info">Energy data platform</a> <a href="../calculators/npv-field-development.html" class="btn btn-default">NPV calculator</a></p>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h2>Bring a real well or field</h2>
+                    <p>Open Deck is free &mdash; ask a wells, production or economics question and check the result.</p>
+                    <!-- OPEN_DECK_CTA -->
+                    <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_wells-subsurface_footer">Try Open Deck on Telegram</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/standards/api-579-fitness-for-service.html
+++ b/content/standards/api-579-fitness-for-service.html
@@ -1,0 +1,152 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="API 579-1 / ASME FFS-1: Fitness-for-service assessment of in-service equipment. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+    <meta name="keywords" content="API 579-1, ASME FFS-1, Fitness-for-service, Metal loss, Remaining strength, API 579-1 / ASME FFS-1 calculator, offshore engineering AI">
+
+    <meta property="og:title" content="API 579-1 / ASME FFS-1 — Fitness-for-service assessment of in-service equipment | AceEngineer">
+    <meta property="og:description" content="API 579-1 / ASME FFS-1: Fitness-for-service assessment of in-service equipment. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://www.aceengineer.com/standards/api-579-fitness-for-service.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="API 579-1 / ASME FFS-1 — Fitness-for-service assessment of in-service equipment">
+    <meta name="twitter:description" content="API 579-1 / ASME FFS-1: Fitness-for-service assessment of in-service equipment. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+
+    <title>API 579-1 / ASME FFS-1 — Fitness-for-service assessment of in-service equipment | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Standards",
+      "item": "https://www.aceengineer.com/standards/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "API 579-1 / ASME FFS-1",
+      "item": "https://www.aceengineer.com/standards/api-579-fitness-for-service.html"
+    }
+  ]
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is fitness-for-service?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A quantitative check of whether equipment with damage \u2014 corrosion, cracks, dents \u2014 is still fit to operate. API 579-1/ASME FFS-1 gives the assessment levels and acceptance criteria."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What can Deckhand assess?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "General and local metal loss at Levels 1 and 2 from wall-thickness readings against the design pressure, returning the remaining strength and the allowable pressure, with the assumptions traced."
+      }
+    }
+  ]
+}
+    </script>
+
+    <style>
+        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
+        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
+        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
+        .faq{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}
+        .faq summary{font-weight:600;color:#2c3e50;cursor:pointer;}
+        .faq p{color:#3a4654;margin:10px 0 0;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Standards</a> &rsaquo; Asset integrity</p>
+                    <h1 class="hero-title" style="text-align:left;">API 579-1 / ASME FFS-1</h1>
+                    <p style="font-size:1.05em;color:#52606d;margin:-6px 0 14px;">Fitness-for-service assessment of in-service equipment</p>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">API 579 / ASME FFS-1 is the fitness-for-service standard for in-service damage. Ask Deckhand to assess a corroded line or vessel from inspection readings and get a remaining-strength verdict.</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start=src_web_std_api-579-fitness-for-service once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_std_api-579-fitness-for-service">Run it on Open Deck</a>
+                        
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">What you can ask it to do</h2>
+                    <ul class="ask-list">
+                        <li>Run a Level 1 / Level 2 general and local metal-loss assessment from wall-thickness readings against the design pressure.</li>
+                        <li>Estimate remaining strength and the maximum allowable working pressure.</li>
+                        <li>State the assumptions and where a Level 3 (detailed) assessment would be needed.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;text-align:center;">
+        <div class="container">
+            <h2 class="section-title">Related standards</h2>
+            <div style="margin:18px 0;">
+                <span class="domain-chip">API 579-1</span>
+                <span class="domain-chip">ASME FFS-1</span>
+                <span class="domain-chip">Fitness-for-service</span>
+                <span class="domain-chip">Metal loss</span>
+                <span class="domain-chip">Remaining strength</span>
+            </div>
+            <p>Part of <a href="../solutions/subsea-pipelines-integrity.html">Subsea, Pipelines &amp; Integrity</a> &middot; <a href="../platform.html">see the platform engine</a></p>
+        </div>
+    </section>
+
+    <section style="padding:40px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">Questions</h2>
+                    <details class="faq"><summary>What is fitness-for-service?</summary><p>A quantitative check of whether equipment with damage — corrosion, cracks, dents — is still fit to operate. API 579-1/ASME FFS-1 gives the assessment levels and acceptance criteria.</p></details>
+                    <details class="faq"><summary>What can Deckhand assess?</summary><p>General and local metal loss at Levels 1 and 2 from wall-thickness readings against the design pressure, returning the remaining strength and the allowable pressure, with the assumptions traced.</p></details>
+            </div></div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container"><div class="row"><div class="col-md-8 col-md-offset-2 text-center">
+            <h2>Run API 579-1 / ASME FFS-1 on your own inputs</h2>
+            <p>Open Deck is free &mdash; bring your numbers and check the result against your own methods.</p>
+            <!-- OPEN_DECK_CTA -->
+            <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_std_api-579-fitness-for-service_footer">Try Open Deck on Telegram</a>
+        </div></div></div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/standards/dnv-rp-b401-cathodic-protection.html
+++ b/content/standards/dnv-rp-b401-cathodic-protection.html
@@ -1,0 +1,152 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="DNV-RP-B401: Cathodic protection design — sacrificial anodes. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+    <meta name="keywords" content="DNV-RP-B401, DNV-RP-F103, Cathodic protection, Sacrificial anodes, Coating breakdown, DNV-RP-B401 calculator, offshore engineering AI">
+
+    <meta property="og:title" content="DNV-RP-B401 — Cathodic protection design — sacrificial anodes | AceEngineer">
+    <meta property="og:description" content="DNV-RP-B401: Cathodic protection design — sacrificial anodes. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://www.aceengineer.com/standards/dnv-rp-b401-cathodic-protection.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="DNV-RP-B401 — Cathodic protection design — sacrificial anodes">
+    <meta name="twitter:description" content="DNV-RP-B401: Cathodic protection design — sacrificial anodes. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+
+    <title>DNV-RP-B401 — Cathodic protection design — sacrificial anodes | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Standards",
+      "item": "https://www.aceengineer.com/standards/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "DNV-RP-B401",
+      "item": "https://www.aceengineer.com/standards/dnv-rp-b401-cathodic-protection.html"
+    }
+  ]
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What does DNV-RP-B401 cover?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The design of sacrificial-anode cathodic-protection systems for offshore structures \u2014 current-density demand, coating breakdown factors, anode mass and current-capacity checks over the design life."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What structures can Deckhand size?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Jackets, subsea manifolds, offshore-wind monopiles, FPSO hulls and pipelines (the pipeline case uses DNV-RP-F103 for anode spacing and reach)."
+      }
+    }
+  ]
+}
+    </script>
+
+    <style>
+        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
+        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
+        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
+        .faq{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}
+        .faq summary{font-weight:600;color:#2c3e50;cursor:pointer;}
+        .faq p{color:#3a4654;margin:10px 0 0;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Standards</a> &rsaquo; Asset integrity</p>
+                    <h1 class="hero-title" style="text-align:left;">DNV-RP-B401</h1>
+                    <p style="font-size:1.05em;color:#52606d;margin:-6px 0 14px;">Cathodic protection design — sacrificial anodes</p>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">DNV-RP-B401 is the recommended practice for sacrificial-anode cathodic-protection design. Ask Deckhand to size the anodes for a structure and get the current demand and anode mass.</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start=src_web_std_dnv-rp-b401-cathodic-protection once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_std_dnv-rp-b401-cathodic-protection">Run it on Open Deck</a>
+                        
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">What you can ask it to do</h2>
+                    <ul class="ask-list">
+                        <li>Work out current demand from surface areas, coating breakdown and design life.</li>
+                        <li>Size the sacrificial-anode mass and number, and check the final-current capacity.</li>
+                        <li>Apply it to a jacket, manifold, monopile, FPSO hull or pipeline.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;text-align:center;">
+        <div class="container">
+            <h2 class="section-title">Related standards</h2>
+            <div style="margin:18px 0;">
+                <span class="domain-chip">DNV-RP-B401</span>
+                <span class="domain-chip">DNV-RP-F103</span>
+                <span class="domain-chip">Cathodic protection</span>
+                <span class="domain-chip">Sacrificial anodes</span>
+                <span class="domain-chip">Coating breakdown</span>
+            </div>
+            <p>Part of <a href="../solutions/subsea-pipelines-integrity.html">Subsea, Pipelines &amp; Integrity</a> &middot; <a href="../platform.html">see the platform engine</a></p>
+        </div>
+    </section>
+
+    <section style="padding:40px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">Questions</h2>
+                    <details class="faq"><summary>What does DNV-RP-B401 cover?</summary><p>The design of sacrificial-anode cathodic-protection systems for offshore structures — current-density demand, coating breakdown factors, anode mass and current-capacity checks over the design life.</p></details>
+                    <details class="faq"><summary>What structures can Deckhand size?</summary><p>Jackets, subsea manifolds, offshore-wind monopiles, FPSO hulls and pipelines (the pipeline case uses DNV-RP-F103 for anode spacing and reach).</p></details>
+            </div></div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container"><div class="row"><div class="col-md-8 col-md-offset-2 text-center">
+            <h2>Run DNV-RP-B401 on your own inputs</h2>
+            <p>Open Deck is free &mdash; bring your numbers and check the result against your own methods.</p>
+            <!-- OPEN_DECK_CTA -->
+            <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_std_dnv-rp-b401-cathodic-protection_footer">Try Open Deck on Telegram</a>
+        </div></div></div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/standards/dnv-rp-c203-fatigue.html
+++ b/content/standards/dnv-rp-c203-fatigue.html
@@ -1,0 +1,179 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="DNV-RP-C203: Fatigue design of offshore steel structures. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+    <meta name="keywords" content="DNV-RP-C203, API RP 2A-WSD, BS 7608, S-N curves, Miner's rule, DNV-RP-C203 calculator, offshore engineering AI">
+
+    <meta property="og:title" content="DNV-RP-C203 — Fatigue design of offshore steel structures | AceEngineer">
+    <meta property="og:description" content="DNV-RP-C203: Fatigue design of offshore steel structures. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://www.aceengineer.com/standards/dnv-rp-c203-fatigue.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="DNV-RP-C203 — Fatigue design of offshore steel structures">
+    <meta name="twitter:description" content="DNV-RP-C203: Fatigue design of offshore steel structures. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+
+    <title>DNV-RP-C203 — Fatigue design of offshore steel structures | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Standards",
+      "item": "https://www.aceengineer.com/standards/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "DNV-RP-C203",
+      "item": "https://www.aceengineer.com/standards/dnv-rp-c203-fatigue.html"
+    }
+  ]
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What does DNV-RP-C203 cover?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It is the recommended practice for fatigue design of offshore steel structures \u2014 S-N curves for welded, base-material and bolted details, stress-concentration factors, thickness effect, and the environment classes (air, seawater with and without cathodic protection)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which S-N curve should I use?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The curve depends on the detail geometry, the loading direction, the environment, and whether the weld is ground or as-welded. Deckhand selects the curve from your detail description and states the choice so a checker can verify it."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can you compare fatigue across standards?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes \u2014 the same stress history can be assessed by DNV-RP-C203, API RP 2A-WSD or BS 7608 and the results shown together, so you can see how the governing curve changes."
+      }
+    }
+  ]
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "DNV-RP-C203 calculator",
+  "applicationCategory": "EngineeringApplication",
+  "operatingSystem": "Web",
+  "url": "https://www.aceengineer.com/standards/dnv-rp-c203-fatigue.html",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "publisher": {
+    "@id": "https://www.aceengineer.com/#organization"
+  }
+}
+    </script>
+
+    <style>
+        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
+        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
+        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
+        .faq{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}
+        .faq summary{font-weight:600;color:#2c3e50;cursor:pointer;}
+        .faq p{color:#3a4654;margin:10px 0 0;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Standards</a> &rsaquo; Fatigue</p>
+                    <h1 class="hero-title" style="text-align:left;">DNV-RP-C203</h1>
+                    <p style="font-size:1.05em;color:#52606d;margin:-6px 0 14px;">Fatigue design of offshore steel structures</p>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">DNV-RP-C203 gives the S-N curves and stress-concentration guidance for fatigue design of welded and bolted offshore steel details. Ask Deckhand to run a check against the right curve and it returns the damage, the life, and the assumptions.</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start=src_web_std_dnv-rp-c203-fatigue once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_std_dnv-rp-c203-fatigue">Run it on Open Deck</a>
+                        <a href="../calculators/fatigue-sn-curve.html" class="btn btn-info btn-lg">S-N fatigue calculator</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">What you can ask it to do</h2>
+                    <ul class="ask-list">
+                        <li>Pick the correct S-N curve for a detail (in air, seawater with or without cathodic protection) and estimate fatigue damage from a stress history.</li>
+                        <li>Apply stress-concentration and thickness corrections and report the governing detail.</li>
+                        <li>Compare a detail against DNV-RP-C203, API RP 2A and BS 7608 side by side.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;text-align:center;">
+        <div class="container">
+            <h2 class="section-title">Related standards</h2>
+            <div style="margin:18px 0;">
+                <span class="domain-chip">DNV-RP-C203</span>
+                <span class="domain-chip">API RP 2A-WSD</span>
+                <span class="domain-chip">BS 7608</span>
+                <span class="domain-chip">S-N curves</span>
+                <span class="domain-chip">Miner's rule</span>
+            </div>
+            <p>Part of <a href="../solutions/subsea-pipelines-integrity.html">Subsea, Pipelines &amp; Integrity</a> &middot; <a href="../platform.html">see the platform engine</a></p>
+        </div>
+    </section>
+
+    <section style="padding:40px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">Questions</h2>
+                    <details class="faq"><summary>What does DNV-RP-C203 cover?</summary><p>It is the recommended practice for fatigue design of offshore steel structures — S-N curves for welded, base-material and bolted details, stress-concentration factors, thickness effect, and the environment classes (air, seawater with and without cathodic protection).</p></details>
+                    <details class="faq"><summary>Which S-N curve should I use?</summary><p>The curve depends on the detail geometry, the loading direction, the environment, and whether the weld is ground or as-welded. Deckhand selects the curve from your detail description and states the choice so a checker can verify it.</p></details>
+                    <details class="faq"><summary>Can you compare fatigue across standards?</summary><p>Yes — the same stress history can be assessed by DNV-RP-C203, API RP 2A-WSD or BS 7608 and the results shown together, so you can see how the governing curve changes.</p></details>
+            </div></div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container"><div class="row"><div class="col-md-8 col-md-offset-2 text-center">
+            <h2>Run DNV-RP-C203 on your own inputs</h2>
+            <p>Open Deck is free &mdash; bring your numbers and check the result against your own methods.</p>
+            <!-- OPEN_DECK_CTA -->
+            <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_std_dnv-rp-c203-fatigue_footer">Try Open Deck on Telegram</a>
+        </div></div></div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/standards/dnv-rp-f105-free-span-viv.html
+++ b/content/standards/dnv-rp-f105-free-span-viv.html
@@ -1,0 +1,151 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="DNV-RP-F105: Free spanning pipelines — VIV and fatigue. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+    <meta name="keywords" content="DNV-RP-F105, Free span, Vortex-induced vibration, Span fatigue, DNV-RP-F105 calculator, offshore engineering AI">
+
+    <meta property="og:title" content="DNV-RP-F105 — Free spanning pipelines — VIV and fatigue | AceEngineer">
+    <meta property="og:description" content="DNV-RP-F105: Free spanning pipelines — VIV and fatigue. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://www.aceengineer.com/standards/dnv-rp-f105-free-span-viv.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="DNV-RP-F105 — Free spanning pipelines — VIV and fatigue">
+    <meta name="twitter:description" content="DNV-RP-F105: Free spanning pipelines — VIV and fatigue. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+
+    <title>DNV-RP-F105 — Free spanning pipelines — VIV and fatigue | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Standards",
+      "item": "https://www.aceengineer.com/standards/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "DNV-RP-F105",
+      "item": "https://www.aceengineer.com/standards/dnv-rp-f105-free-span-viv.html"
+    }
+  ]
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Why are free spans a problem?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Where a pipeline crosses a depression it spans unsupported; current over the span sheds vortices that make it vibrate, and the cyclic stress accumulates fatigue. DNV-RP-F105 is the recommended practice for assessing it."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the allowable span length?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The longest unsupported length that keeps vortex-induced vibration and the resulting fatigue within limits for the seabed and flow conditions. Deckhand estimates it and flags spans that need intervention."
+      }
+    }
+  ]
+}
+    </script>
+
+    <style>
+        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
+        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
+        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
+        .faq{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}
+        .faq summary{font-weight:600;color:#2c3e50;cursor:pointer;}
+        .faq p{color:#3a4654;margin:10px 0 0;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Standards</a> &rsaquo; Pipelines</p>
+                    <h1 class="hero-title" style="text-align:left;">DNV-RP-F105</h1>
+                    <p style="font-size:1.05em;color:#52606d;margin:-6px 0 14px;">Free spanning pipelines — VIV and fatigue</p>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">DNV-RP-F105 governs free-spanning subsea pipelines — the vortex-induced vibration and the fatigue it drives. Ask Deckhand to screen a span for allowable length.</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start=src_web_std_dnv-rp-f105-free-span-viv once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_std_dnv-rp-f105-free-span-viv">Run it on Open Deck</a>
+                        
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">What you can ask it to do</h2>
+                    <ul class="ask-list">
+                        <li>Estimate a span's natural frequencies and screen it for cross-flow and in-line vortex-induced vibration.</li>
+                        <li>Work out the allowable free-span length for the seabed and flow conditions.</li>
+                        <li>Flag where a span needs intervention (rock dump, supports) to control fatigue.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;text-align:center;">
+        <div class="container">
+            <h2 class="section-title">Related standards</h2>
+            <div style="margin:18px 0;">
+                <span class="domain-chip">DNV-RP-F105</span>
+                <span class="domain-chip">Free span</span>
+                <span class="domain-chip">Vortex-induced vibration</span>
+                <span class="domain-chip">Span fatigue</span>
+            </div>
+            <p>Part of <a href="../solutions/subsea-pipelines-integrity.html">Subsea, Pipelines &amp; Integrity</a> &middot; <a href="../platform.html">see the platform engine</a></p>
+        </div>
+    </section>
+
+    <section style="padding:40px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">Questions</h2>
+                    <details class="faq"><summary>Why are free spans a problem?</summary><p>Where a pipeline crosses a depression it spans unsupported; current over the span sheds vortices that make it vibrate, and the cyclic stress accumulates fatigue. DNV-RP-F105 is the recommended practice for assessing it.</p></details>
+                    <details class="faq"><summary>What is the allowable span length?</summary><p>The longest unsupported length that keeps vortex-induced vibration and the resulting fatigue within limits for the seabed and flow conditions. Deckhand estimates it and flags spans that need intervention.</p></details>
+            </div></div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container"><div class="row"><div class="col-md-8 col-md-offset-2 text-center">
+            <h2>Run DNV-RP-F105 on your own inputs</h2>
+            <p>Open Deck is free &mdash; bring your numbers and check the result against your own methods.</p>
+            <!-- OPEN_DECK_CTA -->
+            <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_std_dnv-rp-f105-free-span-viv_footer">Try Open Deck on Telegram</a>
+        </div></div></div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/standards/dnv-rp-f109-on-bottom-stability.html
+++ b/content/standards/dnv-rp-f109-on-bottom-stability.html
@@ -1,0 +1,178 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="DNV-RP-F109: On-bottom stability design of submarine pipelines. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+    <meta name="keywords" content="DNV-RP-F109, On-bottom stability, Hydrodynamic loads, Submerged weight, DNV-RP-F109 calculator, offshore engineering AI">
+
+    <meta property="og:title" content="DNV-RP-F109 — On-bottom stability design of submarine pipelines | AceEngineer">
+    <meta property="og:description" content="DNV-RP-F109: On-bottom stability design of submarine pipelines. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://www.aceengineer.com/standards/dnv-rp-f109-on-bottom-stability.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="DNV-RP-F109 — On-bottom stability design of submarine pipelines">
+    <meta name="twitter:description" content="DNV-RP-F109: On-bottom stability design of submarine pipelines. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+
+    <title>DNV-RP-F109 — On-bottom stability design of submarine pipelines | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Standards",
+      "item": "https://www.aceengineer.com/standards/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "DNV-RP-F109",
+      "item": "https://www.aceengineer.com/standards/dnv-rp-f109-on-bottom-stability.html"
+    }
+  ]
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is on-bottom stability?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Whether a subsea pipeline stays put on the seabed under wave and current loads, rather than being lifted or pushed sideways. DNV-RP-F109 is the recommended practice for designing it."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What drives the result?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The sea state and current, the pipe's submerged weight (including any concrete coating), the seabed friction, and the allowed displacement. Deckhand reports which governs and the utilisation."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do you size the concrete coating?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes \u2014 Deckhand can report the submerged weight, and hence the coating, required to bring the stability utilisation within the criterion."
+      }
+    }
+  ]
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "DNV-RP-F109 calculator",
+  "applicationCategory": "EngineeringApplication",
+  "operatingSystem": "Web",
+  "url": "https://www.aceengineer.com/standards/dnv-rp-f109-on-bottom-stability.html",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "publisher": {
+    "@id": "https://www.aceengineer.com/#organization"
+  }
+}
+    </script>
+
+    <style>
+        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
+        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
+        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
+        .faq{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}
+        .faq summary{font-weight:600;color:#2c3e50;cursor:pointer;}
+        .faq p{color:#3a4654;margin:10px 0 0;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Standards</a> &rsaquo; Pipelines</p>
+                    <h1 class="hero-title" style="text-align:left;">DNV-RP-F109</h1>
+                    <p style="font-size:1.05em;color:#52606d;margin:-6px 0 14px;">On-bottom stability design of submarine pipelines</p>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">DNV-RP-F109 covers the stability of a subsea line on the seabed under wave and current loading. Ask Deckhand to check it and get the required submerged weight and the utilisation.</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start=src_web_std_dnv-rp-f109-on-bottom-stability once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_std_dnv-rp-f109-on-bottom-stability">Run it on Open Deck</a>
+                        <a href="../calculators/on-bottom-stability.html" class="btn btn-info btn-lg">On-bottom stability calculator</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">What you can ask it to do</h2>
+                    <ul class="ask-list">
+                        <li>Work out hydrodynamic loads on a pipeline from a sea state and current and the submerged weight it needs.</li>
+                        <li>Run the absolute-stability and the generalised (allowed-displacement) checks.</li>
+                        <li>Report the stability utilisation and the concrete-coating or weight needed to pass.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;text-align:center;">
+        <div class="container">
+            <h2 class="section-title">Related standards</h2>
+            <div style="margin:18px 0;">
+                <span class="domain-chip">DNV-RP-F109</span>
+                <span class="domain-chip">On-bottom stability</span>
+                <span class="domain-chip">Hydrodynamic loads</span>
+                <span class="domain-chip">Submerged weight</span>
+            </div>
+            <p>Part of <a href="../solutions/subsea-pipelines-integrity.html">Subsea, Pipelines &amp; Integrity</a> &middot; <a href="../platform.html">see the platform engine</a></p>
+        </div>
+    </section>
+
+    <section style="padding:40px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">Questions</h2>
+                    <details class="faq"><summary>What is on-bottom stability?</summary><p>Whether a subsea pipeline stays put on the seabed under wave and current loads, rather than being lifted or pushed sideways. DNV-RP-F109 is the recommended practice for designing it.</p></details>
+                    <details class="faq"><summary>What drives the result?</summary><p>The sea state and current, the pipe's submerged weight (including any concrete coating), the seabed friction, and the allowed displacement. Deckhand reports which governs and the utilisation.</p></details>
+                    <details class="faq"><summary>Do you size the concrete coating?</summary><p>Yes — Deckhand can report the submerged weight, and hence the coating, required to bring the stability utilisation within the criterion.</p></details>
+            </div></div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container"><div class="row"><div class="col-md-8 col-md-offset-2 text-center">
+            <h2>Run DNV-RP-F109 on your own inputs</h2>
+            <p>Open Deck is free &mdash; bring your numbers and check the result against your own methods.</p>
+            <!-- OPEN_DECK_CTA -->
+            <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_std_dnv-rp-f109-on-bottom-stability_footer">Try Open Deck on Telegram</a>
+        </div></div></div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/standards/dnv-st-f101-wall-thickness.html
+++ b/content/standards/dnv-st-f101-wall-thickness.html
@@ -1,0 +1,179 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="DNV-ST-F101: Submarine pipeline systems — pressure containment &amp; wall thickness. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+    <meta name="keywords" content="DNV-ST-F101, ASME B31.4 / B31.8, PD 8010, Pressure containment, Collapse, DNV-ST-F101 calculator, offshore engineering AI">
+
+    <meta property="og:title" content="DNV-ST-F101 — Submarine pipeline systems — pressure containment &amp; wall thickness | AceEngineer">
+    <meta property="og:description" content="DNV-ST-F101: Submarine pipeline systems — pressure containment &amp; wall thickness. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://www.aceengineer.com/standards/dnv-st-f101-wall-thickness.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="DNV-ST-F101 — Submarine pipeline systems — pressure containment &amp; wall thickness">
+    <meta name="twitter:description" content="DNV-ST-F101: Submarine pipeline systems — pressure containment &amp; wall thickness. Run it from chat with Deckhand — standards-traceable, deterministic, with every assumption shown.">
+
+    <title>DNV-ST-F101 — Submarine pipeline systems — pressure containment &amp; wall thickness | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Standards",
+      "item": "https://www.aceengineer.com/standards/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "DNV-ST-F101",
+      "item": "https://www.aceengineer.com/standards/dnv-st-f101-wall-thickness.html"
+    }
+  ]
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What does DNV-ST-F101 govern?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It is the standard for submarine pipeline systems \u2014 design, materials, construction and operation. The most-asked part is wall-thickness design \u2014 pressure containment, local buckling/collapse, and combined loading."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How is the minimum wall thickness determined?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "From the design pressure and the pipe grade for pressure containment, plus fabrication tolerance and corrosion allowance, then verified against collapse and combined-loading limits. Deckhand reports the governing check and the utilisation."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can you compare design codes?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes \u2014 wall thickness can be screened across DNV-ST-F101, ASME B31 and PD 8010 together so the code difference is explicit."
+      }
+    }
+  ]
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "DNV-ST-F101 calculator",
+  "applicationCategory": "EngineeringApplication",
+  "operatingSystem": "Web",
+  "url": "https://www.aceengineer.com/standards/dnv-st-f101-wall-thickness.html",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "publisher": {
+    "@id": "https://www.aceengineer.com/#organization"
+  }
+}
+    </script>
+
+    <style>
+        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
+        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
+        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
+        .faq{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}
+        .faq summary{font-weight:600;color:#2c3e50;cursor:pointer;}
+        .faq p{color:#3a4654;margin:10px 0 0;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Standards</a> &rsaquo; Pipelines</p>
+                    <h1 class="hero-title" style="text-align:left;">DNV-ST-F101</h1>
+                    <p style="font-size:1.05em;color:#52606d;margin:-6px 0 14px;">Submarine pipeline systems — pressure containment &amp; wall thickness</p>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">DNV-ST-F101 is the offshore pipeline standard. Ask Deckhand to size a wall for pressure containment and the collapse and combined-loading limits, with every factor and assumption shown.</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start=src_web_std_dnv-st-f101-wall-thickness once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_std_dnv-st-f101-wall-thickness">Run it on Open Deck</a>
+                        <a href="../calculators/wall-thickness.html" class="btn btn-info btn-lg">Wall-thickness calculator</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">What you can ask it to do</h2>
+                    <ul class="ask-list">
+                        <li>Size a pipeline wall for design pressure (pressure containment) with fabrication and corrosion allowances.</li>
+                        <li>Check system collapse and propagation buckling, and combined-loading utilisation.</li>
+                        <li>Screen the same line across DNV-ST-F101, ASME B31 and PD 8010 in one report.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;text-align:center;">
+        <div class="container">
+            <h2 class="section-title">Related standards</h2>
+            <div style="margin:18px 0;">
+                <span class="domain-chip">DNV-ST-F101</span>
+                <span class="domain-chip">ASME B31.4 / B31.8</span>
+                <span class="domain-chip">PD 8010</span>
+                <span class="domain-chip">Pressure containment</span>
+                <span class="domain-chip">Collapse</span>
+            </div>
+            <p>Part of <a href="../solutions/subsea-pipelines-integrity.html">Subsea, Pipelines &amp; Integrity</a> &middot; <a href="../platform.html">see the platform engine</a></p>
+        </div>
+    </section>
+
+    <section style="padding:40px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">Questions</h2>
+                    <details class="faq"><summary>What does DNV-ST-F101 govern?</summary><p>It is the standard for submarine pipeline systems — design, materials, construction and operation. The most-asked part is wall-thickness design — pressure containment, local buckling/collapse, and combined loading.</p></details>
+                    <details class="faq"><summary>How is the minimum wall thickness determined?</summary><p>From the design pressure and the pipe grade for pressure containment, plus fabrication tolerance and corrosion allowance, then verified against collapse and combined-loading limits. Deckhand reports the governing check and the utilisation.</p></details>
+                    <details class="faq"><summary>Can you compare design codes?</summary><p>Yes — wall thickness can be screened across DNV-ST-F101, ASME B31 and PD 8010 together so the code difference is explicit.</p></details>
+            </div></div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container"><div class="row"><div class="col-md-8 col-md-offset-2 text-center">
+            <h2>Run DNV-ST-F101 on your own inputs</h2>
+            <p>Open Deck is free &mdash; bring your numbers and check the result against your own methods.</p>
+            <!-- OPEN_DECK_CTA -->
+            <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_std_dnv-st-f101-wall-thickness_footer">Try Open Deck on Telegram</a>
+        </div></div></div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/standards/index.html
+++ b/content/standards/index.html
@@ -1,0 +1,85 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Engineering standards you can run from chat — DNV, API, ASME and more. Each page explains the standard and lets you run the check on Open Deck, standards-traceable and deterministic.">
+    <meta name="keywords" content="engineering standards calculator, DNV API ASME calculators, offshore standards, fatigue wall thickness on-bottom stability cathodic protection">
+
+    <meta property="og:title" content="Engineering Standards, Run From Chat | AceEngineer">
+    <meta property="og:description" content="Run DNV / API / ASME checks from a chat message — traced to the clause, deterministic.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://www.aceengineer.com/standards/">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Engineering Standards, Run From Chat | AceEngineer">
+    <meta name="twitter:description" content="Run DNV / API / ASME checks from chat, traced to the clause.">
+
+    <title>Engineering Standards, Run From Chat | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <style>
+        .std-card{background:#fff;border:1px solid #e6e8eb;border-radius:10px;padding:22px;margin-bottom:24px;height:100%;}
+        .std-card h3{font-size:1.05em;color:#2c3e50;margin:6px 0 14px;}
+        .std-code{display:inline-block;background:#2c3e50;color:#fff;border-radius:6px;padding:3px 10px;font-size:.82em;font-weight:700;}
+        .sol-group-title{margin:34px 0 10px;}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:24px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h1 class="hero-title">Standards, run from chat</h1>
+                    <p class="hero-subtitle">Each standard below explains what it governs and lets you run the check on Open Deck &mdash; traced to the clause, deterministic, with the assumptions shown.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:24px 0 56px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title sol-group-title">Fatigue</h2>
+                    <div class="row">
+                        <div class="col-md-4"><div class="std-card"><span class="std-code">DNV-RP-C203</span><h3>Fatigue design of offshore steel structures</h3><a href="dnv-rp-c203-fatigue.html" class="btn btn-sm btn-info">Open</a></div></div>
+                    </div>
+
+                    <h2 class="section-title sol-group-title">Pipelines</h2>
+                    <div class="row">
+                        <div class="col-md-4"><div class="std-card"><span class="std-code">DNV-ST-F101</span><h3>Submarine pipeline systems — pressure containment &amp; wall thickness</h3><a href="dnv-st-f101-wall-thickness.html" class="btn btn-sm btn-info">Open</a></div></div>
+                        <div class="col-md-4"><div class="std-card"><span class="std-code">DNV-RP-F109</span><h3>On-bottom stability design of submarine pipelines</h3><a href="dnv-rp-f109-on-bottom-stability.html" class="btn btn-sm btn-info">Open</a></div></div>
+                        <div class="col-md-4"><div class="std-card"><span class="std-code">DNV-RP-F105</span><h3>Free spanning pipelines — VIV and fatigue</h3><a href="dnv-rp-f105-free-span-viv.html" class="btn btn-sm btn-info">Open</a></div></div>
+                    </div>
+
+                    <h2 class="section-title sol-group-title">Asset integrity</h2>
+                    <div class="row">
+                        <div class="col-md-4"><div class="std-card"><span class="std-code">API 579-1 / ASME FFS-1</span><h3>Fitness-for-service assessment of in-service equipment</h3><a href="api-579-fitness-for-service.html" class="btn btn-sm btn-info">Open</a></div></div>
+                        <div class="col-md-4"><div class="std-card"><span class="std-code">DNV-RP-B401</span><h3>Cathodic protection design — sacrificial anodes</h3><a href="dnv-rp-b401-cathodic-protection.html" class="btn btn-sm btn-info">Open</a></div></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container"><div class="row"><div class="col-md-8 col-md-offset-2 text-center">
+            <h2>Bring a real check</h2>
+            <p>Join Open Deck and run any of these against your own inputs.</p>
+            <!-- OPEN_DECK_CTA -->
+            <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_standards_hub">Try Open Deck on Telegram</a>
+        </div></div></div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/scripts/seo/generate_standard_pages.py
+++ b/scripts/seo/generate_standard_pages.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Programmatic-SEO generator — standard landing pages (W8, aceengineer-website#27).
+
+Reads config/seo/standards.yaml and emits:
+  - content/standards/<slug>.html      one cluster page per standard
+  - content/standards/index.html       the cluster hub
+  - sitemap.xml                         refreshes the marked generated block
+
+The generated pages are committed (the repo builds content/ -> dist/). Re-run
+after editing the manifest:
+
+    uv run python scripts/seo/generate_standard_pages.py
+
+Each page is part of a topic cluster that points up to its Solutions pillar
+page (W5) and, where one exists, the matching free calculator. Content is
+authored in the manifest; this script only renders it. No external claims are
+invented here.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "config" / "seo" / "standards.yaml"
+OUT_DIR = ROOT / "content" / "standards"
+SITEMAP = ROOT / "sitemap.xml"
+BASE = "https://www.aceengineer.com"
+
+SITE_BEGIN = "  <!-- BEGIN standards (generated) -->"
+SITE_END = "  <!-- END standards (generated) -->"
+
+
+def esc(text: str) -> str:
+    """HTML-escape visible text (leaves &mdash; style entities authored as plain dashes)."""
+    return html.escape(str(text).strip(), quote=False)
+
+
+def render_page(s: dict) -> str:
+    slug = s["slug"]
+    code = esc(s["code"])
+    name = esc(s["name"])
+    discipline = esc(s["discipline"])
+    intro = esc(s["intro"])
+    pillar = s["pillar"]
+    calc = s.get("calculator")
+    src_tag = s["src_tag"]
+    url = f"{BASE}/standards/{slug}.html"
+
+    title = f"{s['code']} — {s['name']} | AceEngineer"
+    description = (
+        f"{s['code']}: {s['name']}. Run it from chat with Deckhand — "
+        "standards-traceable, deterministic, with every assumption shown."
+    )
+    keywords = ", ".join(s.get("chips", []) + [f"{s['code']} calculator", "offshore engineering AI"])
+
+    # --- structured data ---
+    breadcrumb = {
+        "@context": "https://schema.org", "@type": "BreadcrumbList",
+        "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "Standards", "item": f"{BASE}/standards/"},
+            {"@type": "ListItem", "position": 2, "name": s["code"], "item": url},
+        ],
+    }
+    faq_schema = {
+        "@context": "https://schema.org", "@type": "FAQPage",
+        "mainEntity": [
+            {"@type": "Question", "name": f["q"],
+             "acceptedAnswer": {"@type": "Answer", "text": f["a"]}}
+            for f in s.get("faqs", [])
+        ],
+    }
+    schema_blocks = [breadcrumb, faq_schema]
+    if calc:
+        schema_blocks.append({
+            "@context": "https://schema.org", "@type": "SoftwareApplication",
+            "name": f"{s['code']} calculator", "applicationCategory": "EngineeringApplication",
+            "operatingSystem": "Web", "url": url,
+            "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"},
+            "publisher": {"@id": f"{BASE}/#organization"},
+        })
+    schema_html = "\n".join(
+        f'    <script type="application/ld+json">\n{json.dumps(b, indent=2)}\n    </script>'
+        for b in schema_blocks
+    )
+
+    does_html = "\n".join(f"                        <li>{esc(d)}</li>" for d in s.get("does", []))
+    chips_html = "\n".join(
+        f'                <span class="domain-chip">{esc(c)}</span>' for c in s.get("chips", [])
+    )
+    faqs_html = "\n".join(
+        f'                    <details class="faq"><summary>{esc(f["q"])}</summary>'
+        f'<p>{esc(f["a"])}</p></details>'
+        for f in s.get("faqs", [])
+    )
+
+    calc_btn = (
+        f'<a href="{calc["href"]}" class="btn btn-info btn-lg">{esc(calc["label"])}</a>'
+        if calc else ""
+    )
+
+    return f"""---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="{esc(description)}">
+    <meta name="keywords" content="{esc(keywords)}">
+
+    <meta property="og:title" content="{esc(s['code'])} — {name} | AceEngineer">
+    <meta property="og:description" content="{esc(description)}">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{url}">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{esc(s['code'])} — {name}">
+    <meta name="twitter:description" content="{esc(description)}">
+
+    <title>{esc(title)}</title>
+
+    <include src="partials/head-common.html"></include>
+
+{schema_html}
+
+    <style>
+        .ask-list{{list-style:none;padding:0;max-width:820px;margin:0 auto;}}
+        .ask-list li{{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}}
+        .domain-chip{{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}}
+        .faq{{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}}
+        .faq summary{{font-weight:600;color:#2c3e50;cursor:pointer;}}
+        .faq p{{color:#3a4654;margin:10px 0 0;}}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1">
+                    <p style="text-transform:uppercase;letter-spacing:.08em;color:#6b7785;font-size:.85em;"><a href="index.html" style="color:#6b7785;">Standards</a> &rsaquo; {discipline}</p>
+                    <h1 class="hero-title" style="text-align:left;">{code}</h1>
+                    <p style="font-size:1.05em;color:#52606d;margin:-6px 0 14px;">{name}</p>
+                    <p class="hero-subtitle" style="text-align:left;margin-left:0;">{intro}</p>
+                    <div class="hero-cta" style="text-align:left;">
+                        <!-- OPEN_DECK_CTA: swap to https://t.me/the_deckhand_bot?start={src_tag} once deckhand#432 live -->
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="{src_tag}">Run it on Open Deck</a>
+                        {calc_btn}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:56px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">What you can ask it to do</h2>
+                    <ul class="ask-list">
+{does_html}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;text-align:center;">
+        <div class="container">
+            <h2 class="section-title">Related standards</h2>
+            <div style="margin:18px 0;">
+{chips_html}
+            </div>
+            <p>Part of <a href="{pillar['href']}">{esc(pillar['label'])}</a> &middot; <a href="../platform.html">see the platform engine</a></p>
+        </div>
+    </section>
+
+    <section style="padding:40px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">Questions</h2>
+{faqs_html}
+            </div></div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container"><div class="row"><div class="col-md-8 col-md-offset-2 text-center">
+            <h2>Run {code} on your own inputs</h2>
+            <p>Open Deck is free &mdash; bring your numbers and check the result against your own methods.</p>
+            <!-- OPEN_DECK_CTA -->
+            <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="{src_tag}_footer">Try Open Deck on Telegram</a>
+        </div></div></div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>
+"""
+
+
+def render_index(standards: list[dict]) -> str:
+    by_disc: dict[str, list[dict]] = {}
+    for s in standards:
+        by_disc.setdefault(s["discipline"], []).append(s)
+
+    groups_html = []
+    for disc, items in by_disc.items():
+        cards = "\n".join(
+            f'                        <div class="col-md-4"><div class="std-card">'
+            f'<span class="std-code">{esc(s["code"])}</span>'
+            f'<h3>{esc(s["name"])}</h3>'
+            f'<a href="{s["slug"]}.html" class="btn btn-sm btn-info">Open</a></div></div>'
+            for s in items
+        )
+        groups_html.append(
+            f'                    <h2 class="section-title sol-group-title">{esc(disc)}</h2>\n'
+            f'                    <div class="row">\n{cards}\n                    </div>'
+        )
+    groups = "\n\n".join(groups_html)
+
+    return f"""---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Engineering standards you can run from chat — DNV, API, ASME and more. Each page explains the standard and lets you run the check on Open Deck, standards-traceable and deterministic.">
+    <meta name="keywords" content="engineering standards calculator, DNV API ASME calculators, offshore standards, fatigue wall thickness on-bottom stability cathodic protection">
+
+    <meta property="og:title" content="Engineering Standards, Run From Chat | AceEngineer">
+    <meta property="og:description" content="Run DNV / API / ASME checks from a chat message — traced to the clause, deterministic.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{BASE}/standards/">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Engineering Standards, Run From Chat | AceEngineer">
+    <meta name="twitter:description" content="Run DNV / API / ASME checks from chat, traced to the clause.">
+
+    <title>Engineering Standards, Run From Chat | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <style>
+        .std-card{{background:#fff;border:1px solid #e6e8eb;border-radius:10px;padding:22px;margin-bottom:24px;height:100%;}}
+        .std-card h3{{font-size:1.05em;color:#2c3e50;margin:6px 0 14px;}}
+        .std-code{{display:inline-block;background:#2c3e50;color:#fff;border-radius:6px;padding:3px 10px;font-size:.82em;font-weight:700;}}
+        .sol-group-title{{margin:34px 0 10px;}}
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:24px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h1 class="hero-title">Standards, run from chat</h1>
+                    <p class="hero-subtitle">Each standard below explains what it governs and lets you run the check on Open Deck &mdash; traced to the clause, deterministic, with the assumptions shown.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section style="padding:24px 0 56px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+{groups}
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container"><div class="row"><div class="col-md-8 col-md-offset-2 text-center">
+            <h2>Bring a real check</h2>
+            <p>Join Open Deck and run any of these against your own inputs.</p>
+            <!-- OPEN_DECK_CTA -->
+            <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_standards_hub">Try Open Deck on Telegram</a>
+        </div></div></div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>
+"""
+
+
+def sitemap_block(standards: list[dict]) -> str:
+    rows = [SITE_BEGIN]
+    rows.append("  <url>")
+    rows.append(f"    <loc>{BASE}/standards/</loc>")
+    rows.append("    <lastmod>2026-06-17</lastmod>")
+    rows.append("    <changefreq>weekly</changefreq>")
+    rows.append("    <priority>0.8</priority>")
+    rows.append("  </url>")
+    for s in standards:
+        rows.append("  <url>")
+        rows.append(f"    <loc>{BASE}/standards/{s['slug']}.html</loc>")
+        rows.append("    <lastmod>2026-06-17</lastmod>")
+        rows.append("    <changefreq>monthly</changefreq>")
+        rows.append("    <priority>0.7</priority>")
+        rows.append("  </url>")
+    rows.append(SITE_END)
+    return "\n".join(rows)
+
+
+def update_sitemap(standards: list[dict]) -> None:
+    text = SITEMAP.read_text()
+    block = sitemap_block(standards)
+    if SITE_BEGIN in text and SITE_END in text:
+        pre = text.split(SITE_BEGIN)[0]
+        post = text.split(SITE_END, 1)[1]
+        text = pre + block + post
+    else:
+        text = text.replace("</urlset>", block + "\n</urlset>")
+    SITEMAP.write_text(text)
+
+
+def main() -> None:
+    data = yaml.safe_load(MANIFEST.read_text())
+    standards = data["standards"]
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    for s in standards:
+        (OUT_DIR / f"{s['slug']}.html").write_text(render_page(s))
+    (OUT_DIR / "index.html").write_text(render_index(standards))
+    update_sitemap(standards)
+
+    print(f"generated {len(standards)} standard pages + index into {OUT_DIR.relative_to(ROOT)}")
+    print("sitemap.xml updated")
+
+
+if __name__ == "__main__":
+    main()

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -401,4 +401,48 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+  <!-- BEGIN standards (generated) -->
+  <url>
+    <loc>https://www.aceengineer.com/standards/</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/standards/dnv-rp-c203-fatigue.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/standards/dnv-st-f101-wall-thickness.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/standards/dnv-rp-f109-on-bottom-stability.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/standards/dnv-rp-f105-free-span-viv.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/standards/api-579-fitness-for-service.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/standards/dnv-rp-b401-cathodic-protection.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <!-- END standards (generated) -->
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,9 +3,33 @@
   <!-- Homepage -->
   <url>
     <loc>https://www.aceengineer.com/</loc>
-    <lastmod>2026-01-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
+  </url>
+
+  <!-- Deckhand -->
+  <url>
+    <loc>https://www.aceengineer.com/deckhand.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <!-- Platform -->
+  <url>
+    <loc>https://www.aceengineer.com/platform.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <!-- Proof -->
+  <url>
+    <loc>https://www.aceengineer.com/proof.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
 
   <!-- About Page -->

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -32,6 +32,56 @@
     <priority>0.8</priority>
   </url>
 
+  <!-- Solutions hub + domain pages -->
+  <url>
+    <loc>https://www.aceengineer.com/solutions/</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/solutions/subsea-pipelines-integrity.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/solutions/floating-marine.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/solutions/wells-subsurface.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/solutions/power-electrical-controls.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/solutions/codes-standards-maritime-law.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/solutions/design-cad.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/solutions/manufacturing-fabrication.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
   <!-- About Page -->
   <url>
     <loc>https://www.aceengineer.com/about.html</loc>

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,5 @@
 {
   "version": 2,
-  "public": true,
-  "name": "aceengineer-website",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "redirects": [


### PR DESCRIPTION
## What

First tracer slice of the [aceengineer.com relaunch epic (#19)](https://github.com/vamseeachanta/aceengineer-website/issues/19) — repositions the site from a calculator/consultancy brochure to **"the AI engineering firm for offshore energy,"** and adds the three pages the product had no presence for.

Covers, in whole or part: **W1** (#20), **W2** (#21), **W3** (#22), **W4** (#23), **W6** (#25).

## Changes

- **W1 — Information architecture** (`nav.html`, `footer.html`, `sitemap.xml`): new nav `Home · Deckhand · Platform · Solutions · Proof · Calculators · Company` with a primary **Try Open Deck** CTA. Solutions points to the existing `engineering.html` for now (full domain pages = W5, #24). No broken internal links.
- **W2 — Homepage reposition** (`index.html`): new hero, a *Meet Deckhand* section with a chat demo, a *deterministic-by-design* strip, refreshed metrics (7,000+ functions / 42 standards / 680 byte-identical cases), and updated Organization + Service schema.
- **W3 — Deckhand page** (`deckhand.html`): how it works, hard guardrails, Open Deck vs private tiers, capability domains; `SoftwareApplication` + `FAQPage` schema.
- **W4 — Platform page** (`platform.html`): digitalmodel capabilities with honest today/next/later tiering (no overclaiming autonomous design).
- **W6 — Proof page** (`proof.html`): determinism, standards traceability, assumption-ledger example.

## Messaging & accuracy

- Settled framework only: *"AI that shows its work"* + *"Deterministic deliverables."* Engineering language; no "revolutionary/cutting-edge AI."
- Capability figures sourced from the digitalmodel README (7,355 functions, 42 standards). Roadmap items are labelled as roadmap, not shipped.

## CTAs / funnel

- Open Deck CTAs point to the **live** group invite (`t.me/+…`), each carrying `data-cta="open-deck"` + a `data-src` source tag (groundwork for lead attribution, **W10** / #29).
- Every CTA is marked `<!-- OPEN_DECK_CTA -->` for a one-pass swap to the source-tagged bot deep-link (`t.me/the_deckhand_bot?start=src_…`) once the front-door handler ([deckhand#432](https://github.com/vamseeachanta/deckhand/issues/432)) is live.

## Posture

Product-only: confident category framing, **no fundraising / acquisition signals** (that narrative stays private in `aceengineer-strategy`).

## Verification

- `npm run build` → 55 pages, new pages rendered into `dist/`.
- `npx jest` → 146 passed. `pytest` → 203 passed. `verify_repo_structure.py` → OK.
- Link integrity: all new nav targets resolve; 11 Open Deck CTAs rendered across `dist/`.

## Follow-ups (separate slices)

- W5 (#24) Solutions-by-domain pages · W7 (#26) design-system refresh · W8 (#27) programmatic-SEO engine · **W9 (#28) demo gallery** — will absorb the in-flight [demo-video v3 work (deckhand#425)](https://github.com/vamseeachanta/deckhand/issues/425) when those assets land · W10 (#29) lead-capture wiring · W11 (#30) vision surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
