### PR TITLE
feat(seo): W10 — CTA lead-source tracking via GA events

### DIFF
--- a/GOOGLE_ANALYTICS_SETUP.md
+++ b/GOOGLE_ANALYTICS_SETUP.md
@@ -409,3 +409,24 @@ G-XXXXXXXXXX
 ---
 
 **Ready to implement?** Create your GA4 property first, then add the tracking script to all pages in the next commit.
+
+---
+
+## CTA / lead-source tracking (W10, #29)
+
+`assets/js/cta-tracking.js` (loaded on every page via `partials/head-common.html`) fires a GA4 event whenever a tagged call-to-action is clicked:
+
+```
+event:  cta_click
+params: cta_type    e.g. "open-deck"
+        cta_source  e.g. "src_web_std_dnv-st-f101-wall-thickness"
+        destination the link href (usually the Open Deck Telegram URL)
+        page_path   the originating page
+```
+
+Every Open Deck CTA carries `data-cta="open-deck"` and a `data-src="src_web_<domain>[_<workflow>]"` tag. The same `src_<domain>_<workflow>` convention is read on the Telegram side for lead attribution (deckhand#433) once the bot deep-link handler (deckhand#432) is live, so a click can be followed from page → bot.
+
+**To make leads visible in GA4:**
+1. **Admin → Events** — confirm `cta_click` appears after a few clicks.
+2. **Admin → Key events** — mark `cta_click` (or a filtered version where `cta_type = open-deck`) as a key event (conversion).
+3. Build an **Exploration** broken down by the `cta_source` custom dimension to see which page/domain drives Open Deck joins. Register `cta_source`, `cta_type`, `destination` under **Admin → Custom definitions** to use them as dimensions.

--- a/assets/js/cta-tracking.js
+++ b/assets/js/cta-tracking.js
@@ -1,0 +1,56 @@
+/* CTA tracking (W10, aceengineer-website#29)
+ *
+ * Turns the data-cta / data-src tags on call-to-action links into Google
+ * Analytics events, so web -> Open Deck (Telegram) hand-offs are attributable
+ * by source tag (src_web_<domain>[_<workflow>]). Pairs with the deckhand-side
+ * lead attribution (deckhand#433) that reads the same src_<domain>_<workflow>
+ * tag once the bot deep-link handler (deckhand#432) is live.
+ *
+ * Emits gtag('event', 'cta_click', { cta_type, cta_source, destination,
+ * page_path }). Falls back to dataLayer.push when gtag isn't ready, and is a
+ * no-op if neither exists, so it never breaks a page.
+ */
+(function () {
+    'use strict';
+
+    function send(eventName, params) {
+        if (typeof window.gtag === 'function') {
+            window.gtag('event', eventName, params);
+            return true;
+        }
+        if (Array.isArray(window.dataLayer)) {
+            window.dataLayer.push(Object.assign({ event: eventName }, params));
+            return true;
+        }
+        return false;
+    }
+
+    function onClick(el) {
+        return function () {
+            send('cta_click', {
+                cta_type: el.getAttribute('data-cta') || 'unknown',
+                cta_source: el.getAttribute('data-src') || '',
+                destination: el.getAttribute('href') || '',
+                page_path: window.location ? window.location.pathname : ''
+            });
+        };
+    }
+
+    function init() {
+        var ctas = document.querySelectorAll('[data-cta]');
+        for (var i = 0; i < ctas.length; i++) {
+            ctas[i].addEventListener('click', onClick(ctas[i]));
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+    // Exposed for unit testing
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = { send: send, init: init };
+    }
+})();

--- a/content/partials/head-common.html
+++ b/content/partials/head-common.html
@@ -1,6 +1,7 @@
 <link rel="icon" type="image/svg+xml" href="{{ rootPath }}assets/favicon.svg">
 <link rel="stylesheet" href="{{ rootPath }}assets/css/styles.min.css">
 <script defer src="{{ rootPath }}assets/js/navbar-toggle.js"></script>
+<script defer src="{{ rootPath }}assets/js/cta-tracking.js"></script>
 
 <!-- Google Analytics - deferred until after page is interactive -->
 <script>

--- a/package.json
+++ b/package.json
@@ -42,11 +42,17 @@
         "displayName": "demo-links",
         "testEnvironment": "jsdom",
         "testMatch": ["<rootDir>/tests/js/demo-links.test.js"]
+      },
+      {
+        "displayName": "cta-tracking",
+        "testEnvironment": "jsdom",
+        "testMatch": ["<rootDir>/tests/js/cta-tracking.test.js"]
       }
     ],
     "collectCoverageFrom": [
       "build.js",
       "assets/js/navbar-toggle.js",
+      "assets/js/cta-tracking.js",
       "assets/js/npv-calculator-engine.js",
       "demos/hse-risk-dashboard-data.js"
     ]

--- a/tests/js/cta-tracking.test.js
+++ b/tests/js/cta-tracking.test.js
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe('cta-tracking', () => {
+  const scriptPath = require.resolve('../../assets/js/cta-tracking.js');
+
+  function load() {
+    delete require.cache[scriptPath];
+    const mod = require('../../assets/js/cta-tracking.js');
+    // jsdom has already fired DOMContentLoaded; the module inits immediately
+    // when readyState !== 'loading', so listeners are attached on require.
+    return mod;
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <a id="cta" href="https://t.me/+ABC" data-cta="open-deck"
+         data-src="src_web_std_dnv-st-f101-wall-thickness">Try Open Deck</a>
+      <a id="plain" href="/about.html">About</a>
+    `;
+    delete window.gtag;
+    window.dataLayer = [];
+  });
+
+  test('fires a gtag cta_click event with the source tag on click', () => {
+    const calls = [];
+    window.gtag = (...args) => calls.push(args);
+    load();
+
+    document.getElementById('cta').click();
+
+    expect(calls).toHaveLength(1);
+    const [eventType, name, params] = calls[0];
+    expect(eventType).toBe('event');
+    expect(name).toBe('cta_click');
+    expect(params.cta_type).toBe('open-deck');
+    expect(params.cta_source).toBe('src_web_std_dnv-st-f101-wall-thickness');
+    expect(params.destination).toBe('https://t.me/+ABC');
+  });
+
+  test('does not attach tracking to links without data-cta', () => {
+    const calls = [];
+    window.gtag = (...args) => calls.push(args);
+    load();
+
+    document.getElementById('plain').click();
+    expect(calls).toHaveLength(0);
+  });
+
+  test('falls back to dataLayer.push when gtag is unavailable', () => {
+    const mod = load();
+    const ok = mod.send('cta_click', { cta_source: 'src_web_nav' });
+    expect(ok).toBe(true);
+    expect(window.dataLayer).toContainEqual({ event: 'cta_click', cta_source: 'src_web_nav' });
+  });
+
+  test('send is a no-op (returns false) when no analytics sink exists', () => {
+    const mod = load();
+    delete window.gtag;
+    delete window.dataLayer;
+    expect(mod.send('cta_click', {})).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

**W10 (#29)** — turns the `data-cta` / `data-src` tags that the relaunch put on every CTA into GA4 events, so web → Open Deck (Telegram) hand-offs are attributable by lead source.

## Changes
- **`assets/js/cta-tracking.js`** — on click of any `[data-cta]`, emits `gtag('event','cta_click',{cta_type,cta_source,destination,page_path})`. Falls back to `dataLayer.push`; no-op if neither exists, so it never breaks a page. Loaded on every page via `head-common.html` (defer).
- **`tests/js/cta-tracking.test.js`** — 4 jsdom tests (event fires with the source tag; untagged links ignored; dataLayer fallback; no-op sink). Registered as a jest project + added to coverage.
- **`GOOGLE_ANALYTICS_SETUP.md`** — documents the event shape and how to mark `cta_click` a key event and break it down by `cta_source`.

## Funnel
Uses the same `src_<domain>_<workflow>` convention the Telegram side reads for lead attribution ([deckhand#433](https://github.com/vamseeachanta/deckhand/issues/433)) once the deep-link handler ([deckhand#432](https://github.com/vamseeachanta/deckhand/issues/432)) is live — so a click can be followed page → bot.

## Verification
`npx jest` → **150 passed** (8 suites). `npm run build` → 70 pages, script present in `dist` and referenced on every page.

Closes #29. Refs #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
