### PR TITLE
feat(design-system): W7 — extract shared components to components.css

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1,0 +1,103 @@
+/* ==========================================================================
+   A&CE Design System — shared components (W7, aceengineer-website#26)
+
+   Single source of truth for components introduced by the 2026 relaunch that
+   were previously duplicated inline across the homepage, Deckhand, Platform,
+   Proof, Solutions and Standards pages. Bundled into styles.min.css via
+   build.js (cssFiles). Page-unique one-offs may still live inline; anything
+   reused on 2+ pages belongs here.
+   ========================================================================== */
+
+:root {
+  --ace-ink: #2c3e50;          /* headings / primary ink */
+  --ace-body: #3a4654;         /* body copy */
+  --ace-muted: #6b7785;        /* eyebrows / secondary */
+  --ace-line: #e6e8eb;         /* card borders */
+  --ace-surface: #ffffff;      /* card surface */
+  --ace-surface-alt: #f8f9fa;  /* section tint */
+  --ace-chip: #eef1f4;         /* chip / pill background */
+  --ace-accent: #1f8a4c;       /* runnable / positive accent */
+  --ace-radius: 10px;
+  --ace-radius-sm: 8px;
+  --ace-shadow: 0 4px 15px rgba(0, 0, 0, 0.08);
+}
+
+/* --- eyebrow (breadcrumb-style kicker above a page H1) --------------------- */
+.section-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--ace-muted);
+  font-size: .85em;
+}
+.section-eyebrow a { color: var(--ace-muted); }
+
+/* --- chips / pills -------------------------------------------------------- */
+.domain-chip {
+  display: inline-block;
+  background: var(--ace-chip);
+  color: var(--ace-ink);
+  border-radius: 16px;
+  padding: 6px 14px;
+  margin: 5px;
+  font-size: .92em;
+  text-decoration: none;
+  transition: background .15s ease;
+}
+a.domain-chip:hover,
+a.domain-chip:focus {
+  background: #dfe5ea;
+  color: var(--ace-ink);
+  text-decoration: none;
+}
+
+/* tier flags (runnable vs advisory) */
+.tier-flag {
+  display: inline-block;
+  border-radius: 14px;
+  padding: 3px 12px;
+  font-size: .78em;
+  font-weight: 700;
+  letter-spacing: .02em;
+}
+.tier-flag.flag-a { background: #e3f3ea; color: var(--ace-accent); }
+.tier-flag.flag-b { background: var(--ace-chip); color: #52606d; }
+
+/* --- "what you can ask it to do" list ------------------------------------ */
+.ask-list {
+  list-style: none;
+  padding: 0;
+  max-width: 820px;
+  margin: 0 auto;
+}
+.ask-list li {
+  background: var(--ace-surface);
+  border: 1px solid var(--ace-line);
+  border-radius: var(--ace-radius-sm);
+  padding: 14px 18px;
+  margin-bottom: 12px;
+  color: var(--ace-body);
+}
+.ask-list li b { color: var(--ace-ink); }
+
+/* --- FAQ accordion ------------------------------------------------------- */
+.faq {
+  max-width: 820px;
+  margin: 0 auto 12px;
+  background: var(--ace-surface);
+  border: 1px solid var(--ace-line);
+  border-radius: var(--ace-radius-sm);
+  padding: 14px 18px;
+}
+.faq summary { font-weight: 600; color: var(--ace-ink); cursor: pointer; }
+.faq p { color: var(--ace-body); margin: 10px 0 0; }
+
+/* --- advisory note (escalate-only channels) ------------------------------ */
+.advisory-note {
+  background: var(--ace-chip);
+  border-left: 4px solid #52606d;
+  padding: 16px 20px;
+  border-radius: 6px;
+  max-width: 820px;
+  margin: 0 auto;
+  color: var(--ace-body);
+}

--- a/build.js
+++ b/build.js
@@ -167,7 +167,7 @@ async function bundleCSS() {
     const distCssDir = path.join(distDir, 'assets/css');
 
     // Read CSS files in correct order
-    const cssFiles = ['fonts.css', 'bootstrap-united.css', 'responsive.css', 'marketing.css'];
+    const cssFiles = ['fonts.css', 'bootstrap-united.css', 'responsive.css', 'marketing.css', 'components.css'];
     let combined = '';
     let totalOriginal = 0;
 

--- a/content/deckhand.html
+++ b/content/deckhand.html
@@ -73,7 +73,6 @@
         .guardrail-row { background:#f8f9fa; padding:56px 0; }
         .guardrail-item { padding:14px; }
         .guardrail-item .g-icon { font-size:1.6em; margin-right:8px; }
-        .domain-chip { display:inline-block; background:#eef1f4; color:#2c3e50; border-radius:16px; padding:6px 14px; margin:5px; font-size:0.92em; }
     </style>
 </head>
 <body>

--- a/content/solutions/codes-standards-maritime-law.html
+++ b/content/solutions/codes-standards-maritime-law.html
@@ -28,11 +28,7 @@ rootPath: "../"
       {"@type":"ListItem","position":2,"name":"Codes, Standards & Maritime Law","item":"https://aceengineer.com/solutions/codes-standards-maritime-law.html"}]}
     </script>
 
-    <style>
-        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
-        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
-        .advisory-note{background:#eef1f4;border-left:4px solid #52606d;padding:16px 20px;border-radius:6px;max-width:820px;margin:0 auto;color:#3a4654;}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 

--- a/content/solutions/design-cad.html
+++ b/content/solutions/design-cad.html
@@ -28,11 +28,7 @@ rootPath: "../"
       {"@type":"ListItem","position":2,"name":"Design & CAD","item":"https://aceengineer.com/solutions/design-cad.html"}]}
     </script>
 
-    <style>
-        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
-        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
-        .advisory-note{background:#eef1f4;border-left:4px solid #52606d;padding:16px 20px;border-radius:6px;max-width:820px;margin:0 auto;color:#3a4654;}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 

--- a/content/solutions/floating-marine.html
+++ b/content/solutions/floating-marine.html
@@ -48,12 +48,7 @@ rootPath: "../"
       {"@type":"ListItem","position":2,"name":"Floating & Marine Systems","item":"https://aceengineer.com/solutions/floating-marine.html"}]}
     </script>
 
-    <style>
-        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
-        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
-        .ask-list li b{color:#2c3e50;}
-        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 

--- a/content/solutions/index.html
+++ b/content/solutions/index.html
@@ -26,9 +26,6 @@ rootPath: "../"
         .sol-card { background:#fff; border:1px solid #e6e8eb; border-radius:10px; padding:26px; margin-bottom:24px; height:100%; }
         .sol-card h3 { margin-top:6px; color:#2c3e50; }
         .sol-card p { color:#4a5568; }
-        .tier-flag { display:inline-block; border-radius:14px; padding:3px 12px; font-size:.78em; font-weight:700; letter-spacing:.02em; }
-        .flag-a { background:#e3f3ea; color:#1f8a4c; }
-        .flag-b { background:#eef1f4; color:#52606d; }
         .sol-group-title { margin:36px 0 8px; }
     </style>
 </head>

--- a/content/solutions/manufacturing-fabrication.html
+++ b/content/solutions/manufacturing-fabrication.html
@@ -28,11 +28,7 @@ rootPath: "../"
       {"@type":"ListItem","position":2,"name":"Manufacturing & Fabrication","item":"https://aceengineer.com/solutions/manufacturing-fabrication.html"}]}
     </script>
 
-    <style>
-        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
-        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
-        .advisory-note{background:#eef1f4;border-left:4px solid #52606d;padding:16px 20px;border-radius:6px;max-width:820px;margin:0 auto;color:#3a4654;}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 

--- a/content/solutions/power-electrical-controls.html
+++ b/content/solutions/power-electrical-controls.html
@@ -28,11 +28,7 @@ rootPath: "../"
       {"@type":"ListItem","position":2,"name":"Power, Electrical & Controls","item":"https://aceengineer.com/solutions/power-electrical-controls.html"}]}
     </script>
 
-    <style>
-        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
-        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
-        .advisory-note{background:#eef1f4;border-left:4px solid #52606d;padding:16px 20px;border-radius:6px;max-width:820px;margin:0 auto;color:#3a4654;}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 

--- a/content/solutions/subsea-pipelines-integrity.html
+++ b/content/solutions/subsea-pipelines-integrity.html
@@ -48,12 +48,7 @@ rootPath: "../"
       {"@type":"ListItem","position":2,"name":"Subsea, Pipelines & Integrity","item":"https://aceengineer.com/solutions/subsea-pipelines-integrity.html"}]}
     </script>
 
-    <style>
-        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
-        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
-        .ask-list li b{color:#2c3e50;}
-        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 

--- a/content/solutions/wells-subsurface.html
+++ b/content/solutions/wells-subsurface.html
@@ -48,12 +48,7 @@ rootPath: "../"
       {"@type":"ListItem","position":2,"name":"Wells & Subsurface","item":"https://aceengineer.com/solutions/wells-subsurface.html"}]}
     </script>
 
-    <style>
-        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
-        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
-        .ask-list li b{color:#2c3e50;}
-        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 

--- a/content/standards/api-579-fitness-for-service.html
+++ b/content/standards/api-579-fitness-for-service.html
@@ -67,14 +67,7 @@ rootPath: "../"
 }
     </script>
 
-    <style>
-        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
-        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
-        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
-        .faq{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}
-        .faq summary{font-weight:600;color:#2c3e50;cursor:pointer;}
-        .faq p{color:#3a4654;margin:10px 0 0;}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 

--- a/content/standards/dnv-rp-b401-cathodic-protection.html
+++ b/content/standards/dnv-rp-b401-cathodic-protection.html
@@ -67,14 +67,7 @@ rootPath: "../"
 }
     </script>
 
-    <style>
-        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
-        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
-        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
-        .faq{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}
-        .faq summary{font-weight:600;color:#2c3e50;cursor:pointer;}
-        .faq p{color:#3a4654;margin:10px 0 0;}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 

--- a/content/standards/dnv-rp-c203-fatigue.html
+++ b/content/standards/dnv-rp-c203-fatigue.html
@@ -93,14 +93,7 @@ rootPath: "../"
 }
     </script>
 
-    <style>
-        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
-        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
-        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
-        .faq{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}
-        .faq summary{font-weight:600;color:#2c3e50;cursor:pointer;}
-        .faq p{color:#3a4654;margin:10px 0 0;}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 

--- a/content/standards/dnv-rp-f105-free-span-viv.html
+++ b/content/standards/dnv-rp-f105-free-span-viv.html
@@ -67,14 +67,7 @@ rootPath: "../"
 }
     </script>
 
-    <style>
-        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
-        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
-        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
-        .faq{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}
-        .faq summary{font-weight:600;color:#2c3e50;cursor:pointer;}
-        .faq p{color:#3a4654;margin:10px 0 0;}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 

--- a/content/standards/dnv-rp-f109-on-bottom-stability.html
+++ b/content/standards/dnv-rp-f109-on-bottom-stability.html
@@ -93,14 +93,7 @@ rootPath: "../"
 }
     </script>
 
-    <style>
-        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
-        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
-        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
-        .faq{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}
-        .faq summary{font-weight:600;color:#2c3e50;cursor:pointer;}
-        .faq p{color:#3a4654;margin:10px 0 0;}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 

--- a/content/standards/dnv-st-f101-wall-thickness.html
+++ b/content/standards/dnv-st-f101-wall-thickness.html
@@ -93,14 +93,7 @@ rootPath: "../"
 }
     </script>
 
-    <style>
-        .ask-list{list-style:none;padding:0;max-width:820px;margin:0 auto;}
-        .ask-list li{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}
-        .domain-chip{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}
-        .faq{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}
-        .faq summary{font-weight:600;color:#2c3e50;cursor:pointer;}
-        .faq p{color:#3a4654;margin:10px 0 0;}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 

--- a/scripts/seo/generate_standard_pages.py
+++ b/scripts/seo/generate_standard_pages.py
@@ -129,14 +129,7 @@ rootPath: "../"
 
 {schema_html}
 
-    <style>
-        .ask-list{{list-style:none;padding:0;max-width:820px;margin:0 auto;}}
-        .ask-list li{{background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;margin-bottom:12px;color:#3a4654;}}
-        .domain-chip{{display:inline-block;background:#eef1f4;color:#2c3e50;border-radius:16px;padding:6px 14px;margin:5px;font-size:.92em;}}
-        .faq{{max-width:820px;margin:0 auto 12px;background:#fff;border:1px solid #e6e8eb;border-radius:8px;padding:14px 18px;}}
-        .faq summary{{font-weight:600;color:#2c3e50;cursor:pointer;}}
-        .faq p{{color:#3a4654;margin:10px 0 0;}}
-    </style>
+    <!-- shared component styles: assets/css/components.css -->
 </head>
 <body>
 


### PR DESCRIPTION
## What

**W7 (#26)** — turns the component CSS the relaunch duplicated inline across 13 pages into a single tokenized design-system stylesheet.

## Changes
- **`assets/css/components.css`** (new) — `:root` design tokens (palette, radius, shadow) + the components reused on 2+ pages: `.domain-chip` (with link hover), `.ask-list`, `.faq`, `.advisory-note`, `.tier-flag/.flag-a/.flag-b`, `.section-eyebrow`.
- **`build.js`** — `components.css` added to the bundled `styles.min.css`.
- Removed the duplicated inline `<style>` blocks from the 3 Tier-A + 4 Tier-B Solutions pages, the Solutions hub, `deckhand.html`, and the **standards-page generator template** (regenerated). Page-unique one-offs (chat demo, deterministic strip, proof pillars, hub cards) stay inline.

## Why it's not bloat
13× duplicated inline blocks collapse into one cached rule. The CSS bundle grows ~1.6KB minified; the HTML shrinks by more, and the rule is now cached once instead of re-sent per page. PurgeCSS still runs on bootstrap; `components.css` is concatenated + minified.

## Verification
`npx jest` → 146 passed. `pytest` → 203 passed. `npm run build` → 70 pages. Confirmed all shared classes resolve in `dist/assets/css/styles.min.css` and no inline duplicates remain on the leaf pages.

Closes #26. Refs #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
