### PR TITLE
Add GitHub Pages mirror (github.io only, no domain collision, GA stripped)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,109 @@
+name: Deploy GitHub Pages mirror
+
+# GitHub Pages mirror of the static site.
+#
+# IMPORTANT — this is a MIRROR only, it must NOT collide with the live
+# Vercel deployment at aceengineer.com:
+#   * No CNAME is added/uploaded — the site lives at the github.io subpath
+#     (https://vamseeachanta.github.io/aceengineer-website). The repo-root
+#     CNAME (aceengineer.com) is for Vercel and is explicitly NOT included in
+#     the Pages artifact (build.js never copies it into dist/, and we hard-fail
+#     if one ever appears).
+#   * The Google Analytics tag (G-K31E51DQ47) is stripped from the built HTML
+#     so the mirror does not double-count traffic. Source templates are left
+#     untouched so the Vercel build keeps its GA.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'content/**'
+      - 'assets/**'
+      - 'build.js'
+      - 'package.json'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent Pages deployment; let in-progress runs finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build static site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Strip Google Analytics from the mirror (no double-counting)
+        run: |
+          set -euo pipefail
+          if grep -rl 'G-K31E51DQ47' dist >/dev/null 2>&1; then
+            # Neutralize the measurement id everywhere it appears in built HTML.
+            grep -rl 'G-K31E51DQ47' dist \
+              | grep -E '\.html$' \
+              | xargs sed -i "s/G-K31E51DQ47/G-PAGES-MIRROR-DISABLED/g"
+            echo "Stripped GA measurement id from built HTML."
+          else
+            echo "No GA measurement id found in dist/ — nothing to strip."
+          fi
+          # Hard fail if the live id somehow survived.
+          if grep -rq 'G-K31E51DQ47' dist; then
+            echo "ERROR: GA tag G-K31E51DQ47 still present in dist/ after strip." >&2
+            exit 1
+          fi
+
+      - name: Ensure Vercel CNAME does not leak into the Pages artifact
+        run: |
+          set -euo pipefail
+          # build.js does not copy the repo-root CNAME into dist/, but guard anyway:
+          # an aceengineer.com CNAME in the Pages deploy would hijack the live domain.
+          if [ -f dist/CNAME ]; then
+            echo "Removing stray CNAME from dist/ (must not claim the Vercel domain)."
+            rm -f dist/CNAME
+          fi
+          if [ -f dist/CNAME ]; then
+            echo "ERROR: CNAME still present in dist/." >&2
+            exit 1
+          fi
+          echo "Confirmed: no CNAME in the Pages artifact."
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Closes #40 (CI build + deploy portion; tools-gallery content items remain follow-on).

## What this adds
A new `.github/workflows/pages.yml` that deploys a **GitHub Pages mirror** of the static site, built the same way Vercel builds it (`npm ci` + `npm run build` → `dist/`, per `build.js`).

## No domain collision with the live Vercel site
- This is a **mirror only**, served at the github.io subpath: `https://vamseeachanta.github.io/aceengineer-website`.
- **No CNAME is added or uploaded.** The repo-root `CNAME` (`aceengineer.com`) is for Vercel; `build.js` does not copy it into `dist/`, and the workflow **hard-fails** if a CNAME ever leaks into the Pages artifact — so the mirror can never claim `aceengineer.com`.

## GA decision: stripped from the mirror
- A post-build step removes the Google Analytics measurement id `G-K31E51DQ47` from the built HTML in `dist/` before upload, so the mirror does **not** double-count traffic.
- **Source templates are untouched** — the Vercel build keeps its GA tag.
- The step hard-fails if the id survives the strip.

## Workflow details
- `actions/setup-node` @ Node 20 (matches existing `ci.yml`), `npm ci`, `npm run build`.
- Uploads `dist/` via `upload-pages-artifact`, deploys via `deploy-pages`.
- `permissions`: `contents:read`, `pages:write`, `id-token:write`.
- `concurrency: pages`; triggers on push to `main` (paths `content/**`, `assets/**`, `build.js`, `package.json`, `.github/workflows/pages.yml`) + `workflow_dispatch`.

## Local verification
- `npm ci` + `npm run build` succeeded (89 pages built).
- `dist/index.html` present; 89 HTML files carried the GA tag → all stripped to **0** by the strip step.
- No `CNAME` in `dist/` (confirmed); `dist/` stays gitignored.

## One-time human step
Enable Pages: **Settings → Pages → Source = GitHub Actions**.

## Data note
Content is BSEE / marine-safety public-domain-derived — no NDA/client data.