### PR TITLE
feat(web): API-first reframe — Deckhand = the API for real-world work

### DIFF
--- a/content/api-catalog.html
+++ b/content/api-catalog.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="The Deckhand API-path catalog: live engineering workflows you can call, with required inputs, deliverables, and example report URLs — plus the domains being onboarded. Every claim maps to a real workflow row.">
+    <meta name="keywords" content="Deckhand API catalog, engineering API paths, domain-workflows, mooring screening, wall thickness screening, standards-traceable report, deterministic engineering">
+
+    <meta property="og:title" content="API-path catalog — Deckhand | AceEngineer">
+    <meta property="og:description" content="Live engineering API paths you can call today — required inputs, deliverables, example report URLs — plus the roadmap of domains being onboarded.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/api-catalog.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="API-path catalog — Deckhand | AceEngineer">
+    <meta name="twitter:description" content="Live engineering API paths, required inputs, deliverables, and example report URLs.">
+
+    <title>API-path catalog — Deckhand | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <style>
+        .catalog-table { width:100%; border-collapse:collapse; margin:8px 0 16px; background:#fff; }
+        .catalog-table th, .catalog-table td { text-align:left; padding:12px 12px; border-bottom:1px solid #eceff2; vertical-align:top; font-size:0.93em; }
+        .catalog-table th { color:#2c3e50; background:#f8f9fa; }
+        .catalog-table code { background:rgba(0,0,0,0.06); padding:1px 5px; border-radius:4px; font-size:0.92em; }
+        .catalog-table .inputs code { display:inline-block; margin:1px 2px; }
+        .table-wrap { overflow-x:auto; border:1px solid #e6e8eb; border-radius:10px; }
+        .status-badge { display:inline-block; padding:2px 8px; border-radius:10px; font-size:0.8em; font-weight:700; }
+        .status-live { background:#e3f4ea; color:#1f8a4c; }
+        .status-onboarding { background:#fdf3e0; color:#b3791a; }
+        .catalog-note { background:#f8f9fa; border-left:4px solid #2c3e50; padding:14px 18px; margin:18px 0; color:#52606d; }
+        .roadmap-row { background:#f8f9fa; padding:56px 0; }
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:36px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1 text-center">
+                    <h1 class="hero-title">The API-path catalog</h1>
+                    <p class="hero-subtitle">Every workflow is an API path you can call: <code>POST /api/run</code> &rarr; a standards-traceable report URL. Below are the paths that are <strong>live today</strong>, and the domains being <strong>onboarded</strong>. Nothing here is claimed before it has a firable workflow row.</p>
+                    <div class="hero-cta">
+                        <a href="deckhand-api.html" class="btn btn-default btn-lg">How the API works</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Live paths -->
+    <section style="padding:48px 0;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-11 col-md-offset-1">
+                    <h2 class="section-title">Live paths <span class="status-badge status-live">LIVE</span></h2>
+                    <p class="section-subtitle" style="text-align:left;">Runnable today on the free Open Deck tier. DNV-traceable, deterministic, with report URLs published to the public gallery.</p>
+
+                    <div class="table-wrap">
+                        <table class="catalog-table">
+                            <thead>
+                                <tr>
+                                    <th>ref (workflow path)</th>
+                                    <th>domain / subdomain</th>
+                                    <th>required inputs</th>
+                                    <th>deliverable</th>
+                                    <th>example report URL</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>subsea_pipeline_wall_thickness_screen</code><br><span style="color:#6b7785; font-size:0.9em;">engine: digitalmodel wall-thickness quickcheck</span></td>
+                                    <td><code>subsea-pipelines-integrity</code> / <code>pipeline</code></td>
+                                    <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>design_pressure_rating</code> <code>buckle_arrestors</code> <code>data_available</code> <code>deadline</code></td>
+                                    <td>Summary-first reply + standards-traceable HTML report package in a dated sandbox run dir (DNV-ST-F101).</td>
+                                    <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">deckhand-sandbox gallery</a> &rarr; <code>.../report.html</code></td>
+                                </tr>
+                                <tr>
+                                    <td><code>floating_marine_mooring_screen</code><br><span style="color:#6b7785; font-size:0.9em;">engine: digitalmodel mooring analysis</span></td>
+                                    <td><code>floating-marine</code> / <code>mooring</code></td>
+                                    <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>line_material</code> <code>data_available</code> <code>deadline</code></td>
+                                    <td>Summary-first reply + HTML report package in a dated sandbox run dir. Metallic-line screen; non-metallic escalates honestly.</td>
+                                    <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">deckhand-sandbox gallery</a> &rarr; <code>.../report.html</code></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="catalog-note">
+                        <code>ref</code> is the workflow-row key in the source-of-truth catalog
+                        <code>deckhand/config/deckhand/routing/domain-workflows.yaml</code>. The two live paths run on the
+                        open-source <strong>digitalmodel</strong> engine; required inputs are the path's clarification keys
+                        (branch-first inputs like <code>buckle_arrestors</code> / <code>line_material</code> are asked, never guessed).
+                        Each call returns a <code>report_url</code> on the
+                        <a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">public deckhand-sandbox gallery</a>.
+                    </div>
+
+                    <p style="color:#6b7785;">
+                        Two further utility paths back the same surface: an Open Deck <em>public router</em> that directs a
+                        question to the right domain channel, and isolated <em>private-scope delivery</em> paths for
+                        client-confidential work (reports promoted to a client wiki, never the public gallery).
+                        <a href="contact.html">Talk to us</a> about private scopes.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Roadmap / onboarding -->
+    <section class="roadmap-row">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-11 col-md-offset-1">
+                    <h2 class="section-title">Roadmap &mdash; API paths onboarding <span class="status-badge status-onboarding">ONBOARDING</span></h2>
+                    <p class="section-subtitle" style="text-align:left;">These domains are bound and routable but do <strong>not</strong> yet have a runnable public workflow row. They escalate to a human today &mdash; they are <strong>not</strong> shipped capability. Listed here for honesty, not as a claim.</p>
+
+                    <div class="table-wrap">
+                        <table class="catalog-table">
+                            <thead>
+                                <tr>
+                                    <th>domain</th>
+                                    <th>subdomains (planned)</th>
+                                    <th>status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr><td><code>wells-subsurface</code></td><td><code>wells</code>, <code>field-development</code></td><td>Onboarding &mdash; public workflow row owed</td></tr>
+                                <tr><td><code>electrical</code></td><td><code>electrical</code></td><td>Onboarding &mdash; bound, escalate-only</td></tr>
+                                <tr><td><code>cad</code></td><td><code>cad</code></td><td>Onboarding &mdash; bound, escalate-only</td></tr>
+                                <tr><td><code>manufacturing</code></td><td><code>manufacturing</code></td><td>Onboarding &mdash; bound, escalate-only</td></tr>
+                                <tr><td><code>codes-standards-maritime-law</code></td><td>&mdash;</td><td>Onboarding &mdash; bound, no workflow row yet</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="catalog-note">
+                        A domain graduates from <strong>onboarding</strong> to <strong>live</strong> only when it has a firable
+                        workflow row in <code>domain-workflows.yaml</code> <em>and</em> a published report URL. Until then,
+                        a call to one of these paths escalates to a human &mdash; it never fabricates an answer.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h2>Call a live path &mdash; free</h2>
+                    <p>Open Deck is the free chat client of the API. Bring a real subsea-pipeline or mooring question and watch a path run, traced to the standard, on open repos.</p>
+                    <!-- OPEN_DECK_CTA -->
+                    <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_catalog_footer">Try Open Deck on Telegram</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/deckhand-api.html
+++ b/content/deckhand-api.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Deckhand is the API for real-world work. Every engineering workflow is an API path: POST /api/run returns a standards-traceable HTML report URL, deterministically. Chat is one client of the API.">
+    <meta name="keywords" content="engineering API, Deckhand API, /api/run, standards-traceable report URL, deterministic engineering, offshore engineering automation, digitalmodel, report_url">
+
+    <meta property="og:title" content="Deckhand — the API for real-world work | AceEngineer">
+    <meta property="og:description" content="Every engineering workflow is an API path. One call returns a standards-traceable HTML report URL — same input, same output. Chat is one client of the API.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/deckhand-api.html">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Deckhand — the API for real-world work | AceEngineer">
+    <meta name="twitter:description" content="One API call → a standards-traceable report URL. Deterministic, clause-traced. Chat is one client.">
+
+    <title>The API — Deckhand, the API for real-world work | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+
+    <!-- SoftwareApplication schema -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Deckhand API",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Web, Telegram, WhatsApp",
+        "description": "The API for real-world engineering work. Every workflow is an API path; POST /api/run returns a standards-traceable HTML report URL, deterministically. Built on the open-source digitalmodel library.",
+        "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+            "name": "Open Deck — free tier"
+        },
+        "publisher": { "@id": "https://aceengineer.com/#organization" }
+    }
+    </script>
+
+    <style>
+        .api-codeblock {
+            background:#0f1722; color:#d7e2ef; border-radius:10px;
+            padding:22px 24px; overflow-x:auto; font-size:0.92em; line-height:1.55;
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            margin:0 0 18px;
+        }
+        .api-codeblock .k { color:#7fb0ff; }
+        .api-codeblock .s { color:#a7e0a0; }
+        .api-codeblock .c { color:#6b7785; }
+        .api-codeblock .u { color:#ffd28a; }
+        .contract-card { background:#fff; border:1px solid #e6e8eb; border-radius:10px; padding:26px; margin-bottom:24px; height:100%; }
+        .contract-card h3 { margin-top:0; color:#2c3e50; }
+        .client-row { background:#f8f9fa; padding:56px 0; }
+        .client-item { padding:14px; }
+        .client-item .c-icon { font-size:1.5em; margin-right:8px; }
+        .field-table { width:100%; border-collapse:collapse; margin-top:8px; }
+        .field-table th, .field-table td { text-align:left; padding:8px 10px; border-bottom:1px solid #eceff2; vertical-align:top; }
+        .field-table th { color:#2c3e50; }
+        .field-table code { background:rgba(0,0,0,0.06); padding:1px 5px; border-radius:4px; }
+    </style>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:40px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-9 col-md-offset-1 text-center">
+                    <h1 class="hero-title">The API for real-world work</h1>
+                    <p class="hero-subtitle">Every Deckhand workflow is an API path. You make <strong>one call</strong> and get back a <strong>standards-traceable HTML report URL</strong> &mdash; same input, same output, every time. Chat is one client of that call, not the product.</p>
+                    <p class="hero-identity">Built on the open-source <strong>digitalmodel</strong> library &mdash; 7,000+ standard-mapped functions, 42 standards implemented.</p>
+                    <div class="hero-cta">
+                        <a href="api-catalog.html" class="btn btn-primary btn-lg">Browse the API-path catalog</a>
+                        <a href="proof.html" class="btn btn-default btn-lg">See the proof</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- The contract -->
+    <section style="padding:64px 0;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">One contract, every workflow</h2>
+                    <p class="section-subtitle text-center">You don't learn a new interface per discipline. You learn one call. The <code>ref</code> selects the workflow; the report URL is the deliverable.</p>
+
+                    <div class="row" style="margin-top:24px;">
+                        <div class="col-md-6">
+                            <h3 style="color:#2c3e50;">Request</h3>
+                            <div class="api-codeblock"><span class="k">POST</span> /api/run
+{
+  <span class="k">"ref"</span>: <span class="s">"digitalmodel:mooring-fatigue@2"</span>,
+  <span class="k">"domain"</span>: <span class="s">"floating-marine"</span>,
+  <span class="k">"subdomain"</span>: <span class="s">"mooring"</span>,
+  <span class="k">"inputs"</span>: {
+    <span class="k">"objective"</span>: <span class="s">"screen mooring fatigue"</span>,
+    <span class="k">"configuration"</span>: <span class="s">"..."</span>,
+    <span class="k">"environment"</span>: <span class="s">"..."</span>,
+    <span class="k">"line_material"</span>: <span class="s">"chain"</span>
+  }
+}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <h3 style="color:#2c3e50;">Response</h3>
+                            <div class="api-codeblock">{
+  <span class="k">"status"</span>: <span class="s">"PASS"</span>,
+  <span class="k">"report_url"</span>: <span class="u">"https://vamseeachanta.github.io/
+     deckhand-sandbox/.../report.html"</span>,
+  <span class="k">"artifacts"</span>: [<span class="s">"summary.json"</span>, <span class="s">"inputs.yml"</span>, <span class="s">"..."</span>],
+  <span class="k">"coordinate"</span>: {
+    <span class="k">"repo"</span>: <span class="s">"digitalmodel"</span>,
+    <span class="k">"domain"</span>: <span class="s">"floating-marine"</span>,
+    <span class="k">"subdomain"</span>: <span class="s">"mooring"</span>,
+    <span class="k">"resolved_version"</span>: <span class="s">"2"</span>
+  },
+  <span class="k">"duration_s"</span>: <span class="u">12.4</span>
+}</div>
+                        </div>
+                    </div>
+
+                    <p class="text-center" style="margin-top:8px; color:#6b7785;">
+                        The <code>report_url</code> is the work itself &mdash; a self-contained, standards-traceable HTML report you can open, archive, and hand to a checker. Browse real reports on the <a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">public deckhand-sandbox gallery</a>.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- What every response carries -->
+    <section style="padding:8px 0 56px;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">What every response carries</h2>
+                    <div class="row">
+                        <div class="col-md-4"><div class="contract-card"><h3>A report URL</h3><p><code>report_url</code> &mdash; a standards-traceable HTML report with the number, the governing clause, and the assumption ledger. Not a chat blurb you have to trust.</p></div></div>
+                        <div class="col-md-4"><div class="contract-card"><h3>A coordinate</h3><p><code>coordinate</code> pins the exact repo, domain, subdomain, workflow, and resolved version that produced the result &mdash; so the same call is reproducible later.</p></div></div>
+                        <div class="col-md-4"><div class="contract-card"><h3>A status + artifacts</h3><p><code>status</code> (PASS / FAIL / escalate) and <code>artifacts</code> (inputs, summary, plots). Out-of-scope or unbuilt paths return an honest 404, never a fabricated answer.</p></div></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Chat is one client -->
+    <section class="client-row">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">Chat is one client of the API</h2>
+                    <p class="section-subtitle text-center">The same <code>/api/run</code> call is reachable from anywhere. The chat bot is a thin front-end &mdash; not a different product.</p>
+                    <div class="row">
+                        <div class="col-md-6"><div class="client-item"><span class="c-icon">&#128172;</span><strong>Chat (Telegram / WhatsApp).</strong> Ask in plain language; the front-end resolves your message to a <code>ref</code> + inputs and calls the path for you.</div></div>
+                        <div class="col-md-6"><div class="client-item"><span class="c-icon">&#128187;</span><strong>Web button.</strong> Our calculators and "try it" buttons are the same call from a webpage.</div></div>
+                        <div class="col-md-6"><div class="client-item"><span class="c-icon">&#9201;</span><strong>Cron / automation.</strong> Schedule a path to run on new data and post the report URL.</div></div>
+                        <div class="col-md-6"><div class="client-item"><span class="c-icon">&#128279;</span><strong>Partner systems.</strong> Any system that can POST JSON can fire a path and consume the report URL.</div></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Deterministic -->
+    <section style="padding:64px 0;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1">
+                    <h2 class="section-title text-center">Deterministic by contract</h2>
+                    <p class="section-subtitle text-center">The same call returns the same result &mdash; because the compute runs on the digitalmodel engine, not free-form model output.</p>
+                    <table class="field-table">
+                        <thead><tr><th>Field</th><th>Meaning</th></tr></thead>
+                        <tbody>
+                            <tr><td><code>ref</code></td><td>The workflow path to run &mdash; a row in the API-path catalog (<code>domain-workflows.yaml</code>), optionally version-pinned.</td></tr>
+                            <tr><td><code>domain</code> / <code>subdomain</code></td><td>The knowledge-pack coordinate that scopes the run (e.g. <code>floating-marine</code> / <code>mooring</code>).</td></tr>
+                            <tr><td><code>inputs</code></td><td>The required clarification keys for that path. Missing branch-first inputs are asked, never guessed.</td></tr>
+                            <tr><td><code>status</code></td><td><code>PASS</code> / <code>FAIL</code> / escalate. A path with no runnable workflow escalates honestly rather than inventing a number.</td></tr>
+                            <tr><td><code>report_url</code></td><td>The standards-traceable HTML report &mdash; the deliverable.</td></tr>
+                            <tr><td><code>coordinate</code></td><td>The resolved repo / domain / subdomain / workflow / version &mdash; the reproducibility receipt.</td></tr>
+                            <tr><td><code>duration_s</code></td><td>Wall-clock run time of the call.</td></tr>
+                        </tbody>
+                    </table>
+                    <p style="margin-top:18px; color:#6b7785;">Reproducibility is enforced below the model: 680 byte-identical golden cases, PR-only changes, fine-grained credentials per scope. See <a href="deckhand.html">how the guardrails work</a>.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Honesty / scope strip -->
+    <section style="padding:48px 0; background:#f8f9fa;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-10 col-md-offset-1 text-center">
+                    <h2 class="section-title">Live today &mdash; and what's onboarding</h2>
+                    <p class="section-subtitle">We only call a domain "live" when it has a firable workflow row and a published report URL.</p>
+                    <p style="max-width:760px; margin:0 auto;">
+                        <strong>Live:</strong> subsea-pipeline and floating-marine (mooring) screening &mdash; DNV-traceable, deterministic, with report URLs on the public gallery.<br>
+                        <strong>Onboarding (roadmap):</strong> CAD/CAM, manufacturing, electrical, wells &amp; subsurface and more are API paths being onboarded &mdash; not shipped capability yet.
+                    </p>
+                    <p style="margin-top:24px;"><a href="api-catalog.html" class="btn btn-info">See the full API-path catalog</a></p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="cta-section">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2 text-center">
+                    <h2>Call a path &mdash; free</h2>
+                    <p>Open Deck is the free chat client of the API: bring a real offshore / oil &amp; gas question and watch a path run, traced to the standard, on open repos.</p>
+                    <!-- OPEN_DECK_CTA -->
+                    <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_api_footer">Try Open Deck on Telegram</a>
+                    <p class="cta-note">For private, client-confidential work we run isolated scopes &mdash; <a href="contact.html">talk to us</a>.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/index.html
+++ b/content/index.html
@@ -3,22 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="The AI engineering firm for offshore energy. Deckhand drives real analysis, documentation, and pull requests from chat — under hard, auditable guardrails. Standards-traceable, deterministic deliverables.">
-    <meta name="keywords" content="AI engineering, offshore energy AI, OrcaFlex automation, fatigue analysis, mooring design, riser analysis, subsea engineering, deterministic engineering, standards-traceable calculations, engineering AI agent">
+    <meta name="description" content="Deckhand — the API for real-world work. Every engineering workflow is an API path: one call returns a standards-traceable HTML report URL, same input same output. Chat is one client. Offshore live; more domains onboarding.">
+    <meta name="keywords" content="engineering API, Deckhand API, standards-traceable report, deterministic engineering, OrcaFlex automation, fatigue analysis, mooring design, subsea engineering, offshore energy AI, digitalmodel">
 
     <!-- Open Graph meta tags -->
-    <meta property="og:title" content="AceEngineer — The AI Engineering Firm for Offshore Energy">
-    <meta property="og:description" content="Deckhand drives real engineering work from a chat message — analysis, documentation, issues and pull requests — executed by an AI agent under hard, auditable guardrails. Standards-traceable. Deterministic.">
+    <meta property="og:title" content="Deckhand — the API for real-world work | AceEngineer">
+    <meta property="og:description" content="Every engineering workflow is an API path. One call returns a standards-traceable HTML report URL — same input, same output, every time. Chat is one client of the API.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://aceengineer.com">
     <meta property="og:site_name" content="Analytical & Computational Engineering">
 
     <!-- Twitter Card meta tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="AceEngineer — The AI Engineering Firm for Offshore Energy">
-    <meta name="twitter:description" content="An AI agent that does real offshore engineering — and shows its work. Standards-traceable, deterministic deliverables.">
+    <meta name="twitter:title" content="Deckhand — the API for real-world work | AceEngineer">
+    <meta name="twitter:description" content="One API call → a standards-traceable report URL. Deterministic, clause-traced offshore engineering. Chat is one client.">
 
-    <title>The AI Engineering Firm for Offshore Energy | AceEngineer</title>
+    <title>Deckhand — the API for real-world work | AceEngineer</title>
 
     <include src="partials/head-common.html"></include>
 
@@ -159,13 +159,14 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-8 col-md-offset-2 text-center">
-                    <h1 class="hero-title">The AI engineering firm<br>for offshore energy.</h1>
-                    <p class="hero-subtitle">Deckhand drives real engineering work &mdash; analysis, documentation, issues and pull requests &mdash; straight from a chat message, executed by an AI agent under hard, auditable guardrails. Standards-traceable. Deterministic. It shows its work.</p>
+                    <h1 class="hero-title">Deckhand &mdash; the API<br>for real-world work.</h1>
+                    <p class="hero-subtitle">Every engineering workflow is an API path. One call returns a standards-traceable HTML report URL &mdash; same input, same output, every time. Chat (Telegram / WhatsApp) is one client of the API, not the headline. Offshore is live today; more domains are onboarding.</p>
                     <p class="hero-identity">Built on the open-source <strong>digitalmodel</strong> library &mdash; 7,000+ standard-mapped functions, 42 standards implemented, ~30 engineering disciplines.</p>
                     <div class="hero-cta">
+                        <a href="deckhand-api.html" class="btn btn-primary btn-lg">See the API</a>
+                        <a href="api-catalog.html" class="btn btn-default btn-lg">Browse API paths</a>
                         <!-- OPEN_DECK_CTA: live group invite. Swap to https://t.me/the_deckhand_bot?start=src_web_home_hero once deckhand#432 handler is live. -->
-                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_home_hero">Try Open Deck &mdash; free</a>
-                        <a href="proof.html" class="btn btn-default btn-lg">See the proof</a>
+                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-default btn-lg" data-cta="open-deck" data-src="src_web_home_hero">Try Open Deck &mdash; free</a>
                     </div>
                 </div>
             </div>
@@ -177,15 +178,16 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-5">
-                    <h2 class="section-title">Meet Deckhand</h2>
-                    <p class="section-subtitle" style="text-align:left;">Ask an engineering question in plain language. Deckhand runs the real calculation &mdash; against the right standard &mdash; and returns a deliverable with every assumption traced. Changes to code or docs arrive as pull requests, never silent edits.</p>
+                    <h2 class="section-title">Chat is one client of the API</h2>
+                    <p class="section-subtitle" style="text-align:left;">Under the hood, every Deckhand surface calls one API path: <code>POST /api/run</code> &rarr; a standards-traceable report URL. The chat below is just one client of that call &mdash; the same path runs from a webpage button or a cron job. Ask in plain language; Deckhand runs the real calculation against the right standard and returns a deliverable with every assumption traced. Changes to code or docs arrive as pull requests, never silent edits.</p>
                     <ul>
-                        <li><strong>AI that shows its work</strong> &mdash; assumptions, standards, and scope limits on every result.</li>
+                        <li><strong>One call, one report URL</strong> &mdash; every workflow is an API path that returns a standards-traceable HTML report.</li>
                         <li><strong>Deterministic</strong> &mdash; same input, same output, audit-ready.</li>
                         <li><strong>Governed</strong> &mdash; PR-only, no force-push or deletes; everything out of scope returns 404.</li>
                     </ul>
                     <p>
-                        <a href="deckhand.html" class="btn btn-info">How Deckhand works</a>
+                        <a href="deckhand-api.html" class="btn btn-info">See the API</a>
+                        <a href="deckhand.html" class="btn btn-default">How Deckhand works</a>
                         <!-- OPEN_DECK_CTA -->
                         <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-default" data-cta="open-deck" data-src="src_web_home_meet">Try it on Telegram</a>
                     </p>

--- a/content/index.html
+++ b/content/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Deckhand — the API for real-world work. Every engineering workflow is an API path: one call returns a standards-traceable HTML report URL, same input same output. Chat is one client. Offshore live; more domains onboarding.">
-    <meta name="keywords" content="engineering API, Deckhand API, standards-traceable report, deterministic engineering, OrcaFlex automation, fatigue analysis, mooring design, subsea engineering, offshore energy AI, digitalmodel">
+    <meta name="keywords" content="engineering API, Deckhand API, standards-traceable report, deterministic engineering, OrcaFlex automation, fatigue analysis, mooring design, subsea engineering, industry codes and standards, digitalmodel">
 
     <!-- Open Graph meta tags -->
     <meta property="og:title" content="Deckhand — the API for real-world work | AceEngineer">
@@ -32,7 +32,7 @@
         "alternateName": "AceEngineer",
         "url": "https://aceengineer.com",
         "logo": "https://aceengineer.com/assets/img/logo.png",
-        "description": "The AI engineering firm for offshore energy. Deckhand, an AI engineering agent, runs standards-traceable, deterministic analysis for subsea, mooring, fatigue, hydrodynamics, and field development — built on the open-source digitalmodel library.",
+        "description": "The deterministic engineering-workflow firm for offshore energy. Deckhand runs standards-traceable, reproducible analysis — real programming code mapped to industry codes and standards — for subsea, mooring, fatigue, hydrodynamics, and field development, built on the open-source digitalmodel library.",
         "foundingDate": "2010",
         "areaServed": ["United States", "United Kingdom", "Norway", "Brazil"],
         "sameAs": [
@@ -52,7 +52,7 @@
             "availableLanguage": "English"
         },
         "knowsAbout": [
-            "AI engineering agents",
+            "Deterministic engineering workflows",
             "OrcaFlex automation",
             "OrcaWave and AQWA hydrodynamic analysis",
             "Fatigue analysis",
@@ -70,21 +70,21 @@
     {
         "@context": "https://schema.org",
         "@type": "Service",
-        "serviceType": "AI Engineering Services for Offshore Energy",
+        "serviceType": "Deterministic Engineering Workflow Services for Offshore Energy",
         "provider": {
             "@id": "https://aceengineer.com/#organization"
         },
         "areaServed": "Worldwide",
         "hasOfferCatalog": {
             "@type": "OfferCatalog",
-            "name": "AI Engineering Solutions",
+            "name": "Engineering Workflow Solutions",
             "itemListElement": [
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "Deckhand — AI Engineering Agent",
-                        "description": "Drive real engineering work — analysis, documentation, issues and pull requests — from a chat message, executed by an AI agent under hard, auditable guardrails."
+                        "name": "Deckhand — Engineering Workflow API",
+                        "description": "Drive real engineering work — analysis, documentation, issues and pull requests — with one API call (chat is one client), executed by deterministic workflows: real programming code mapped to industry codes and standards, under hard, auditable guardrails."
                     }
                 },
                 {
@@ -211,7 +211,7 @@
             <div class="row">
                 <div class="col-md-10 col-md-offset-1 text-center">
                     <h2 class="section-title" style="color:#fff;">Deterministic by design</h2>
-                    <p class="section-subtitle" style="color:rgba(255,255,255,0.8);">The thing practising engineers actually need from AI: the same answer every time, traceable to a clause, defensible in review.</p>
+                    <p class="section-subtitle" style="color:rgba(255,255,255,0.8);">The thing practising engineers actually need: the same answer every time, traceable to a clause, defensible in review — deterministic workflows built on real code and industry codes and standards.</p>
                     <div class="row" style="margin-top:24px;">
                         <div class="col-md-4 pillar">
                             <div class="pill-emoji">&#9878;</div>
@@ -226,7 +226,7 @@
                         <div class="col-md-4 pillar">
                             <div class="pill-emoji">&#128221;</div>
                             <h3>Assumption ledger</h3>
-                            <p>It states what it assumed and where the scope ends &mdash; AI that shows its work.</p>
+                            <p>It states what it assumed and where the scope ends &mdash; a workflow that shows its work.</p>
                         </div>
                     </div>
                 </div>
@@ -289,7 +289,7 @@
                         <div class="col-md-4">
                             <div class="pain-card">
                                 <div class="pain-icon">&#129302;</div>
-                                <h3>AI You Can't Defend</h3>
+                                <h3>Black-Box Answers You Can't Defend</h3>
                                 <p>Generic chatbots give a different answer every time and cite nothing. You can't put that in a calculation note or hand it to a checker.</p>
                             </div>
                         </div>
@@ -442,7 +442,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-8 col-md-offset-2 text-center">
-                    <h2>Put an AI engineer to work &mdash; free</h2>
+                    <h2>Put a standards-traceable workflow to work &mdash; free</h2>
                     <p>Open Deck is the free tier: bring a real offshore / oil &amp; gas question and watch Deckhand run it, traced to the standard, on open repos.</p>
                     <!-- OPEN_DECK_CTA -->
                     <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_home_footer">Join Open Deck on Telegram</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -16,6 +16,22 @@
     <priority>0.9</priority>
   </url>
 
+  <!-- Deckhand API (the contract) -->
+  <url>
+    <loc>https://www.aceengineer.com/deckhand-api.html</loc>
+    <lastmod>2026-06-28</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <!-- API-path catalog -->
+  <url>
+    <loc>https://www.aceengineer.com/api-catalog.html</loc>
+    <lastmod>2026-06-28</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
   <!-- Platform -->
   <url>
     <loc>https://www.aceengineer.com/platform.html</loc>


### PR DESCRIPTION
## What this does (WS2 of the cross-repo API-first reposition)

Repositions aceengineer.com from **chat-message-centric** to **Deckhand-API-call-centric**. Drafts only — **HITL: not deployed.**

### Homepage hero reframe (`content/index.html`)
- **Old:** *"The AI engineering firm for offshore energy."* — *"Deckhand drives real engineering work … straight from a chat message …"*
- **New:** *"Deckhand — the API for real-world work."* — *"Every engineering workflow is an API path. One call returns a standards-traceable HTML report URL — same input, same output, every time. Chat (Telegram / WhatsApp) is one client of the API … Offshore is live today; more domains are onboarding."*
- digitalmodel credibility line kept (7,000+ standard-mapped functions, 42 standards).
- Title / meta description / OG / Twitter tags updated to the API-first frame.
- "Meet Deckhand" section reframed → **"Chat is one client of the API"** (teaches `POST /api/run` → report URL; the chat demo is retained as a *client*).
- CTAs: **See the API** / **Browse API paths** / **Try Open Deck — free**.
- Changes are surgical and reversible.

### New page — `content/deckhand-api.html` (the API product page)
- The unifying contract: `POST /api/run { ref, domain, subdomain, inputs }` → `{ status, report_url, artifacts, coordinate, duration_s }`, with the `report_url` shape (`…/deckhand-sandbox/.../report.html`).
- "Chat is one client" (chat / web button / cron / partner systems).
- Determinism + field reference; honest live-vs-onboarding strip; links to the catalog.

### New page — `content/api-catalog.html` (the API-path catalog)
- **Live** table built from real rows in `deckhand/config/deckhand/routing/domain-workflows.yaml`:
  `subsea_pipeline_wall_thickness_screen` (subsea-pipelines-integrity / pipeline) and `floating_marine_mooring_screen` (floating-marine / mooring) — each with `ref`, domain/subdomain, required inputs, deliverable, and an example report URL (public deckhand-sandbox gallery).
- Separate clearly-labeled **Roadmap (onboarding)** section for bound-but-uncovered domains: `wells-subsurface`, `electrical`, `cad`, `manufacturing`, `codes-standards-maritime-law`.
- No fabricated paths.

### Honesty rule (critical)
Offshore (mooring & subsea-pipeline screening — DNV-traceable, deterministic) is the **live proof**. CAD/CAM, manufacturing, electrical, wells are described **only** as "API paths onboarding," never as shipped capability. Every claim maps to a real workflow row or a published report URL.

### Build status
- `node build.js` → **pass** (91 pages built, all `<include>` partials resolved, both new pages render into `dist/`).
- Node build test suite → **20/20 pass**.
- New pages registered in `sitemap.xml`.
- `dist/` not committed (build output, gitignored). **Not deployed to Vercel.**

Refs aceengineer-strategy#94. Part of website epic #19 (WS2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)