### PR TITLE
docs(readme): Deckhand API banner + drop AI-native descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # AceEngineer Website
 
+> **Deckhand — the API for real-world work.** This site is the front door to the Deckhand API:
+> every engineering workflow is an **API path**; one call (`POST /api/run`) returns a
+> **standards-traceable HTML report URL** — deterministic, built on real code mapped to industry
+> codes and standards. Live API paths → https://aceengineer.com/api-catalog.html
+
 **Live Site:** https://aceengineer.com/
 
-A static marketing and technical showcase website for AceEngineer - an AI-native engineering consulting platform.
+A static marketing and technical showcase website for AceEngineer — the deterministic engineering-workflow firm for offshore energy (built on real code + industry codes and standards).
 
 ## Quick Links
 


### PR DESCRIPTION
WS4 of the API-centric reposition (workspace-hub#3300, aceengineer-strategy#94). Adds the Deckhand-API banner to the README top and replaces the "AI-native engineering consulting platform" descriptor with "deterministic engineering-workflow firm … built on real code + industry codes and standards."