### PR TITLE
content(web): reconcile api-catalog with the canonical Deckhand catalog + machine-readable links

### DIFF
--- a/content/api-catalog.html
+++ b/content/api-catalog.html
@@ -146,6 +146,36 @@
         </div>
     </section>
 
+    <!-- Machine-readable -->
+    <section style="padding:48px 0;">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-11 col-md-offset-1">
+                    <h2 class="section-title">Machine-readable</h2>
+                    <p class="section-subtitle" style="text-align:left;">The same catalog, for tooling. Both files are generated from the Deckhand workflow catalog (<code>domain-workflows.yaml</code>) &mdash; <strong>same input, same output</strong> as the tables above, so the reference can never drift from the routable paths.</p>
+
+                    <ul style="line-height:2; font-size:1.02em;">
+                        <li>
+                            <a href="https://vamseeachanta.github.io/deckhand-sandbox/api/api-catalog.json" target="_blank" rel="noopener"><strong>Catalog JSON</strong></a>
+                            &mdash; <code>api-catalog.json</code>: the public-safe path catalog (live + roadmap rows; private client paths reduced to a count).
+                        </li>
+                        <li>
+                            <a href="https://vamseeachanta.github.io/deckhand-sandbox/api/openapi.json" target="_blank" rel="noopener"><strong>OpenAPI spec</strong></a>
+                            &mdash; <code>openapi.json</code>: the API surface (<code>POST /api/run</code> and friends) as an OpenAPI 3.1 document.
+                        </li>
+                    </ul>
+
+                    <div class="catalog-note">
+                        These are the public read-tier copies of the catalog this page is reconciled against:
+                        <strong>2 live paths</strong>, <strong>5 onboarding domains</strong>, and isolated private-scope
+                        delivery paths held back from the public surface. The tables above and these files share one
+                        source of truth, so they stay in lockstep.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <section class="cta-section">
         <div class="container">
             <div class="row">


### PR DESCRIPTION
## What

Reconcile `content/api-catalog.html` against the canonical, PII-safe generated catalog at `deckhand/docs/deckhand/api-catalog.json` and add machine-readable links.

## Drift reconciled

The page's LIVE and Roadmap rows were checked row-by-row against the canonical source. They **already matched** — no extra/renamed/missing rows:

- **Live (2):** `subsea_pipeline_wall_thickness_screen` (`subsea-pipelines-integrity` / `pipeline`), `floating_marine_mooring_screen` (`floating-marine` / `mooring`)
- **Roadmap (5):** `wells-subsurface` (wells, field-development), `electrical`, `cad`, `manufacturing`, `codes-standards-maritime-law`

## Added

- **Machine-readable** section linking the public read-tier copies:
  - Catalog JSON — `https://vamseeachanta.github.io/deckhand-sandbox/api/api-catalog.json`
  - OpenAPI spec — `https://vamseeachanta.github.io/deckhand-sandbox/api/openapi.json`
- "generated from the Deckhand workflow catalog — same input, same output" provenance note.

## Honesty / no-AI rules preserved

Offshore paths stay live; CAD/CAM/manufacturing/maritime-law/electrical/wells stay clearly labeled roadmap (escalate-only, never shipped). No "AI" claims introduced.

## Build

`node build.js` → 91 pages, exit 0; `dist/api-catalog.html` renders the new section (`dist/` is gitignored, not committed). Not deployed (HITL via PR).

Refs aceengineer-strategy#94, deckhand#501, deckhand#500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)