### PR TITLE
content(web): add depth to standards cluster pages (give-before-ask)

### DIFF
--- a/content/standards/arps-decline-curve.html
+++ b/content/standards/arps-decline-curve.html
@@ -124,6 +124,65 @@ rootPath: "../"
         </div>
     </section>
 
+    <section style="padding:48px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">Why it matters</h2>
+                <p>Reservoir, production and asset engineers forecast estimated ultimate recovery (EUR) and remaining reserves one well at a time from rate history. Doing it consistently across a whole field &mdash; picking the decline exponent b, fitting the same way every time, and reconciling the forecast to an economic cut-off &mdash; is repetitive and easy to do subjectively. A standards-traceable Arps fit gives every well the same defensible treatment with the parameters and assumptions written down.</p>
+            </div></div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">The method &mdash; governing equations</h2>
+                <p>Arps decline-curve analysis fits the rate history to one of three empirical models and integrates to recovery at the economic rate:</p>
+                <div style="background:#fff;border:1px solid #e3e8ee;border-radius:8px;padding:18px 22px;margin:18px 0;font-family:'SFMono-Regular',Consolas,'Liberation Mono',Menlo,monospace;font-size:.95em;line-height:2;color:#1f2933;overflow-x:auto;">
+                    <div>Rate&ndash;time (general / hyperbolic, 0 &lt; b &lt; 1):</div>
+                    <div>&nbsp;&nbsp;q(t) = q<sub>i</sub> / (1 + b &middot; D<sub>i</sub> &middot; t)<sup>1/b</sup></div>
+                    <div style="margin-top:10px;">&nbsp;&nbsp;Exponential (b = 0):&nbsp; q(t) = q<sub>i</sub> &middot; e<sup>&minus;D<sub>i</sub>t</sup></div>
+                    <div>&nbsp;&nbsp;Harmonic (b = 1):&nbsp; q(t) = q<sub>i</sub> / (1 + D<sub>i</sub> &middot; t)</div>
+                    <div style="margin-top:10px;">Cumulative to an economic rate q<sub>ab</sub>:</div>
+                    <div>&nbsp;&nbsp;Exponential:&nbsp; N<sub>p</sub> = (q<sub>i</sub> &minus; q<sub>ab</sub>) / D<sub>i</sub></div>
+                    <div>&nbsp;&nbsp;Hyperbolic:&nbsp; N<sub>p</sub> = q<sub>i</sub><sup>b</sup> / ((1&minus;b)D<sub>i</sub>) &middot; (q<sub>i</sub><sup>1&minus;b</sup> &minus; q<sub>ab</sub><sup>1&minus;b</sup>)</div>
+                    <div>&nbsp;&nbsp;Harmonic:&nbsp; N<sub>p</sub> = (q<sub>i</sub> / D<sub>i</sub>) &middot; ln(q<sub>i</sub> / q<sub>ab</sub>)</div>
+                </div>
+                <p style="font-size:.92em;color:#52606d;">where q<sub>i</sub> is the initial rate, D<sub>i</sub> the initial nominal decline rate, b the decline exponent and q<sub>ab</sub> the economic abandonment rate. The parameters q<sub>i</sub>, D<sub>i</sub> and b are fitted by regression to the history; EUR is the cumulative produced to date plus N<sub>p</sub> from the current rate to q<sub>ab</sub>.</p>
+                <p style="font-size:.9em;color:#6b7785;"><em>These are the standard Arps relationships. No numeric example is shown here on purpose &mdash; the calculator and Deckhand fit the parameters and compute the forecast and EUR deterministically from your rate history, so every figure is reproducible and traceable.</em></p>
+            </div></div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">What a screening check covers &mdash; and what it does not</h2>
+                <div class="row">
+                    <div class="col-md-6">
+                        <h3 style="font-size:1.05em;color:#1f7a3d;">Covers</h3>
+                        <ul class="ask-list">
+                            <li>Single-well, single-phase boundary-dominated (depletion) decline fits.</li>
+                            <li>Exponential, hyperbolic and harmonic models with fitted q<sub>i</sub>, D<sub>i</sub>, b.</li>
+                            <li>Forward rate forecast and EUR to a user-supplied economic rate.</li>
+                            <li>A parameter report with the fit assumptions stated.</li>
+                        </ul>
+                    </div>
+                    <div class="col-md-6">
+                        <h3 style="font-size:1.05em;color:#9a3b2e;">Does not cover</h3>
+                        <ul class="ask-list">
+                            <li>Transient / early-time flow before boundary-dominated decline, where Arps over-forecasts.</li>
+                            <li>Modified-Arps terminal decline or multi-segment fits unless specified.</li>
+                            <li>Rate-transient, material-balance or numerical-simulation methods.</li>
+                            <li>Well interference, workovers, choke changes, commingled allocation, or economics and pricing.</li>
+                        </ul>
+                    </div>
+                </div>
+                <p style="font-size:.92em;color:#52606d;">The screening assumes the history reflects established decline under roughly constant operating conditions; wells in transient flow or with operational changes need a method-of-record review.</p>
+            </div></div>
+        </div>
+    </section>
+
     <section style="padding:48px 0;text-align:center;">
         <div class="container">
             <h2 class="section-title">Related standards</h2>

--- a/content/standards/dnv-rp-f105-free-span-viv.html
+++ b/content/standards/dnv-rp-f105-free-span-viv.html
@@ -106,6 +106,63 @@ rootPath: "../"
         </div>
     </section>
 
+    <section style="padding:48px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">Why it matters</h2>
+                <p>Every ROV or AUV survey of an in-service pipeline returns a list of free spans where the line crosses seabed depressions. Most are harmless, but each one is a potential vortex-induced-vibration (VIV) fatigue hotspot, and rectification — rock dump or supports — is expensive vessel time. The bottleneck for an integrity engineer is triage: deciding which spans are clearly acceptable, which are clearly not, and which need a full assessment. A standards-traceable screening check against DNV-RP-F105 turns a survey span list into a ranked action list.</p>
+            </div></div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">The method &mdash; governing relationships</h2>
+                <p>RP-F105 screens a span by comparing the current-driven vortex-shedding excitation against the span's natural frequencies, then accumulating fatigue from the resulting stress cycles. The screening forms are:</p>
+                <div style="background:#fff;border:1px solid #e3e8ee;border-radius:8px;padding:18px 22px;margin:18px 0;font-family:'SFMono-Regular',Consolas,'Liberation Mono',Menlo,monospace;font-size:.95em;line-height:2;color:#1f2933;overflow-x:auto;">
+                    <div>Natural frequency (first mode):</div>
+                    <div>&nbsp;&nbsp;f<sub>1</sub> &asymp; C<sub>1</sub> &middot; &radic;[ (1 + CSF) &middot; EI / (m<sub>e</sub> &middot; L<sub>eff</sub><sup>4</sup>) &middot; (1 + S<sub>eff</sub>/P<sub>cr</sub> + C<sub>3</sub>(&delta;/D)<sup>2</sup>) ]</div>
+                    <div style="margin-top:10px;">Reduced velocity (VIV onset parameter):</div>
+                    <div>&nbsp;&nbsp;V<sub>R</sub> = U<sub>c</sub> / (f<sub>1</sub> &middot; D)</div>
+                    <div style="margin-top:10px;">Fatigue damage (Miner's rule against a DNV S-N curve):</div>
+                    <div>&nbsp;&nbsp;D<sub>fat</sub> = &Sigma;<sub>i</sub> n<sub>i</sub> / N<sub>i</sub>&nbsp;&nbsp;&middot;&nbsp;&nbsp;life = T<sub>design</sub> / D<sub>fat</sub></div>
+                </div>
+                <p style="font-size:.92em;color:#52606d;">where C<sub>1</sub>, C<sub>3</sub> are boundary-condition coefficients, EI the bending stiffness, m<sub>e</sub> the effective mass (including added mass), L<sub>eff</sub> the effective span length, CSF the concrete-coating stiffness factor, S<sub>eff</sub> the effective axial force, P<sub>cr</sub> the Euler buckling load, &delta; the static deflection and D the outer diameter. Cross-flow VIV is screened around V<sub>R</sub> &asymp; 3&ndash;4 and in-line VIV at lower V<sub>R</sub>; the stress range follows from the predicted amplitude (A/D) and a unit-stress factor.</p>
+                <p style="font-size:.9em;color:#6b7785;"><em>Symbols and notation follow DNV-RP-F105; the relationships above are the screening forms, not the full response models. No numeric example is shown here on purpose &mdash; the calculator and Deckhand compute every figure deterministically from your inputs, so each result is reproducible and traceable.</em></p>
+            </div></div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">What a screening check covers &mdash; and what it does not</h2>
+                <div class="row">
+                    <div class="col-md-6">
+                        <h3 style="font-size:1.05em;color:#1f7a3d;">Covers</h3>
+                        <ul class="ask-list">
+                            <li>Single, isolated free spans on a known seabed profile.</li>
+                            <li>First-mode cross-flow and in-line VIV screening from steady plus wave-induced current.</li>
+                            <li>An allowable free-span length estimate for the given flow and support conditions.</li>
+                            <li>A pass / detailed-assessment / intervention flag per span with the assumptions shown.</li>
+                        </ul>
+                    </div>
+                    <div class="col-md-6">
+                        <h3 style="font-size:1.05em;color:#9a3b2e;">Does not cover</h3>
+                        <ul class="ask-list">
+                            <li>Multi-span interaction or modal coupling between adjacent spans.</li>
+                            <li>Calibrated soil&ndash;pipe dynamic stiffness, trenching or partial-burial effects beyond simple factors.</li>
+                            <li>Full time-domain VIV fatigue or large-wave (Morison) direct-force fatigue.</li>
+                            <li>Combined loading with pressure, temperature and third-party interaction.</li>
+                        </ul>
+                    </div>
+                </div>
+                <p style="font-size:.92em;color:#52606d;">Spans flagged near a limit should go to a full RP-F105 / finite-element assessment &mdash; the screening narrows where that effort is worth spending.</p>
+            </div></div>
+        </div>
+    </section>
+
     <section style="padding:48px 0;text-align:center;">
         <div class="container">
             <h2 class="section-title">Related standards</h2>

--- a/content/standards/mooring-line-fatigue.html
+++ b/content/standards/mooring-line-fatigue.html
@@ -124,6 +124,63 @@ rootPath: "../"
         </div>
     </section>
 
+    <section style="padding:48px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">Why it matters</h2>
+                <p>A station-keeping engineer on a floating system &mdash; FPSO, FPS or semi &mdash; has to show that every mooring line survives its design service life with the code safety factor. The tension histories come out of time-domain analysis across many sea states, and the fatigue bookkeeping then runs per component: chain, wire and connector each have their own T-N data, and the line that governs is rarely obvious by inspection. A standards-traceable screening check turns a pile of tension cycles into a damage number, an implied life and a clearly identified governing segment.</p>
+            </div></div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;background:#f8f9fa;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">The method &mdash; governing relationships</h2>
+                <p>API RP 2SK and DNV-OS-E301 accumulate fatigue from the tension-range spectrum of each line against component T-N (tension&ndash;cycles-to-failure) data using Miner's rule:</p>
+                <div style="background:#fff;border:1px solid #e3e8ee;border-radius:8px;padding:18px 22px;margin:18px 0;font-family:'SFMono-Regular',Consolas,'Liberation Mono',Menlo,monospace;font-size:.95em;line-height:2;color:#1f2933;overflow-x:auto;">
+                    <div>Tension-range counting (rainflow, per sea state):</div>
+                    <div>&nbsp;&nbsp;n<sub>i</sub> at tension range &Delta;T<sub>i</sub>, weighted by sea-state probability p<sub>j</sub></div>
+                    <div style="margin-top:10px;">T-N curve (tension normalised by reference breaking strength):</div>
+                    <div>&nbsp;&nbsp;N<sub>i</sub> = a<sub>D</sub> &middot; (&Delta;T<sub>i</sub> / RBS)<sup>&minus;m</sup></div>
+                    <div style="margin-top:10px;">Miner's-rule damage, life and acceptance:</div>
+                    <div>&nbsp;&nbsp;D<sub>fat</sub> = &Sigma;<sub>i</sub> n<sub>i</sub> / N<sub>i</sub>&nbsp;&nbsp;&middot;&nbsp;&nbsp;life = T<sub>service</sub> / D<sub>fat</sub>&nbsp;&nbsp;&middot;&nbsp;&nbsp;accept if D<sub>fat</sub> &middot; FDF &le; 1</div>
+                </div>
+                <p style="font-size:.92em;color:#52606d;">where a<sub>D</sub> and m are the component-specific T-N intercept and slope (chain, wire rope or connector), RBS the reference breaking strength, T<sub>service</sub> the design service life and FDF the fatigue design factor set by the code according to component type and inspectability. The governing line or segment is the one with the highest accumulated damage.</p>
+                <p style="font-size:.9em;color:#6b7785;"><em>Symbols and notation follow API RP 2SK / DNV-OS-E301. No numeric example is shown here on purpose &mdash; the calculator and Deckhand compute the damage, life and safety factor deterministically from your tension input and T-N data, so every figure is reproducible and traceable.</em></p>
+            </div></div>
+        </div>
+    </section>
+
+    <section style="padding:48px 0;">
+        <div class="container">
+            <div class="row"><div class="col-md-10 col-md-offset-1">
+                <h2 class="section-title text-center">What a screening check covers &mdash; and what it does not</h2>
+                <div class="row">
+                    <div class="col-md-6">
+                        <h3 style="font-size:1.05em;color:#1f7a3d;">Covers</h3>
+                        <ul class="ask-list">
+                            <li>Damage and implied life per segment from a supplied tension-cycle histogram or time series.</li>
+                            <li>Component T-N data for chain, wire and connectors with Miner summation.</li>
+                            <li>Identification of the governing line and segment.</li>
+                            <li>Comparison against design service life &times; fatigue design factor, assumptions shown.</li>
+                        </ul>
+                    </div>
+                    <div class="col-md-6">
+                        <h3 style="font-size:1.05em;color:#9a3b2e;">Does not cover</h3>
+                        <ul class="ask-list">
+                            <li>The global hydrodynamic / mooring time-domain analysis that produces the tensions (upstream).</li>
+                            <li>Out-of-plane bending of chain at fairleads and connectors unless an OPB model and contact data are supplied.</li>
+                            <li>Corrosion and wear knock-downs beyond a user-supplied factor.</li>
+                            <li>VIV of taut lines, installation transients and thermal effects.</li>
+                        </ul>
+                    </div>
+                </div>
+                <p style="font-size:.92em;color:#52606d;">The screening assumes the tension input represents the design environment; lines flagged near a limit warrant a full code fatigue analysis with the upstream model.</p>
+            </div></div>
+        </div>
+    </section>
+
     <section style="padding:48px 0;text-align:center;">
         <div class="container">
             <h2 class="section-title">Related standards</h2>


### PR DESCRIPTION
## What

The three Open-Deck standards landing pages already existed as thin SEO stubs (hero, "what you can ask", FAQ, CTA) but lacked the technical depth the give-before-ask funnel is built on. This PR enriches all three in place, preserving the existing template, partials, schema, calculator links and Open-Deck CTAs:

- `standards/dnv-rp-f105-free-span-viv.html`
- `standards/mooring-line-fatigue.html`
- `standards/arps-decline-curve.html`

## Sections added to each page

1. **Why it matters** — the ICP pain the standard addresses (integrity-engineer span triage; station-keeping fatigue bookkeeping; consistent per-well EUR fits).
2. **The method — governing equations/relationships** — the screening forms in plain notation (RP-F105 natural frequency / reduced velocity / Miner damage; API RP 2SK / DNV-OS-E301 T-N + Miner; Arps exponential/hyperbolic/harmonic rate-time and cumulative).
3. **What a screening check covers — and what it does not** — an honest two-column envelope so readers know the limits before they trust a screen.

## Marketing rule compliance

Per the no-fabrication rule, **no numeric worked examples are included**. Equations are shown symbolically and the numbers are explicitly deferred to the deterministic calculator / Deckhand, so any figure a reader sees is reproducible. No client names, PII, or internal data — content is generic and educational (these are public pages).

## Verification

`node build.js` rebuilds all three pages cleanly (includes resolved, equations render). `dist/` is gitignored; only the three `content/standards/*.html` source files are changed.