### PR TITLE
content(web): refresh api-catalog page to current live paths (11 screens)

### DIFF
--- a/content/api-catalog.html
+++ b/content/api-catalog.html
@@ -31,6 +31,14 @@
         .status-onboarding { background:#fdf3e0; color:#b3791a; }
         .catalog-note { background:#f8f9fa; border-left:4px solid #2c3e50; padding:14px 18px; margin:18px 0; color:#52606d; }
         .roadmap-row { background:#f8f9fa; padding:56px 0; }
+        .domain-block { margin:0 0 40px; }
+        .domain-block h3 { color:#2c3e50; margin:0 0 4px; }
+        .domain-block .domain-blurb { color:#52606d; margin:0 0 14px; }
+        .workflow-chips { margin:6px 0 4px; line-height:2.1; }
+        .workflow-chips code { background:rgba(0,0,0,0.06); padding:2px 7px; border-radius:5px; font-size:0.85em; margin:1px 3px 1px 0; display:inline-block; color:#3a4756; }
+        .workflow-chips .eng-wed code { background:#eef3fb; color:#2b557a; }
+        details.workflows { margin:4px 0 0; }
+        details.workflows summary { cursor:pointer; color:#2c5aa0; font-weight:600; font-size:0.95em; padding:6px 0; }
     </style>
 </head>
 <body>
@@ -42,7 +50,7 @@
             <div class="row">
                 <div class="col-md-9 col-md-offset-1 text-center">
                     <h1 class="hero-title">The API-path catalog</h1>
-                    <p class="hero-subtitle">Every workflow is an API path you can call: <code>POST /api/run</code> &rarr; a standards-traceable report URL. Below are the paths that are <strong>live today</strong>, and the domains being <strong>onboarded</strong>. Nothing here is claimed before it has a firable workflow row.</p>
+                    <p class="hero-subtitle">Every workflow is an API path you can call: <code>POST /api/run</code> &rarr; a standards-traceable report URL. Below are the screens that are <strong>live today</strong> across three domains, and the domains being <strong>onboarded</strong>. Nothing here is claimed before it has a firable workflow row.</p>
                     <div class="hero-cta">
                         <a href="deckhand-api.html" class="btn btn-default btn-lg">How the API works</a>
                     </div>
@@ -57,52 +65,181 @@
             <div class="row">
                 <div class="col-md-11 col-md-offset-1">
                     <h2 class="section-title">Live paths <span class="status-badge status-live">LIVE</span></h2>
-                    <p class="section-subtitle" style="text-align:left;">Runnable today on the free Open Deck tier. DNV-traceable, deterministic, with report URLs published to the public gallery.</p>
+                    <p class="section-subtitle" style="text-align:left;"><strong>11 live screens</strong> across <strong>3 domains</strong>, surfacing roughly <strong>100 engineering workflows</strong>. Runnable today on the free Open Deck tier &mdash; DNV/API-traceable, deterministic, with report URLs published to the public gallery. Each screen takes a short set of clarification inputs, then routes the question to one of the workflows it surfaces (below) and returns a report URL.</p>
 
-                    <div class="table-wrap">
-                        <table class="catalog-table">
-                            <thead>
-                                <tr>
-                                    <th>ref (workflow path)</th>
-                                    <th>domain / subdomain</th>
-                                    <th>required inputs</th>
-                                    <th>deliverable</th>
-                                    <th>example report URL</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td><code>subsea_pipeline_wall_thickness_screen</code><br><span style="color:#6b7785; font-size:0.9em;">engine: digitalmodel wall-thickness quickcheck</span></td>
-                                    <td><code>subsea-pipelines-integrity</code> / <code>pipeline</code></td>
-                                    <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>design_pressure_rating</code> <code>buckle_arrestors</code> <code>data_available</code> <code>deadline</code></td>
-                                    <td>Summary-first reply + standards-traceable HTML report package in a dated sandbox run dir (DNV-ST-F101).</td>
-                                    <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">deckhand-sandbox gallery</a> &rarr; <code>.../report.html</code></td>
-                                </tr>
-                                <tr>
-                                    <td><code>floating_marine_mooring_screen</code><br><span style="color:#6b7785; font-size:0.9em;">engine: digitalmodel mooring analysis</span></td>
-                                    <td><code>floating-marine</code> / <code>mooring</code></td>
-                                    <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>line_material</code> <code>data_available</code> <code>deadline</code></td>
-                                    <td>Summary-first reply + HTML report package in a dated sandbox run dir. Metallic-line screen; non-metallic escalates honestly.</td>
-                                    <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">deckhand-sandbox gallery</a> &rarr; <code>.../report.html</code></td>
-                                </tr>
-                            </tbody>
-                        </table>
+                    <!-- floating-marine -->
+                    <div class="domain-block">
+                        <h3>floating-marine <span class="status-badge status-live">LIVE</span></h3>
+                        <p class="domain-blurb">FPSO/floater hydrodynamics, mooring, riser, marine installation and vessel screening on the open-source <strong>digitalmodel</strong> engine.</p>
+                        <div class="table-wrap">
+                            <table class="catalog-table">
+                                <thead>
+                                    <tr>
+                                        <th>ref (screen)</th>
+                                        <th>subdomain</th>
+                                        <th>required inputs</th>
+                                        <th>deliverable</th>
+                                        <th>example report URL</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td><code>floating_marine_hydrodynamics_screen</code></td>
+                                        <td><code>hydrodynamics</code></td>
+                                        <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>data_available</code> <code>deadline</code></td>
+                                        <td>Summary-first chat reply + dated sandbox run dir (stress-RAO spectral fatigue, wave spectra, diffraction prep).</td>
+                                        <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">gallery</a> &rarr; <code>/domains/floating-marine/deckhand-deliverables/&lt;run-id&gt;/report.html</code></td>
+                                    </tr>
+                                    <tr>
+                                        <td><code>floating_marine_mooring_screen</code></td>
+                                        <td><code>mooring</code></td>
+                                        <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>line_material</code> <code>data_available</code> <code>deadline</code></td>
+                                        <td>Summary-first reply + dated sandbox run dir. Metallic-line screen; non-metallic escalates honestly.</td>
+                                        <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">gallery</a> &rarr; <code>/domains/floating-marine/deckhand-deliverables/&lt;run-id&gt;/report.html</code></td>
+                                    </tr>
+                                    <tr>
+                                        <td><code>floating_marine_riser_screen</code></td>
+                                        <td><code>riser</code></td>
+                                        <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>data_available</code> <code>deadline</code></td>
+                                        <td>Summary-first reply + dated sandbox run dir (riser LRFD/utilisation code checks, drilling-riser stack-up, stack-up parametric sweep).</td>
+                                        <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">gallery</a> &rarr; <code>/domains/floating-marine/deckhand-deliverables/&lt;run-id&gt;/report.html</code></td>
+                                    </tr>
+                                    <tr>
+                                        <td><code>floating_marine_installation_screen</code></td>
+                                        <td><code>installation</code></td>
+                                        <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>data_available</code> <code>deadline</code></td>
+                                        <td>Summary-first reply + dated sandbox run dir (lifting-lug/padeye strength, rigid-jumper installation, rigging, lift modelling).</td>
+                                        <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">gallery</a> &rarr; <code>/domains/floating-marine/deckhand-deliverables/&lt;run-id&gt;/report.html</code></td>
+                                    </tr>
+                                    <tr>
+                                        <td><code>floating_marine_vessels_screen</code></td>
+                                        <td><code>vessels</code></td>
+                                        <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>data_available</code> <code>deadline</code></td>
+                                        <td>Summary-first reply + dated sandbox run dir (seakeeping operability, stability, resistance, mooring loads).</td>
+                                        <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">gallery</a> &rarr; <code>/domains/floating-marine/deckhand-deliverables/&lt;run-id&gt;/report.html</code></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <details class="workflows">
+                            <summary>Workflows these screens surface (44)</summary>
+                            <div class="workflow-chips">
+                                <code>fpso-spread-mooring</code> <code>mooring-fatigue</code> <code>mooring-fatigue-atlas-query</code> <code>fpso-mooring-full</code> <code>fpso-mooring-atlas-query</code> <code>api-2sk-mooring</code> <code>synthetic-rope-mooring-fatigue</code> <code>synthetic-rope-atlas-query</code> <code>catenary</code> <code>viv-analysis</code> <code>viv-atlas-query</code> <code>api-rp-2rd-riser</code> <code>code-check-atlas-query</code> <code>dnv-os-f201-riser</code> <code>riser-stackup</code> <code>riser-stackup-parametric</code> <code>tsj-sizing</code> <code>spectral-fatigue</code> <code>spectral-fatigue-atlas-query</code> <code>riser-fatigue</code> <code>riser-fatigue-atlas-query</code> <code>orcawave-input-prep</code> <code>aqwa-diffraction-deck-prep</code> <code>hydro-coefficients</code> <code>wave-spectra</code> <code>rao-tabulation</code> <code>rao-atlas-query</code> <code>passing-ship</code> <code>rao-spectral-fatigue</code> <code>ocimf-tanker-loads</code> <code>naval-arch-yaw-moment</code> <code>damage-stability</code> <code>platform-stability</code> <code>hull-resistance</code> <code>hull-seakeeping</code> <code>propeller-rudder-interaction</code> <code>rudder-stock-torque</code> <code>vessel-seakeeping</code> <code>orcaflex-6dbuoy-dnvrph103</code> <code>rigging</code> <code>jumper-installation</code> <code>lifting-lug-design</code> <code>weather-window</code> <span class="eng-wed"><code>marine-safety-stats</code></span>
+                            </div>
+                        </details>
+                    </div>
+
+                    <!-- subsea-pipelines-integrity -->
+                    <div class="domain-block">
+                        <h3>subsea-pipelines-integrity <span class="status-badge status-live">LIVE</span></h3>
+                        <p class="domain-blurb">Pipeline wall-thickness, asset-integrity (API 579 fitness-for-service), structural and geotechnical screening on <strong>digitalmodel</strong>.</p>
+                        <div class="table-wrap">
+                            <table class="catalog-table">
+                                <thead>
+                                    <tr>
+                                        <th>ref (screen)</th>
+                                        <th>subdomain</th>
+                                        <th>required inputs</th>
+                                        <th>deliverable</th>
+                                        <th>example report URL</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td><code>subsea_pipeline_wall_thickness_screen</code></td>
+                                        <td><code>pipeline</code></td>
+                                        <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>design_pressure_rating</code> <code>buckle_arrestors</code> <code>data_available</code> <code>deadline</code></td>
+                                        <td>Summary-first reply + standards-traceable HTML report package in a dated sandbox run dir whose manifest carries the branch-basis fields (DNV-ST-F101).</td>
+                                        <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">gallery</a> &rarr; <code>/domains/subsea-pipelines-integrity/deckhand-deliverables/&lt;run-id&gt;/report.html</code></td>
+                                    </tr>
+                                    <tr>
+                                        <td><code>subsea_asset_integrity_screen</code></td>
+                                        <td><code>asset-integrity</code></td>
+                                        <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>data_available</code> <code>deadline</code></td>
+                                        <td>Summary-first reply + dated sandbox run dir (API 579 fitness-for-service from wall-thickness readings, B31.4/B31.8).</td>
+                                        <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">gallery</a> &rarr; <code>/domains/subsea-pipelines-integrity/deckhand-deliverables/&lt;run-id&gt;/report.html</code></td>
+                                    </tr>
+                                    <tr>
+                                        <td><code>subsea_structural_screen</code></td>
+                                        <td><code>structural</code></td>
+                                        <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>data_available</code> <code>deadline</code></td>
+                                        <td>Summary-first reply + dated sandbox run dir (jacket member/joint capacity, plate &amp; elastic buckling, tubular design envelope, Von Mises, stress-strain).</td>
+                                        <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">gallery</a> &rarr; <code>/domains/subsea-pipelines-integrity/deckhand-deliverables/&lt;run-id&gt;/report.html</code></td>
+                                    </tr>
+                                    <tr>
+                                        <td><code>subsea_geotechnical_screen</code></td>
+                                        <td><code>geotechnical</code></td>
+                                        <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>data_available</code> <code>deadline</code></td>
+                                        <td>Summary-first reply + dated sandbox run dir (pile axial capacity, scour, liquefaction triggering, mudmat bearing capacity).</td>
+                                        <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">gallery</a> &rarr; <code>/domains/subsea-pipelines-integrity/deckhand-deliverables/&lt;run-id&gt;/report.html</code></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <details class="workflows">
+                            <summary>Workflows these screens surface (38)</summary>
+                            <div class="workflow-chips">
+                                <code>pipe-capacity</code> <code>wall-thickness-quickcheck</code> <code>on-bottom-stability-f109</code> <code>free-span-f105</code> <code>free-span-atlas-query</code> <code>pipeline-lateral-buckling</code> <code>pipeline-upheaval-buckling</code> <code>span-rectification</code> <code>pipe-ovality</code> <code>fatigue-analysis</code> <code>plate-buckling</code> <code>time-series</code> <code>jacket-member-joint-checks</code> <code>rao-spectral-fatigue</code> <code>elastic-buckling</code> <code>tubular-design-envelope</code> <code>von-mises</code> <code>stress-strain</code> <code>stress-strain-parametric</code> <code>anchor-capacity</code> <code>anchor-capacity-atlas-query</code> <code>pile-axial-capacity</code> <code>pile-capacity</code> <code>pile-capacity-atlas-query</code> <code>scour-assessment</code> <code>mudmat-bearing-capacity</code> <code>mudmat-bearing-atlas-query</code> <code>liquefaction-triggering</code> <code>cathodic-protection</code> <code>cathodic-protection-pipeline</code> <code>cathodic-protection-jacket</code> <code>cathodic-protection-manifold</code> <code>cathodic-protection-monopile</code> <code>cathodic-protection-fpso</code> <code>api579-pipe-ffs-b314</code> <code>api579-pipe-ffs-b318</code> <code>inspection-planning</code> <span class="eng-wed"><code>pipeline-safety-ffs</code></span>
+                            </div>
+                        </details>
+                    </div>
+
+                    <!-- wells-subsurface -->
+                    <div class="domain-block">
+                        <h3>wells-subsurface <span class="status-badge status-live">LIVE</span></h3>
+                        <p class="domain-blurb">Well production/nodal analysis, drilling &amp; well hydraulics, wellbore/tubular design, and concept-level field-development economics on <strong>digitalmodel</strong> plus public production data from <strong>worldenergydata</strong>.</p>
+                        <div class="table-wrap">
+                            <table class="catalog-table">
+                                <thead>
+                                    <tr>
+                                        <th>ref (screen)</th>
+                                        <th>subdomain</th>
+                                        <th>required inputs</th>
+                                        <th>deliverable</th>
+                                        <th>example report URL</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td><code>wells_subsurface_wells_screen</code></td>
+                                        <td><code>wells</code></td>
+                                        <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>data_available</code> <code>deadline</code></td>
+                                        <td>Summary-first reply + dated sandbox run dir (production nodal analysis, well/drilling hydraulics, wellbore &amp; tubular design, directional well path, artificial-lift health, ESP &amp; coiled-tubing hydraulics, public production data).</td>
+                                        <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">gallery</a> &rarr; <code>/domains/wells-subsurface/deckhand-deliverables/&lt;run-id&gt;/report.html</code></td>
+                                    </tr>
+                                    <tr>
+                                        <td><code>wells_subsurface_field_development_screen</code></td>
+                                        <td><code>field-development</code></td>
+                                        <td class="inputs"><code>objective</code> <code>configuration</code> <code>environment</code> <code>data_available</code> <code>deadline</code></td>
+                                        <td>Summary-first reply + dated sandbox run dir (concept-level CAPEX/OPEX estimates, host-concept selection and scoring, run/dataset comparison) using generic digitalmodel economics only.</td>
+                                        <td><a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">gallery</a> &rarr; <code>/domains/wells-subsurface/deckhand-deliverables/&lt;run-id&gt;/report.html</code></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <details class="workflows">
+                            <summary>Workflows these screens surface (21)</summary>
+                            <div class="workflow-chips">
+                                <code>dynacard-diagnostics</code> <code>well-bore-design</code> <code>well-hydraulics</code> <code>rop-analysis</code> <code>tubular-design-envelope</code> <code>nodal-analysis</code> <code>nodal-analysis-ipr-vlp</code> <code>vlp-correlations</code> <code>ct-hydraulics</code> <code>artificial-lift-field-health</code> <code>wellpath</code> <code>esp-pump-hydraulics</code> <code>capex-estimate</code> <code>opex-estimate</code> <code>concept-selection</code> <code>compare-tool</code> <span class="eng-wed"><code>bsee-production-summary</code> <code>bsee-well-comparison</code> <code>production-forecast-arps</code> <code>sodir-field-summary</code> <code>texas-rrc-production-summary</code></span>
+                            </div>
+                        </details>
                     </div>
 
                     <div class="catalog-note">
-                        <code>ref</code> is the workflow-row key in the source-of-truth catalog
-                        <code>deckhand/config/deckhand/routing/domain-workflows.yaml</code>. The two live paths run on the
-                        open-source <strong>digitalmodel</strong> engine; required inputs are the path's clarification keys
-                        (branch-first inputs like <code>buckle_arrestors</code> / <code>line_material</code> are asked, never guessed).
-                        Each call returns a <code>report_url</code> on the
+                        Each <code>ref</code> is a screen key in the source-of-truth catalog
+                        <code>deckhand/config/deckhand/routing/domain-workflows.yaml</code>. The live screens run on the
+                        open-source <strong>digitalmodel</strong> and <strong>worldenergydata</strong> engines
+                        (<span class="eng-wed"><code>tinted chips</code></span> above are worldenergydata public-data paths).
+                        Required inputs are each screen's clarification keys &mdash; branch-first inputs like
+                        <code>buckle_arrestors</code>, <code>line_material</code> and <code>design_pressure_rating</code>
+                        are asked, never guessed. Every call returns a <code>report_url</code> on the
                         <a href="https://vamseeachanta.github.io/deckhand-sandbox/" target="_blank" rel="noopener">public deckhand-sandbox gallery</a>.
                     </div>
 
                     <p style="color:#6b7785;">
-                        Two further utility paths back the same surface: an Open Deck <em>public router</em> that directs a
-                        question to the right domain channel, and isolated <em>private-scope delivery</em> paths for
-                        client-confidential work (reports promoted to a client wiki, never the public gallery).
-                        <a href="contact.html">Talk to us</a> about private scopes.
+                        A public <em>router</em> path directs a question to the right domain channel, and <strong>4</strong>
+                        isolated <em>private-scope delivery</em> paths handle client-confidential work (reports promoted to a
+                        client wiki, never the public gallery). <a href="contact.html">Talk to us</a> about private scopes.
                     </p>
                 </div>
             </div>
@@ -127,10 +264,9 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr><td><code>wells-subsurface</code></td><td><code>wells</code>, <code>field-development</code></td><td>Onboarding &mdash; public workflow row owed</td></tr>
-                                <tr><td><code>electrical</code></td><td><code>electrical</code></td><td>Onboarding &mdash; bound, escalate-only</td></tr>
                                 <tr><td><code>cad</code></td><td><code>cad</code></td><td>Onboarding &mdash; bound, escalate-only</td></tr>
                                 <tr><td><code>manufacturing</code></td><td><code>manufacturing</code></td><td>Onboarding &mdash; bound, escalate-only</td></tr>
+                                <tr><td><code>electrical</code></td><td><code>electrical</code></td><td>Onboarding &mdash; bound, escalate-only</td></tr>
                                 <tr><td><code>codes-standards-maritime-law</code></td><td>&mdash;</td><td>Onboarding &mdash; bound, no workflow row yet</td></tr>
                             </tbody>
                         </table>
@@ -167,9 +303,10 @@
 
                     <div class="catalog-note">
                         These are the public read-tier copies of the catalog this page is reconciled against:
-                        <strong>2 live paths</strong>, <strong>5 onboarding domains</strong>, and isolated private-scope
-                        delivery paths held back from the public surface. The tables above and these files share one
-                        source of truth, so they stay in lockstep.
+                        <strong>11 live screens</strong> across <strong>3 domains</strong> (surfacing roughly
+                        <strong>100 workflows</strong>), <strong>4 onboarding domains</strong>, and <strong>4</strong>
+                        isolated private-scope delivery paths held back from the public surface. The tables above and these
+                        files share one source of truth, so they stay in lockstep.
                     </div>
                 </div>
             </div>
@@ -181,7 +318,7 @@
             <div class="row">
                 <div class="col-md-8 col-md-offset-2 text-center">
                     <h2>Call a live path &mdash; free</h2>
-                    <p>Open Deck is the free chat client of the API. Bring a real subsea-pipeline or mooring question and watch a path run, traced to the standard, on open repos.</p>
+                    <p>Open Deck is the free chat client of the API. Bring a real subsea-pipeline, mooring, riser, vessel or well question and watch a path run, traced to the standard, on open repos.</p>
                     <!-- OPEN_DECK_CTA -->
                     <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_catalog_footer">Try Open Deck on Telegram</a>
                 </div>


### PR DESCRIPTION
## What

Reconciles `content/api-catalog.html` against the now-current Deckhand catalog (`deckhand/docs/deckhand/api-catalog.json`). The page was last reconciled at **2 live paths + 5 onboarding domains**; the catalog has since grown to **11 live_public screens across 3 domains**, surfacing ~100 engineering workflows.

## Changes

- **Live section** rewritten and grouped by domain:
  - `floating-marine` (5 screens: hydrodynamics, mooring, riser, installation, vessels) — surfaces 44 workflows
  - `subsea-pipelines-integrity` (4 screens: pipeline, asset-integrity, structural, geotechnical) — surfaces 38 workflows
  - `wells-subsurface` (2 screens: wells, field-development) — surfaces 21 workflows
  - Each screen shows subdomain, required inputs (branch-first keys like `buckle_arrestors` / `line_material` / `design_pressure_rating`), deliverable, example report URL, and a collapsible list of the workflows it surfaces (worldenergydata public-data paths tinted).
- `wells-subsurface` moved from onboarding to **live**.
- **Roadmap (onboarding)** now lists the 4 not-shipped domains: `cad`, `manufacturing`, `electrical`, `codes-standards-maritime-law` (escalate-only, labeled not shipped).
- Private-scope count updated to **4**.
- Kept the machine-readable JSON/OpenAPI links, the "generated from the Deckhand catalog" note, the honesty/no-claim rule, and the no-"AI" tone.
- Only `live_public` paths are shown as live — no invented paths.

## Verification

- `node build.js` → 91 pages built, `dist/api-catalog.html` renders (includes expanded, no errors).
- PII grep `{acma,doris,hdic,fdas,baez,seanation}` over content + dist → clean.

Refs aceengineer-strategy#94, deckhand#513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)