### PR TITLE
feat(capabilities): registry SSOT — capabilities.yaml drives HF-backed pages [C1]

### DIFF
--- a/build.js
+++ b/build.js
@@ -23,6 +23,20 @@ function loadCopy(copyFile = './brand/copy.yaml') {
   return _copyCache;
 }
 
+// Load the capability registry (config/capabilities.yaml) — SSOT for the HF-backed
+// capability pages (docs/capabilities-registry.md, epic workspace-hub#3485). Returns
+// { version, capabilities: [...] } (or {} if absent). Cached like loadCopy. Consumed by
+// the build-time HF fetch + render layer (aceengineer-website#50/#51/#52).
+let _capabilitiesCache;
+function loadCapabilities(registryFile = './config/capabilities.yaml') {
+  if (_capabilitiesCache === undefined) {
+    _capabilitiesCache = fs.existsSync(registryFile)
+      ? (yaml.load(fs.readFileSync(registryFile, 'utf8')) || {})
+      : {};
+  }
+  return _capabilitiesCache;
+}
+
 // Parse YAML front matter
 function parseFrontMatter(content) {
   // Tolerate CRLF line endings and a missing trailing newline after the closing ---
@@ -231,4 +245,4 @@ if (require.main === module) {
     });
 }
 
-module.exports = { parseFrontMatter, getHtmlFiles, ensureDir, copySitemap, copyRobotsTxt, loadCopy };
+module.exports = { parseFrontMatter, getHtmlFiles, ensureDir, copySitemap, copyRobotsTxt, loadCopy, loadCapabilities };

--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -1,0 +1,63 @@
+# capabilities.yaml — registry of algorithm/data capabilities surfaced on aceengineer.com
+#
+# Single source of truth (SSOT) for the HF-backed capability pages. build.js reads
+# this at build time, fetches each dataset from the Hugging Face datasets-server
+# /rows API, and renders one indexable page per capability. Adding a new algorithm
+# to the website = publish its HF dataset + add one entry here (CI enforces both).
+#
+# Epic: vamseeachanta/workspace-hub#3485 · C1: vamseeachanta/aceengineer-website#49
+# Schema + how-to: docs/capabilities-registry.md
+#
+# Entry fields:
+#   id             (required) stable kebab-case slug — becomes the page URL /capabilities/<id>.
+#   title          (required) human-readable capability name (unique <title> for SEO).
+#   domain         (required) one of: worldenergy | digitalmodel.
+#   summary        (required) one-sentence description shown on the card + detail page.
+#   hf_dataset     (required) Hugging Face dataset id, e.g. aceengineer/worldenergydata-explorer.
+#   provenance_url (required) link to the source repo/report that produced the data.
+#   status         (required) live | pending | withheld.
+#                    live     → rendered with real HF data.
+#                    pending  → renders a visible placeholder linking to provenance_url (no silent omission).
+#                    withheld → entry present but not surfaced (e.g. data-correctness hold).
+#   primary_config (required) the config (table) whose headline stat appears on the card.
+#   tables         (required) one or more HF configs to render, each:
+#       config           (required) HF dataset config (table) name.
+#       label            (required) tab/section label on the detail page.
+#       viz              (required) table | bar | line | map.
+#       highlight_columns(required) columns shown first / used by the chart. Must exist in the table.
+#   withheld_columns (optional) columns that must NEVER be surfaced (CI blocks them). See #971.
+#   data_limits      (required) honest disclosure of coverage + known limitations.
+
+version: 1
+
+capabilities:
+  - id: field-explorer
+    title: World Energy Field Explorer
+    domain: worldenergy
+    summary: >-
+      Global offshore field drill-down — fields, wells, and country rollups built
+      from BSEE and public regulatory filings.
+    hf_dataset: aceengineer/worldenergydata-explorer
+    provenance_url: https://github.com/vamseeachanta/worldenergydata
+    status: live
+    primary_config: fields
+    tables:
+      - config: fields
+        label: Fields
+        viz: table
+        highlight_columns: [name, operator, region, wells_count, api_gravity]
+      - config: wells
+        label: Wells
+        viz: table
+        highlight_columns: [api, field_id, cum_oil_mmbbl, uptime_pct, status]
+      - config: countries
+        label: Countries
+        viz: bar
+        highlight_columns: [country, fields, facilities]
+    # Economics columns are held out of the public dataset pending correctness
+    # re-verification (worldenergydata#971 fixed → re-enable tracked in #978 / epic C9).
+    withheld_columns: [npv_mm, breakeven_wti]
+    data_limits: >-
+      Coverage is primarily US Gulf of Mexico deepwater (BSEE) plus selected
+      international basins; not a complete global census. Economics (NPV, breakeven)
+      are withheld pending correctness re-verification (worldenergydata#978).

--- a/docs/capabilities-registry.md
+++ b/docs/capabilities-registry.md
@@ -1,0 +1,82 @@
+# Capability registry (`config/capabilities.yaml`)
+
+The registry is the **single source of truth** for the HF-backed capability pages on
+aceengineer.com. The website is a *function of this file*: `build.js` reads it at build
+time, pulls each dataset from the Hugging Face **datasets-server** `/rows` API, and
+renders one indexable page per capability under `/capabilities/`.
+
+> **The going-forward contract.** Adding a new algorithm to the website is two steps:
+> 1. **Publish** its results as a Hugging Face dataset (use the `hf-dataset-publishing`
+>    skill in `workspace-hub`).
+> 2. **Register** it — add one entry to `config/capabilities.yaml`.
+>
+> CI validates every entry (see [C7](https://github.com/vamseeachanta/aceengineer-website/issues/54)).
+> No per-algorithm website code is required.
+>
+> Epic: [workspace-hub#3485](https://github.com/vamseeachanta/workspace-hub/issues/3485).
+
+## Why Hugging Face + build-time
+
+- The datasets-server `/rows` and `/splits` endpoints are **public, CORS-enabled, and
+  need no auth** — the static site pulls data with no backend and no secrets.
+- Fetching at **build time** bakes SEO-indexable static pages, keeps the site fast, and
+  makes it **resilient to HF downtime** (a committed last-good snapshot survives an
+  outage — see [C2](https://github.com/vamseeachanta/aceengineer-website/issues/50)).
+- Freshness comes from **rebuild-on-publish**: publishing a dataset pings a Vercel Deploy
+  Hook ([C5](https://github.com/vamseeachanta/workspace-hub/issues/3488)). An optional
+  client-side "refresh to latest" is progressive enhancement only
+  ([C6](https://github.com/vamseeachanta/aceengineer-website/issues/53)).
+
+## Schema
+
+```yaml
+version: 1
+capabilities:
+  - id: <kebab-case>          # required · stable URL slug → /capabilities/<id>
+    title: <string>           # required · unique, SEO-friendly page title
+    domain: worldenergy|digitalmodel   # required
+    summary: <string>         # required · one sentence
+    hf_dataset: <owner/name>  # required · Hugging Face dataset id
+    provenance_url: <url>     # required · source repo/report
+    status: live|pending|withheld      # required
+    primary_config: <config>  # required · table whose headline stat is on the card
+    tables:                   # required · one or more
+      - config: <config>              # required · HF dataset config (table) name
+        label: <string>               # required · section label
+        viz: table|bar|line|map       # required
+        highlight_columns: [<col>...] # required · must exist in the table
+    withheld_columns: [<col>...]      # optional · never surfaced; CI blocks them
+    data_limits: <string>     # required · honest coverage/limitations disclosure
+```
+
+### `status` semantics
+
+| status     | rendered? | behavior |
+|------------|-----------|----------|
+| `live`     | yes       | full page with real HF data |
+| `pending`  | placeholder | visible "— pending" card linking to `provenance_url` (never a silent gap) |
+| `withheld` | no        | entry kept for the record but not surfaced (e.g. data-correctness hold) |
+
+## Validation
+
+`scripts/validate-capabilities.js` performs **offline structural** validation
+(required fields, enum values, unique ids, `highlight_columns` not in
+`withheld_columns`). Run it locally:
+
+```bash
+npm run validate:capabilities
+```
+
+**Online** resolution — that every `hf_dataset` and `config` actually resolves via the
+datasets-server `/splits` API, and that no `withheld_columns` leak into rendered output —
+is enforced in CI by [C7](https://github.com/vamseeachanta/aceengineer-website/issues/54).
+
+## Adding a capability (checklist)
+
+1. Publish the dataset to `aceengineer/<repo>-<projection>` (public) via the skill.
+2. **Sanity-check the numbers** before publishing — "faithful to source" ≠ "correct"
+   (lesson from worldenergydata#971).
+3. Add an entry here with accurate `highlight_columns` (copy real column names from the
+   dataset's `/rows` response).
+4. `npm run validate:capabilities` → green.
+5. Open the PR; CI resolves the dataset and blocks withheld columns.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "node build.js",
     "serve": "npx serve dist",
     "lint:copy": "node scripts/lint-copy.js",
+    "validate:capabilities": "node scripts/validate-capabilities.js",
     "test": "jest",
     "test:coverage": "jest --coverage"
   },
@@ -18,6 +19,11 @@
         "displayName": "copy-lint",
         "testEnvironment": "node",
         "testMatch": ["<rootDir>/tests/js/copy-lint.test.js"]
+      },
+      {
+        "displayName": "capabilities-registry",
+        "testEnvironment": "node",
+        "testMatch": ["<rootDir>/tests/js/capabilities-registry.test.js"]
       },
       {
         "displayName": "jsdom",

--- a/scripts/validate-capabilities.js
+++ b/scripts/validate-capabilities.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * validate-capabilities.js — offline structural validation of config/capabilities.yaml.
+ *
+ * The registry is the SSOT for the HF-backed capability pages (docs/capabilities-registry.md,
+ * epic workspace-hub#3485). This gate catches malformed entries before build/CI:
+ *   - required fields present, correct types
+ *   - `domain`, `status`, and each table `viz` are within their allowed enums
+ *   - `id`s are unique and kebab-case
+ *   - each capability has at least one table, and `primary_config` names a real table
+ *   - no `highlight_columns` entry is also in `withheld_columns` (would leak a held column)
+ *
+ * It does NOT hit the network. Online resolution (dataset/config exist via the
+ * datasets-server /splits API; no withheld column reaches rendered output) is the
+ * CI gate in C7 (aceengineer-website#54).
+ *
+ *   node scripts/validate-capabilities.js     # or: npm run validate:capabilities
+ *
+ * Exit 0 = valid ("validate:capabilities PASS"), exit 1 = errors printed.
+ */
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const repoRoot = path.resolve(__dirname, '..');
+const DEFAULT_REGISTRY = path.join(repoRoot, 'config', 'capabilities.yaml');
+
+const DOMAINS = ['worldenergy', 'digitalmodel'];
+const STATUSES = ['live', 'pending', 'withheld'];
+const VIZ = ['table', 'bar', 'line', 'map'];
+const KEBAB = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+// Load + parse the registry. Returns the parsed object (throws on unreadable/invalid YAML).
+function loadRegistry(registryFile = DEFAULT_REGISTRY) {
+  const raw = fs.readFileSync(registryFile, 'utf8');
+  return yaml.load(raw) || {};
+}
+
+// Validate a parsed registry object. Returns an array of human-readable error strings
+// (empty === valid). Pure/offline so build.js and tests can reuse it.
+function validateRegistry(registry) {
+  const errors = [];
+  if (!registry || typeof registry !== 'object') {
+    return ['registry is empty or not an object'];
+  }
+  if (registry.version !== 1) {
+    errors.push(`version must be 1 (got ${JSON.stringify(registry.version)})`);
+  }
+  const caps = registry.capabilities;
+  if (!Array.isArray(caps) || caps.length === 0) {
+    errors.push('capabilities must be a non-empty array');
+    return errors;
+  }
+
+  const seenIds = new Set();
+  caps.forEach((cap, i) => {
+    const where = `capabilities[${i}]${cap && cap.id ? ` (${cap.id})` : ''}`;
+    const req = (field, type = 'string') => {
+      const v = cap[field];
+      if (v === undefined || v === null || (type === 'string' && String(v).trim() === '')) {
+        errors.push(`${where}: missing required field '${field}'`);
+        return false;
+      }
+      return true;
+    };
+
+    if (req('id')) {
+      if (!KEBAB.test(cap.id)) errors.push(`${where}: id must be kebab-case`);
+      if (seenIds.has(cap.id)) errors.push(`${where}: duplicate id '${cap.id}'`);
+      seenIds.add(cap.id);
+    }
+    req('title');
+    req('summary');
+    req('hf_dataset');
+    req('provenance_url');
+    req('data_limits');
+
+    if (req('domain') && !DOMAINS.includes(cap.domain)) {
+      errors.push(`${where}: domain must be one of ${DOMAINS.join('|')} (got '${cap.domain}')`);
+    }
+    if (req('status') && !STATUSES.includes(cap.status)) {
+      errors.push(`${where}: status must be one of ${STATUSES.join('|')} (got '${cap.status}')`);
+    }
+
+    const withheld = new Set(Array.isArray(cap.withheld_columns) ? cap.withheld_columns : []);
+
+    const tables = cap.tables;
+    if (!Array.isArray(tables) || tables.length === 0) {
+      errors.push(`${where}: 'tables' must be a non-empty array`);
+    } else {
+      const configNames = new Set();
+      tables.forEach((t, j) => {
+        const tw = `${where}.tables[${j}]`;
+        if (!t || typeof t !== 'object') { errors.push(`${tw}: not an object`); return; }
+        if (!t.config) errors.push(`${tw}: missing 'config'`);
+        else configNames.add(t.config);
+        if (!t.label) errors.push(`${tw}: missing 'label'`);
+        if (!VIZ.includes(t.viz)) errors.push(`${tw}: viz must be one of ${VIZ.join('|')} (got '${t.viz}')`);
+        if (!Array.isArray(t.highlight_columns) || t.highlight_columns.length === 0) {
+          errors.push(`${tw}: highlight_columns must be a non-empty array`);
+        } else {
+          t.highlight_columns
+            .filter(c => withheld.has(c))
+            .forEach(c => errors.push(`${tw}: highlight column '${c}' is also in withheld_columns`));
+        }
+      });
+      if (req('primary_config') && !configNames.has(cap.primary_config)) {
+        errors.push(`${where}: primary_config '${cap.primary_config}' is not among this capability's tables`);
+      }
+    }
+  });
+
+  return errors;
+}
+
+// CLI entry
+function main() {
+  const registryFile = process.argv[2] || DEFAULT_REGISTRY;
+  let registry;
+  try {
+    registry = loadRegistry(registryFile);
+  } catch (err) {
+    console.error(`validate:capabilities FAIL — cannot read/parse ${registryFile}: ${err.message}`);
+    process.exit(1);
+  }
+  const errors = validateRegistry(registry);
+  if (errors.length) {
+    console.error('validate:capabilities FAIL');
+    errors.forEach(e => console.error(`  - ${e}`));
+    process.exit(1);
+  }
+  const n = registry.capabilities.length;
+  console.log(`validate:capabilities PASS — ${n} capabilit${n === 1 ? 'y' : 'ies'} valid`);
+}
+
+if (require.main === module) main();
+
+module.exports = { loadRegistry, validateRegistry, DEFAULT_REGISTRY, DOMAINS, STATUSES, VIZ };

--- a/tests/js/capabilities-registry.test.js
+++ b/tests/js/capabilities-registry.test.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const {
+  loadRegistry,
+  validateRegistry,
+  DEFAULT_REGISTRY,
+} = require('../../scripts/validate-capabilities');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const validateScript = path.join(repoRoot, 'scripts', 'validate-capabilities.js');
+
+function runValidate(file) {
+  const args = [validateScript];
+  if (file) args.push(file);
+  try {
+    const stdout = execFileSync('node', args, { cwd: repoRoot, encoding: 'utf8' });
+    return { code: 0, stdout };
+  } catch (err) {
+    return { code: err.status, stdout: (err.stdout || '') + (err.stderr || '') };
+  }
+}
+
+describe('config/capabilities.yaml', () => {
+  test('exists, parses, and passes structural validation', () => {
+    const registry = loadRegistry(DEFAULT_REGISTRY);
+    expect(registry.version).toBe(1);
+    expect(Array.isArray(registry.capabilities)).toBe(true);
+    expect(registry.capabilities.length).toBeGreaterThan(0);
+    expect(validateRegistry(registry)).toEqual([]);
+  });
+
+  test('is seeded with the World Energy Field Explorer entry', () => {
+    const registry = loadRegistry(DEFAULT_REGISTRY);
+    const explorer = registry.capabilities.find(c => c.id === 'field-explorer');
+    expect(explorer).toBeDefined();
+    expect(explorer.hf_dataset).toBe('aceengineer/worldenergydata-explorer');
+    expect(explorer.domain).toBe('worldenergy');
+    expect(explorer.tables.map(t => t.config).sort()).toEqual(['countries', 'fields', 'wells']);
+    // economics stays withheld until worldenergydata#978 re-verifies it
+    expect(explorer.withheld_columns).toEqual(expect.arrayContaining(['npv_mm', 'breakeven_wti']));
+  });
+
+  test('CLI exits 0 with PASS on the real registry', () => {
+    const { code, stdout } = runValidate();
+    expect(stdout).toContain('validate:capabilities PASS');
+    expect(code).toBe(0);
+  });
+});
+
+describe('validateRegistry catches malformed entries', () => {
+  const base = () => ({
+    version: 1,
+    capabilities: [{
+      id: 'x', title: 'X', domain: 'worldenergy', summary: 's',
+      hf_dataset: 'aceengineer/x', provenance_url: 'u', status: 'live',
+      primary_config: 'main', data_limits: 'd',
+      tables: [{ config: 'main', label: 'Main', viz: 'table', highlight_columns: ['a'] }],
+    }],
+  });
+
+  test('flags a bad domain enum', () => {
+    const r = base(); r.capabilities[0].domain = 'aerospace';
+    expect(validateRegistry(r).some(e => /domain must be one of/.test(e))).toBe(true);
+  });
+
+  test('flags a bad viz enum', () => {
+    const r = base(); r.capabilities[0].tables[0].viz = 'pie';
+    expect(validateRegistry(r).some(e => /viz must be one of/.test(e))).toBe(true);
+  });
+
+  test('flags duplicate ids', () => {
+    const r = base(); r.capabilities.push({ ...r.capabilities[0] });
+    expect(validateRegistry(r).some(e => /duplicate id/.test(e))).toBe(true);
+  });
+
+  test('flags primary_config not among tables', () => {
+    const r = base(); r.capabilities[0].primary_config = 'nope';
+    expect(validateRegistry(r).some(e => /primary_config/.test(e))).toBe(true);
+  });
+
+  test('flags a highlight column that is also withheld (leak guard)', () => {
+    const r = base();
+    r.capabilities[0].withheld_columns = ['a'];
+    expect(validateRegistry(r).some(e => /also in withheld_columns/.test(e))).toBe(true);
+  });
+
+  test('CLI exits 1 with FAIL on a malformed registry fixture', () => {
+    const tmp = path.join(repoRoot, 'tests', 'js', '__tmp_bad_registry.yaml');
+    fs.writeFileSync(tmp, 'version: 1\ncapabilities:\n  - id: BAD_ID\n    title: t\n');
+    try {
+      const { code, stdout } = runValidate(tmp);
+      expect(code).toBe(1);
+      expect(stdout).toContain('validate:capabilities FAIL');
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+});


### PR DESCRIPTION
Implements **C1** of epic vamseeachanta/workspace-hub#3485 — the registry SSOT that drives HF-backed capability pages on aceengineer.com. **Closes #49.**

## What this adds
- **`config/capabilities.yaml`** — the single source of truth. Each entry maps an algorithm/product to its Hugging Face dataset + which tables/columns to render. Seeded with the live `aceengineer/worldenergydata-explorer` dataset (fields / wells / countries) using **real column names** pulled from the datasets-server `/rows` API.
- **`build.js`** — adds a cached `loadCapabilities()` loader (mirrors the existing `loadCopy()`) and exports it. **No change to current build output** — the render layer consumes it in C2–C4.
- **`scripts/validate-capabilities.js`** + `npm run validate:capabilities` — offline structural validation (required fields, enum checks, unique kebab-case ids, `primary_config` resolves, and a **leak guard**: no `highlight_columns` entry may also be `withheld`).
- **`tests/js/capabilities-registry.test.js`** — registered as its own jest project so **CI actually runs it** (this repo has previously had contract tests added but not executed by CI — avoided here).
- **`docs/capabilities-registry.md`** — schema + the going-forward "publish + 1 line" contract.

## The going-forward contract
Adding a new algorithm to the website becomes: **publish its HF dataset** (existing `hf-dataset-publishing` skill) **+ add one entry here**. CI (C7, #54) will enforce that the dataset/config resolve and that no withheld column leaks. The website becomes a *function of this file* — no per-algorithm website code.

## Data-correctness note
Economics columns (`npv_mm`, `breakeven_wti`) are listed in `withheld_columns` and are not surfaced. worldenergydata#971 (the sign/units error) is fixed; re-enabling them is deliberately gated to the C9 verification lane (worldenergydata#978).

## Verification
- `npm run build` — succeeds, output unchanged.
- `npm test` — **198/198 across 12 projects** (new `capabilities-registry` project included).
- `npm run validate:capabilities` — `PASS — 1 capability valid`.

Follow-on lanes: C2 build-time HF client (#50) · C3 index+cards (#51) · C4 detail template (#52).
