### PR TITLE
feat(capabilities): /capabilities index + card grid from registry [C3]

### DIFF
--- a/build.js
+++ b/build.js
@@ -7,9 +7,14 @@ const yaml = require('js-yaml');
 const { PurgeCSS } = require('purgecss');
 const CleanCSS = require('clean-css');
 const hf = require('./scripts/hf-fetch');
+const { renderCards } = require('./scripts/render-capabilities');
 
 const srcDir = './content';
 const distDir = './dist';
+
+// Rendered capability cards (C3, #51), computed once at build start from the hydrated
+// registry and injected into every page as the `capabilitiesCards` template local.
+let _capabilitiesCards = '';
 
 // Load canonical firm-copy (brand/copy.yaml) — single source of truth (issue #9).
 // Exposed to every page as the `copy` template object, e.g. {{ copy.firm_lede }}.
@@ -115,6 +120,12 @@ async function processFile(filePath) {
     locals.copy = loadCopy();
   }
 
+  // Expose the rendered capability cards (C3) to any page that wants them
+  // (content/capabilities/index.html uses {{{ capabilitiesCards }}}).
+  if (locals.capabilitiesCards === undefined) {
+    locals.capabilitiesCards = _capabilitiesCards;
+  }
+
   // Process includes first, then expressions (so included content gets variables expanded)
   const result = await posthtml([
     include({ root: srcDir }),
@@ -170,6 +181,19 @@ async function build() {
   }
   fs.mkdirSync(distDir);
 
+  // Hydrate the capability registry (C2) and render its cards (C3) before processing
+  // pages, so content/capabilities/index.html can inject them. Never fails the build.
+  try {
+    const reg = await loadHydratedCapabilities();
+    _capabilitiesCards = renderCards(reg);
+    const tables = (reg.capabilities || []).flatMap(c => c.tables || []);
+    const bySource = tables.reduce((a, t) => { a[t.data_source] = (a[t.data_source] || 0) + 1; return a; }, {});
+    console.log(`Capabilities: ${(reg.capabilities || []).length} registered · ${tables.length} tables · sources ${JSON.stringify(bySource)}`);
+  } catch (err) {
+    _capabilitiesCards = '';
+    console.warn(`Capabilities render skipped: ${err.message}`);
+  }
+
   // Process all HTML files
   const files = getHtmlFiles(srcDir);
   for (const file of files) {
@@ -180,19 +204,6 @@ async function build() {
   copyAssets();
   copySitemap();
   copyRobotsTxt();
-
-  // Warm the capability registry data (C2, #50): hydrate each table from committed
-  // snapshots (or live if HF_FETCH=1) and report the data source so failures surface.
-  // Page rendering from this data is C3/C4; here we only validate + wire it in.
-  try {
-    const reg = await loadHydratedCapabilities();
-    const caps = reg.capabilities || [];
-    const tables = caps.flatMap(c => c.tables || []);
-    const bySource = tables.reduce((a, t) => { a[t.data_source] = (a[t.data_source] || 0) + 1; return a; }, {});
-    console.log(`Capabilities: ${caps.length} registered · ${tables.length} tables · sources ${JSON.stringify(bySource)}`);
-  } catch (err) {
-    console.warn(`Capabilities hydration skipped: ${err.message}`);
-  }
 
   console.log(`\nBuild complete! ${files.length} pages built.`);
 }

--- a/content/capabilities/index.html
+++ b/content/capabilities/index.html
@@ -1,0 +1,62 @@
+---
+rootPath: "../"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Live engineering and energy-data capabilities from AceEngineer — each backed by a public Hugging Face dataset you can explore and download.">
+    <meta name="keywords" content="offshore engineering datasets, energy data, Hugging Face datasets, field development, digital model, world energy data, open data">
+
+    <meta property="og:title" content="Capabilities — Live, Data-Backed | AceEngineer">
+    <meta property="og:description" content="Every AceEngineer capability is backed by a public Hugging Face dataset — explore fields, wells, and engineering results directly.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aceengineer.com/capabilities/">
+    <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Capabilities — Live, Data-Backed | AceEngineer">
+    <meta name="twitter:description" content="Engineering and energy-data capabilities, each backed by a public Hugging Face dataset.">
+
+    <title>Capabilities — Live, Data-Backed | AceEngineer</title>
+
+    <include src="partials/head-common.html"></include>
+</head>
+<body>
+
+    <include src="partials/nav.html"></include>
+
+    <section class="hero-section" style="padding-bottom:28px;">
+        <div class="container">
+            <h1 style="margin-bottom:10px;">Capabilities, backed by live data</h1>
+            <p style="font-size:1.15rem;color:#444;max-width:760px;">
+                Each capability below is powered by a public
+                <a href="https://huggingface.co/aceengineer" rel="noopener">Hugging Face dataset</a>
+                that we publish from our engineering and energy-data pipelines. The numbers are the
+                real published records — explore or download them directly. New algorithms are added
+                here automatically as we ship them.
+            </p>
+        </div>
+    </section>
+
+    <section style="padding:8px 0 56px;">
+        <div class="container">
+            {{{ capabilitiesCards }}}
+        </div>
+    </section>
+
+    <section style="padding:40px 0;background:#f8f9fa;">
+        <div class="container" style="max-width:820px;">
+            <h2 style="font-size:1.3rem;">How this works</h2>
+            <p style="color:#555;">
+                We publish analysis results as versioned datasets on Hugging Face, then this site
+                renders them at build time — so what you see is the same data our tools produce,
+                with provenance and honest coverage notes. Data is refreshed as pipelines run.
+            </p>
+        </div>
+    </section>
+
+    <include src="partials/footer.html"></include>
+
+</body>
+</html>

--- a/content/energy.html
+++ b/content/energy.html
@@ -170,6 +170,12 @@
 
         <p>The various areas of solutions are below.</p>
 
+        <p style="padding:14px 18px;background:#eef5f2;border-left:4px solid #0b6e4f;border-radius:6px;">
+            📊 <strong>See the data behind the work:</strong>
+            our <a href="capabilities/">live capabilities</a> are each backed by a public
+            Hugging Face dataset you can explore and download.
+        </p>
+
         <h2>Field Development</h2>
         <p>Field economics analysis and development decision support using BSEE production data and industry-standard financial modeling.</p>
         <ul>

--- a/content/engineering.html
+++ b/content/engineering.html
@@ -84,6 +84,7 @@
                     <div class="hero-cta">
                         <a href="contact.html" class="btn btn-primary btn-lg">Schedule a Demo</a>
                         <a href="#pricing" class="btn btn-default btn-lg">See Pricing</a>
+                        <a href="capabilities/" class="btn btn-default btn-lg">Explore Live Data</a>
                     </div>
                 </div>
             </div>

--- a/content/partials/nav.html
+++ b/content/partials/nav.html
@@ -19,6 +19,7 @@
                 <li><a href="{{ rootPath }}proof.html">Proof</a></li>
                 <li><a href="{{ rootPath }}vision.html">Vision</a></li>
                 <li><a href="{{ rootPath }}calculators/">Calculators</a></li>
+                <li><a href="{{ rootPath }}capabilities/">Capabilities</a></li>
                 <li><a href="{{ rootPath }}about.html">Company</a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
         "testMatch": ["<rootDir>/tests/js/hf-fetch.test.js"]
       },
       {
+        "displayName": "render-capabilities",
+        "testEnvironment": "node",
+        "testMatch": ["<rootDir>/tests/js/render-capabilities.test.js"]
+      },
+      {
         "displayName": "jsdom",
         "testEnvironment": "jsdom",
         "testMatch": ["<rootDir>/tests/js/navbar-toggle.test.js"]
@@ -80,6 +85,7 @@
     "collectCoverageFrom": [
       "build.js",
       "scripts/hf-fetch.js",
+      "scripts/render-capabilities.js",
       "assets/js/navbar-toggle.js",
       "assets/js/cta-tracking.js",
       "assets/js/npv-calculator-engine.js",

--- a/scripts/render-capabilities.js
+++ b/scripts/render-capabilities.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * render-capabilities.js — render the capability registry into HTML for the website.
+ *
+ * C3 (aceengineer-website#51), epic workspace-hub#3485. Pure functions (no I/O) so they
+ * are unit-testable; build.js injects the output into content/capabilities/index.html as
+ * the `capabilitiesCards` template local. Cards use inline styles + existing container
+ * classes so PurgeCSS can't strip them.
+ *
+ * Each card links to the capability's data on Hugging Face (a real, live target today).
+ * When the per-capability detail pages land (C4, #52), the primary link flips to the
+ * internal /capabilities/<id>.html page.
+ *
+ * Data comes from the hydrated registry (C2): each table carries `data` (columns/rows/
+ * total_rows) + `data_source` ('live' | 'snapshot' | 'unavailable').
+ */
+
+const DOMAIN_LABELS = {
+  worldenergy: 'World Energy',
+  digitalmodel: 'Digital Model',
+};
+const DOMAIN_COLORS = {
+  worldenergy: '#0b6e4f',
+  digitalmodel: '#1d4e89',
+};
+
+function escapeHtml(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function hfDatasetUrl(dataset) {
+  return `https://huggingface.co/datasets/${dataset}`;
+}
+
+// Per-table row counts for the little stat strip, e.g. [{count: 10, label: 'fields'}].
+function tableStats(cap) {
+  return (cap.tables || []).map(t => ({
+    count: t.data && typeof t.data.total_rows === 'number' ? t.data.total_rows : null,
+    label: t.label || t.config,
+    truncated: !!(t.data && t.data.truncated),
+  }));
+}
+
+// True when at least one table actually has data to show.
+function hasData(cap) {
+  return (cap.tables || []).some(t => t.data && Array.isArray(t.data.rows) && t.data.rows.length);
+}
+
+function renderStatStrip(cap) {
+  const stats = tableStats(cap).filter(s => s.count != null);
+  if (!stats.length) return '';
+  const items = stats.map(s =>
+    `<span style="display:inline-block;margin-right:18px;">` +
+    `<strong style="font-size:1.4rem;color:#111;">${s.count.toLocaleString('en-US')}</strong> ` +
+    `<span style="color:#555;">${escapeHtml(s.label)}</span></span>`
+  ).join('');
+  return `<div style="margin:14px 0 10px;">${items}</div>`;
+}
+
+function renderCard(cap) {
+  const domainLabel = DOMAIN_LABELS[cap.domain] || cap.domain;
+  const domainColor = DOMAIN_COLORS[cap.domain] || '#444';
+  const pending = cap.status === 'pending' || !hasData(cap);
+
+  const badge =
+    `<span style="display:inline-block;background:${domainColor};color:#fff;font-size:.72rem;` +
+    `font-weight:600;letter-spacing:.04em;text-transform:uppercase;padding:3px 10px;border-radius:999px;">` +
+    `${escapeHtml(domainLabel)}</span>`;
+
+  // Live vs pending body
+  let body;
+  let cta;
+  if (pending) {
+    body =
+      `<p style="color:#555;margin:12px 0 6px;">${escapeHtml(cap.summary)}</p>` +
+      `<p style="color:#a15c00;font-size:.9rem;margin:8px 0;">— data pending publication</p>`;
+    cta =
+      `<a href="${escapeHtml(cap.provenance_url)}" style="font-weight:600;color:${domainColor};">` +
+      `Follow progress →</a>`;
+  } else {
+    body =
+      `<p style="color:#555;margin:12px 0 4px;">${escapeHtml(cap.summary)}</p>` +
+      renderStatStrip(cap) +
+      `<p style="color:#777;font-size:.82rem;margin:6px 0 0;">${escapeHtml(cap.data_limits || '')}</p>`;
+    cta =
+      `<a href="${escapeHtml(hfDatasetUrl(cap.hf_dataset))}" rel="noopener" ` +
+      `style="font-weight:600;color:${domainColor};">Explore data on Hugging Face →</a>`;
+  }
+
+  return (
+    `<article style="background:#fff;border:1px solid #e6e8eb;border-radius:12px;padding:24px;` +
+    `box-shadow:0 1px 3px rgba(0,0,0,.05);display:flex;flex-direction:column;height:100%;">` +
+    `<div style="margin-bottom:8px;">${badge}</div>` +
+    `<h3 style="margin:6px 0 0;font-size:1.35rem;color:#111;">${escapeHtml(cap.title)}</h3>` +
+    `<div style="flex:1 1 auto;">${body}</div>` +
+    `<div style="margin-top:16px;">${cta}</div>` +
+    `</article>`
+  );
+}
+
+// Render the full grid. `registry` is the hydrated { version, capabilities: [...] }.
+function renderCards(registry) {
+  const caps = (registry && registry.capabilities || []).filter(c => c.status !== 'withheld');
+  if (!caps.length) {
+    return `<p style="color:#777;">No capabilities published yet.</p>`;
+  }
+  const cards = caps.map(cap =>
+    `<div style="flex:1 1 340px;max-width:520px;">${renderCard(cap)}</div>`
+  ).join('\n');
+  return `<div style="display:flex;flex-wrap:wrap;gap:24px;align-items:stretch;">\n${cards}\n</div>`;
+}
+
+module.exports = {
+  escapeHtml, hfDatasetUrl, tableStats, hasData,
+  renderStatStrip, renderCard, renderCards,
+  DOMAIN_LABELS,
+};

--- a/tests/js/render-capabilities.test.js
+++ b/tests/js/render-capabilities.test.js
@@ -1,0 +1,74 @@
+const fs = require('fs');
+const path = require('path');
+const { escapeHtml, renderCard, renderCards, hfDatasetUrl } = require('../../scripts/render-capabilities');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+// A hydrated-registry fixture (shape produced by C2's hydrateRegistry).
+function liveCap(over = {}) {
+  return {
+    id: 'field-explorer', title: 'World Energy Field Explorer', domain: 'worldenergy',
+    summary: 'Global offshore field drill-down.', hf_dataset: 'aceengineer/worldenergydata-explorer',
+    provenance_url: 'https://github.com/vamseeachanta/worldenergydata', status: 'live',
+    data_limits: 'Coverage is primarily US Gulf of Mexico.',
+    tables: [
+      { config: 'fields', label: 'Fields', data: { total_rows: 10, rows: [{ a: 1 }] }, data_source: 'snapshot' },
+      { config: 'wells', label: 'Wells', data: { total_rows: 56, rows: [{ a: 1 }] }, data_source: 'snapshot' },
+    ],
+    ...over,
+  };
+}
+
+describe('escapeHtml', () => {
+  test('escapes HTML-significant characters', () => {
+    expect(escapeHtml('<a href="x">&</a>')).toBe('&lt;a href=&quot;x&quot;&gt;&amp;&lt;/a&gt;');
+  });
+});
+
+describe('renderCard (live)', () => {
+  const html = renderCard(liveCap());
+  test('shows title, domain label, and the HF explore link', () => {
+    expect(html).toContain('World Energy Field Explorer');
+    expect(html).toContain('World Energy');
+    expect(html).toContain(hfDatasetUrl('aceengineer/worldenergydata-explorer'));
+    expect(html).toContain('Explore data on Hugging Face');
+  });
+  test('shows per-table stat counts and the data-limits note', () => {
+    expect(html).toContain('>10<');
+    expect(html).toContain('>56<');
+    expect(html).toContain('Coverage is primarily US Gulf of Mexico.');
+  });
+});
+
+describe('renderCard (pending / no data)', () => {
+  test('renders a placeholder linking to provenance, not an HF explore link', () => {
+    const html = renderCard(liveCap({ status: 'pending', tables: [{ config: 'x', label: 'X', data: null, data_source: 'unavailable' }] }));
+    expect(html).toContain('data pending');
+    expect(html).toContain('Follow progress');
+    expect(html).toContain('github.com/vamseeachanta/worldenergydata');
+    expect(html).not.toContain('Explore data on Hugging Face');
+  });
+});
+
+describe('renderCards', () => {
+  test('filters out withheld capabilities', () => {
+    const reg = { capabilities: [liveCap(), liveCap({ id: 'secret', title: 'Secret', status: 'withheld' })] };
+    const html = renderCards(reg);
+    expect(html).toContain('World Energy Field Explorer');
+    expect(html).not.toContain('Secret');
+  });
+  test('handles an empty registry', () => {
+    expect(renderCards({ capabilities: [] })).toContain('No capabilities');
+  });
+});
+
+describe('page wiring', () => {
+  test('content/capabilities/index.html injects the capabilitiesCards local', () => {
+    const src = fs.readFileSync(path.join(repoRoot, 'content', 'capabilities', 'index.html'), 'utf8');
+    expect(src).toContain('{{{ capabilitiesCards }}}');
+  });
+  test('nav links to the capabilities page', () => {
+    const nav = fs.readFileSync(path.join(repoRoot, 'content', 'partials', 'nav.html'), 'utf8');
+    expect(nav).toContain('capabilities/');
+  });
+});


### PR DESCRIPTION
Implements **C3** of epic vamseeachanta/workspace-hub#3485 — the first *visible* capability surface on the site. **Closes #51.** Builds on C1 (#55) + C2 (#56).

## What ships
- **`content/capabilities/index.html`** — a new `/capabilities/` page (reuses the site chrome: head/nav/footer partials) that renders one card per registered capability.
- **`scripts/render-capabilities.js`** — a **pure, unit-tested** renderer. Each card shows: domain badge, title, summary, **live per-table row counts** (10 fields / 56 wells / 84 countries, straight from the hydrated snapshot), a data-limits note, and a link to the dataset on Hugging Face.
- **`build.js`** — computes the cards once at build start from the hydrated registry (C2) and injects them as the `capabilitiesCards` template local.
- **Discoverability** — a `Capabilities` link in the shared nav, plus callouts on `energy.html` and `engineering.html`.

## Guardrails honored
- **Placeholder-links-to-issue**: a `pending`/no-data capability renders a visible "— data pending" card linking to its provenance, never a silent omission.
- **Withheld** capabilities are filtered out entirely.
- Inline styles so PurgeCSS can't strip the card styling.

## Interim link target (flips in C4)
Cards currently link to the capability's **Hugging Face dataset** (a real, live target today). When the per-capability detail pages land in **C4 (#52)**, the primary link flips to the internal `/capabilities/<id>.html` page. This keeps every merge shippable with zero 404s.

## Verification
- `npm run build` → renders `capabilities/index.html` (92 pages), `sources {"snapshot":3}`.
- `python3 scripts/maintenance/verify_repo_structure.py` → OK.
- `npm test` → **215/215 across 14 projects** (new `render-capabilities` project; nav/copy-lint/demo-link tests still green).

Follow-on: C4 detail pages with table + chart (#52).
