### PR TITLE
feat(design): Subsea7-themed, capabilities-first homepage + new logo

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,0 +1,104 @@
+/* theme.css — Subsea7 "deterministically simple" theme for aceengineer.com.
+ * Loaded last in the bundle so it overrides bootstrap/marketing where needed.
+ * Palette + type extracted from the FDG pre-read one-pager (deep petrol-navy
+ * structure + teal signature accent, serif body + uppercase-sans labels).
+ * No literal "AI" anywhere in copy — "deterministic engineering workflows". */
+
+:root {
+  --navy:      #0b3d5c;   /* primary / structure / links */
+  --navy-2:    #0B3D91;   /* brighter logo navy */
+  --teal:      #2BB2A6;   /* signature accent */
+  --teal-deep: #0e7e88;   /* accent rule / worldenergy domain */
+  --blue:      #2364aa;   /* emphasis */
+  --ink:       #26323a;   /* body text */
+  --muted:     #5a6b76;   /* captions / footer */
+  --tint:      #eef4f8;   /* anchor / callout bg */
+  --hairline:  #d0d7de;   /* dividers */
+  --underline: #b8c9d4;   /* link underline */
+  --bg:        #ffffff;
+
+  --font-body: Georgia, 'Times New Roman', serif;
+  --font-ui:   'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+/* ---- Capabilities-focused surfaces opt in via .theme-page on <body> ---- */
+.theme-page {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font-body);
+  line-height: 1.55;
+}
+.theme-page h1, .theme-page h2, .theme-page h3 { font-family: var(--font-ui); color: var(--navy); }
+.theme-page b, .theme-page strong { color: var(--navy); }         /* emphasis = navy, not just bold */
+.theme-page .kicker {
+  font-family: var(--font-ui); text-transform: uppercase; letter-spacing: 1.5px;
+  font-weight: 700; color: var(--teal-deep); font-size: .8rem; margin: 0 0 6px;
+}
+.theme-page .section-label {
+  font-family: var(--font-ui); text-transform: uppercase; letter-spacing: .8px;
+  color: var(--navy); font-size: .95rem; border-bottom: 1px solid var(--hairline);
+  padding-bottom: 4px; margin: 0 0 18px;
+}
+.theme-page .mantra { font-style: italic; color: var(--navy); font-size: 1.25rem; }
+
+/* Anchor / callout box — the signature takeaway component */
+.callout {
+  background: var(--tint);
+  border-left: 5px solid var(--navy);
+  border-radius: 0 6px 6px 0;
+  padding: 14px 18px;
+  color: var(--ink);
+}
+
+/* Understated, non-buttony links */
+.theme-page .link-quiet {
+  color: var(--navy); font-weight: 600; text-decoration: underline;
+  text-decoration-color: var(--underline); text-underline-offset: 2px;
+}
+
+/* Primary CTA — "Use it for free" */
+.btn-free {
+  display: inline-block; background: var(--teal); color: #063b38;
+  font-family: var(--font-ui); font-weight: 700; letter-spacing: .2px;
+  padding: 12px 24px; border-radius: 8px; text-decoration: none;
+  border: 1px solid var(--teal-deep);
+}
+.btn-free:hover { background: var(--teal-deep); color: #fff; text-decoration: none; }
+.btn-ghost {
+  display: inline-block; background: transparent; color: var(--navy);
+  font-family: var(--font-ui); font-weight: 600; padding: 12px 22px;
+  border-radius: 8px; text-decoration: none; border: 1px solid var(--hairline);
+}
+.btn-ghost:hover { border-color: var(--navy); text-decoration: none; }
+
+/* Two-layer "lookup on top / rigorous underneath" panel (the iceberg motif) */
+.layers { max-width: 720px; margin: 0 auto; border-radius: 10px; overflow: hidden; border: 1px solid var(--hairline); }
+.layers .surface { background: #f4fbfa; padding: 20px 22px; }
+.layers .surface .row {
+  display: flex; align-items: center; gap: 12px; font-family: var(--font-mono);
+  font-size: 1rem; color: var(--navy);
+}
+.layers .surface .row .arrow { color: var(--teal-deep); font-weight: 700; }
+.layers .depth {
+  background: var(--navy); color: #dceaf2; padding: 18px 22px;
+  font-family: var(--font-mono); font-size: .9rem; line-height: 1.5;
+}
+.layers .depth .waterline-note { color: var(--teal); font-family: var(--font-ui); font-size: .78rem;
+  text-transform: uppercase; letter-spacing: 1px; margin-bottom: 8px; }
+
+/* Deterministic pipeline strip (monospace flow) */
+.flow {
+  background: #eef5f2; border: 1px solid #cddfd8; border-radius: 6px;
+  padding: 16px 20px; font-family: var(--font-mono); font-size: .95rem;
+  line-height: 1.5; color: var(--navy); overflow-x: auto;
+}
+
+/* Themed nav (navy) */
+.navbar-inverse.theme-nav { background: var(--navy); border: none; }
+.navbar-inverse.theme-nav .navbar-nav > li > a { color: #dce7ef; font-family: var(--font-ui); }
+.navbar-inverse.theme-nav .navbar-nav > li > a:hover { color: #fff; }
+.navbar-inverse.theme-nav .btn-nav-cta {
+  background: var(--teal); color: #063b38; border-radius: 6px; font-weight: 700;
+}
+.navbar-inverse.theme-nav .btn-nav-cta:hover { background: #fff; color: var(--navy); }

--- a/assets/img/logo.svg
+++ b/assets/img/logo.svg
@@ -1,18 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 160" role="img" aria-labelledby="title desc">
-  <title id="title">AceEngineer logo</title>
-  <desc id="desc">AceEngineer wordmark with angular engineering mark in plum and copper.</desc>
-  <defs>
-    <linearGradient id="aceGradient" x1="0" x2="1" y1="0" y2="1">
-      <stop offset="0" stop-color="#5E2B3D"/>
-      <stop offset="1" stop-color="#C25A2A"/>
-    </linearGradient>
-  </defs>
-  <rect width="640" height="160" rx="28" fill="#fff7f2"/>
-  <g transform="translate(34 30)">
-    <path d="M50 0 L100 100 H76 L64 74 H35 L23 100 H0 L50 0 Z M43 56 H56 L50 33 Z" fill="url(#aceGradient)"/>
-    <path d="M116 14 H184 V36 H141 V50 H178 V70 H141 V84 H186 V106 H116 Z" fill="#5E2B3D"/>
-    <path d="M202 14 H272 V38 H226 V82 H272 V106 H202 Z" fill="#C25A2A"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 160" role="img" aria-labelledby="logoTitle logoDesc">
+  <title id="logoTitle">AceEngineer</title>
+  <desc id="logoDesc">AceEngineer — Analytical &amp; Computational Engineering. Everyday complex engineering, made deterministically simple.</desc>
+  <!-- Mark: a simple lookup surface (teal) resting on the rigorous deterministic strata (navy).
+       "Simple at the point of use, rigorous underneath." Solid fills only for portability. -->
+  <g transform="translate(30 34)">
+    <!-- simple surface: one clean lookup cell (input -> answer) -->
+    <rect x="0" y="0" width="92" height="30" rx="6" fill="#2BB2A6"/>
+    <rect x="10" y="9" width="26" height="12" rx="2" fill="#ffffff" opacity="0.92"/>
+    <rect x="56" y="9" width="26" height="12" rx="2" fill="#0b3d5c"/>
+    <!-- waterline -->
+    <rect x="0" y="39" width="92" height="3" rx="1.5" fill="#0b3d5c"/>
+    <!-- rigorous strata beneath (deterministic layers, densifying) -->
+    <rect x="0" y="50" width="92" height="6" rx="3" fill="#0b3d5c"/>
+    <rect x="0" y="61" width="78" height="6" rx="3" fill="#0b3d5c" opacity="0.78"/>
+    <rect x="0" y="72" width="64" height="6" rx="3" fill="#0b3d5c" opacity="0.58"/>
+    <rect x="0" y="83" width="50" height="6" rx="3" fill="#0b3d5c" opacity="0.4"/>
   </g>
-  <text x="330" y="76" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="48" font-weight="700" fill="#3b1f2b">AceEngineer</text>
-  <text x="330" y="112" text-anchor="middle" font-family="Arial, sans-serif" font-size="17" letter-spacing="1.8" fill="#7a4a3c">ANALYTICAL &amp; COMPUTATIONAL ENGINEERING</text>
+  <!-- Wordmark -->
+  <text x="150" y="74" font-family="'Segoe UI', Helvetica, Arial, sans-serif" font-size="46" font-weight="700" letter-spacing="-0.5" fill="#0b3d5c">AceEngineer</text>
+  <text x="152" y="104" font-family="'Segoe UI', Helvetica, Arial, sans-serif" font-size="15" font-weight="600" letter-spacing="2.4" fill="#2BB2A6">MADE DETERMINISTICALLY SIMPLE</text>
 </svg>

--- a/build.js
+++ b/build.js
@@ -285,7 +285,7 @@ async function bundleCSS() {
     const distCssDir = path.join(distDir, 'assets/css');
 
     // Read CSS files in correct order
-    const cssFiles = ['fonts.css', 'bootstrap-united.css', 'responsive.css', 'marketing.css', 'components.css'];
+    const cssFiles = ['fonts.css', 'bootstrap-united.css', 'responsive.css', 'marketing.css', 'components.css', 'theme.css'];
     let combined = '';
     let totalOriginal = 0;
 

--- a/content/capabilities/index.html
+++ b/content/capabilities/index.html
@@ -22,7 +22,7 @@ rootPath: "../"
 
     <include src="partials/head-common.html"></include>
 </head>
-<body>
+<body class="theme-page">
 
     <include src="partials/nav.html"></include>
 

--- a/content/index.html
+++ b/content/index.html
@@ -3,26 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Deckhand — the API for real-world work. Every engineering workflow is an API path: one call returns a standards-traceable HTML report URL, same input same output. Chat is one client. Offshore live; more domains onboarding.">
-    <meta name="keywords" content="engineering API, Deckhand API, standards-traceable report, deterministic engineering, OrcaFlex automation, fatigue analysis, mooring design, subsea engineering, industry codes and standards, digitalmodel">
+    <meta name="description" content="AceEngineer turns everyday complex engineering into deterministic, reusable workflows — each backed by a public dataset you can explore and use for free.">
+    <meta name="keywords" content="deterministic engineering workflows, offshore engineering, field development, digital model, world energy data, lookup tables, reproducible engineering">
 
-    <!-- Open Graph meta tags -->
-    <meta property="og:title" content="Deckhand — the API for real-world work | AceEngineer">
-    <meta property="og:description" content="Every engineering workflow is an API path. One call returns a standards-traceable HTML report URL — same input, same output, every time. Chat is one client of the API.">
+    <meta property="og:title" content="AceEngineer — Everyday complex engineering, made deterministically simple">
+    <meta property="og:description" content="Deterministic engineering workflows, each backed by a public dataset you can explore and use for free.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://aceengineer.com">
+    <meta property="og:url" content="https://www.aceengineer.com/">
     <meta property="og:site_name" content="Analytical & Computational Engineering">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="AceEngineer — made deterministically simple">
+    <meta name="twitter:description" content="Deterministic engineering workflows, each backed by a public dataset. Use it for free.">
 
-    <!-- Twitter Card meta tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Deckhand — the API for real-world work | AceEngineer">
-    <meta name="twitter:description" content="One API call → a standards-traceable report URL. Deterministic, clause-traced offshore engineering. Chat is one client.">
-
-    <title>Deckhand — the API for real-world work | AceEngineer</title>
+    <title>AceEngineer — Everyday complex engineering, made deterministically simple</title>
 
     <include src="partials/head-common.html"></include>
 
-    <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
@@ -31,458 +27,85 @@
         "name": "Analytical & Computational Engineering",
         "alternateName": "AceEngineer",
         "url": "https://aceengineer.com",
-        "logo": "https://aceengineer.com/assets/img/logo.png",
-        "description": "The deterministic engineering-workflow firm for offshore energy. Deckhand runs standards-traceable, reproducible analysis — real programming code mapped to industry codes and standards — for subsea, mooring, fatigue, hydrodynamics, and field development, built on the open-source digitalmodel library.",
+        "description": "Deterministic engineering workflows for offshore and energy engineering, each backed by a public dataset.",
         "foundingDate": "2010",
-        "areaServed": ["United States", "United Kingdom", "Norway", "Brazil"],
-        "sameAs": [
-            "https://www.linkedin.com/company/aceengineer",
-            "https://github.com/vamseeachanta"
-        ],
-        "founder": {
-            "@type": "Person",
-            "name": "Vamsee Achanta",
-            "jobTitle": "Principal Engineer"
-        },
-        "contactPoint": {
-            "@type": "ContactPoint",
-            "email": "support@aceengineer.com",
-            "contactType": "Sales",
-            "areaServed": "Worldwide",
-            "availableLanguage": "English"
-        },
-        "knowsAbout": [
-            "Deterministic engineering workflows",
-            "OrcaFlex automation",
-            "OrcaWave and AQWA hydrodynamic analysis",
-            "Fatigue analysis",
-            "Mooring system design",
-            "Riser engineering",
-            "Fitness-for-service (API 579)",
-            "Subsea pipelines",
-            "Offshore field development economics"
-        ]
-    }
-    </script>
-
-    <!-- Service Schema -->
-    <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "Service",
-        "serviceType": "Deterministic Engineering Workflow Services for Offshore Energy",
-        "provider": {
-            "@id": "https://aceengineer.com/#organization"
-        },
         "areaServed": "Worldwide",
-        "hasOfferCatalog": {
-            "@type": "OfferCatalog",
-            "name": "Engineering Workflow Solutions",
-            "itemListElement": [
-                {
-                    "@type": "Offer",
-                    "itemOffered": {
-                        "@type": "Service",
-                        "name": "Deckhand — Engineering Workflow API",
-                        "description": "Drive real engineering work — analysis, documentation, issues and pull requests — with one API call (chat is one client), executed by deterministic workflows: real programming code mapped to industry codes and standards, under hard, auditable guardrails."
-                    }
-                },
-                {
-                    "@type": "Offer",
-                    "itemOffered": {
-                        "@type": "Service",
-                        "name": "Engineering Platform (digitalmodel)",
-                        "description": "7,000+ standard-mapped functions across ~30 engineering disciplines; every result traces to a DNV, API, ISO, or ASME clause."
-                    }
-                },
-                {
-                    "@type": "Offer",
-                    "itemOffered": {
-                        "@type": "Service",
-                        "name": "Fatigue & Hydrodynamics Automation",
-                        "description": "221 S-N curves from 17 standards; OrcaFlex / OrcaWave / AQWA model generation and post-processing."
-                    }
-                }
-            ]
-        }
+        "founder": { "@type": "Person", "name": "Vamsee Achanta" }
     }
     </script>
-
-    <style>
-        .calculator-showcase-section {
-            padding: 64px 0;
-            background: #f8f9fa;
-        }
-        .showcase-card {
-            background: #fff;
-            border: 1px solid #e0e0e0;
-            border-radius: 8px;
-            padding: 32px;
-            margin-bottom: 24px;
-            transition: box-shadow 0.3s ease;
-        }
-        .showcase-card:hover {
-            box-shadow: 0 4px 15px rgba(0,0,0,0.1);
-        }
-        .showcase-card h3 {
-            margin-top: 0;
-            color: #2c3e50;
-        }
-        /* Deckhand intro */
-        .deckhand-section { padding: 72px 0; background: #fff; }
-        .chat-demo {
-            max-width: 520px; margin: 0 auto;
-            border: 1px solid #e0e0e0; border-radius: 12px; overflow: hidden;
-            box-shadow: 0 6px 24px rgba(0,0,0,0.08); background: #fbfcfd;
-        }
-        .chat-demo .chat-head {
-            background: #2c3e50; color: #fff; padding: 12px 16px; font-size: 0.95em; font-weight: 600;
-        }
-        .chat-demo .bubble { margin: 14px 16px; padding: 10px 14px; border-radius: 14px; line-height: 1.45; }
-        .chat-demo .from-user { background: #d9eafc; margin-left: 60px; }
-        .chat-demo .from-bot  { background: #eef1f4; margin-right: 40px; }
-        .chat-demo .bubble code { background: rgba(0,0,0,0.06); padding: 1px 5px; border-radius: 4px; }
-        .chat-demo .meta { font-size: 0.82em; color: #6b7785; }
-        .deterministic-strip { background: #2c3e50; color: #fff; padding: 56px 0; }
-        .deterministic-strip .pillar { text-align: center; padding: 12px; }
-        .deterministic-strip .pillar h3 { color: #fff; margin: 8px 0; }
-        .deterministic-strip .pillar p { color: rgba(255,255,255,0.78); }
-        .deterministic-strip .pill-emoji { font-size: 2em; }
-    </style>
 </head>
-<body>
+<body class="theme-page">
 
     <include src="partials/nav.html"></include>
 
-    <!-- Hero Section -->
-    <section class="hero-section">
+    <!-- Hero -->
+    <section style="padding:64px 0 40px;">
+        <div class="container" style="max-width:860px;">
+            <p class="kicker">Deterministic engineering workflows</p>
+            <h1 style="font-size:2.6rem;line-height:1.15;margin:0 0 14px;">Everyday complex engineering —<br>made deterministically simple.</h1>
+            <p style="font-size:1.2rem;color:var(--ink);max-width:680px;">
+                We pre-compute the hard engineering across the envelope and hand you the simple part:
+                a lookup you can read in daily work — every number traceable to its standard, code, and data.
+            </p>
+            <div style="margin-top:26px;display:flex;gap:14px;flex-wrap:wrap;">
+                <a href="/capabilities/" class="btn-free">Use it for free →</a>
+                <a href="contact.html" class="btn-ghost">Custom work? Reach out</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Iceberg / lookup motif: simple on top, rigorous underneath -->
+    <section style="padding:20px 0 44px;">
         <div class="container">
-            <div class="row">
-                <div class="col-md-8 col-md-offset-2 text-center">
-                    <h1 class="hero-title">Deckhand &mdash; the API<br>for real-world work.</h1>
-                    <p class="hero-subtitle">Every engineering workflow is an API path. One call returns a standards-traceable HTML report URL &mdash; same input, same output, every time. Chat (Telegram / WhatsApp) is one client of the API, not the headline. Offshore is live today; more domains are onboarding.</p>
-                    <p class="hero-identity">Built on the open-source <strong>digitalmodel</strong> library &mdash; 7,000+ standard-mapped functions, 42 standards implemented, ~30 engineering disciplines.</p>
-                    <div class="hero-cta">
-                        <a href="deckhand-api.html" class="btn btn-primary btn-lg">See the API</a>
-                        <a href="api-catalog.html" class="btn btn-default btn-lg">Browse API paths</a>
-                        <!-- OPEN_DECK_CTA: live group invite. Swap to https://t.me/the_deckhand_bot?start=src_web_home_hero once deckhand#432 handler is live. -->
-                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-default btn-lg" data-cta="open-deck" data-src="src_web_home_hero">Try Open Deck &mdash; free</a>
-                    </div>
+            <div class="layers">
+                <div class="surface">
+                    <div class="row"><span>your case</span><span class="arrow">→</span><span>your answer</span></div>
+                    <p style="margin:10px 0 0;color:var(--muted);font-family:var(--font-ui);font-size:.85rem;">Simple at the point of use — a lookup, ready in daily work.</p>
+                </div>
+                <div class="depth">
+                    <div class="waterline-note">Rigorous underneath</div>
+                    Deterministic workflows · curated data · encoded standards · golden tests · input &amp; result hashes.
+                    <br>Composition is model-assisted; execution is 100% deterministic — the model never produces an engineering number.
                 </div>
             </div>
         </div>
     </section>
 
-    <!-- Meet Deckhand -->
-    <section class="deckhand-section">
+    <!-- Capabilities (live, data-backed) -->
+    <section style="padding:20px 0 40px;">
         <div class="container">
-            <div class="row">
-                <div class="col-md-5">
-                    <h2 class="section-title">Chat is one client of the API</h2>
-                    <p class="section-subtitle" style="text-align:left;">Under the hood, every Deckhand surface calls one API path: <code>POST /api/run</code> &rarr; a standards-traceable report URL. The chat below is just one client of that call &mdash; the same path runs from a webpage button or a cron job. Ask in plain language; Deckhand runs the real calculation against the right standard and returns a deliverable with every assumption traced. Changes to code or docs arrive as pull requests, never silent edits.</p>
-                    <ul>
-                        <li><strong>One call, one report URL</strong> &mdash; every workflow is an API path that returns a standards-traceable HTML report.</li>
-                        <li><strong>Deterministic</strong> &mdash; same input, same output, audit-ready.</li>
-                        <li><strong>Governed</strong> &mdash; PR-only, no force-push or deletes; everything out of scope returns 404.</li>
-                    </ul>
-                    <p>
-                        <a href="deckhand-api.html" class="btn btn-info">See the API</a>
-                        <a href="deckhand.html" class="btn btn-default">How Deckhand works</a>
-                        <!-- OPEN_DECK_CTA -->
-                        <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-default" data-cta="open-deck" data-src="src_web_home_meet">Try it on Telegram</a>
-                    </p>
-                </div>
-                <div class="col-md-6 col-md-offset-1">
-                    <div class="chat-demo" aria-label="Example Deckhand conversation">
-                        <div class="chat-head">Open Deck &middot; @the_deckhand_bot</div>
-                        <div class="bubble from-user">Wall thickness for a 12" pipeline, 10 MPa design pressure, X65 &mdash; DNV-ST-F101?</div>
-                        <div class="bubble from-bot">Minimum wall <strong>9.5 mm</strong> (incl. 1.0 mm corrosion allowance). Governing check: pressure containment, DNV-ST-F101 (2021) §5.4.2. Utilisation 0.81.<br><span class="meta">Assumptions: SMYS 450 MPa, t<sub>fab</sub> −12.5%, no buckling check requested. Full note &amp; PR ready on request.</span></div>
-                        <div class="bubble from-user">Add the local buckling check.</div>
-                        <div class="bubble from-bot">Done &mdash; combined loading per §5.4.4 passes (utilisation 0.88). Opened <code>PR #42</code> with the calculation note + inputs.</div>
-                    </div>
-                </div>
+            <h2 class="section-label">Capabilities — live &amp; data-backed</h2>
+            <p style="max-width:720px;color:var(--ink);margin:0 0 22px;">
+                Each capability is powered by a public dataset we publish from our engineering and
+                energy-data pipelines. Explore the real records, or use the workflow for free.
+                New capabilities appear here automatically as we ship them.
+            </p>
+            {{{ capabilitiesCards }}}
+        </div>
+    </section>
+
+    <!-- Deterministic pipeline -->
+    <section style="padding:20px 0 44px;">
+        <div class="container" style="max-width:860px;">
+            <h2 class="section-label">How a result is produced</h2>
+            <div class="flow">client basis&nbsp; →&nbsp; explicit specification&nbsp; →&nbsp; deterministic workflow&nbsp; →&nbsp; checked result&nbsp; →&nbsp; report</div>
+            <div class="callout" style="margin-top:18px;">
+                <em class="mantra">Everyday complex engineering — made deterministically simple.</em>
             </div>
         </div>
     </section>
 
-    <!-- Deterministic by design strip -->
-    <section class="deterministic-strip">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-10 col-md-offset-1 text-center">
-                    <h2 class="section-title" style="color:#fff;">Deterministic by design</h2>
-                    <p class="section-subtitle" style="color:rgba(255,255,255,0.8);">The thing practising engineers actually need: the same answer every time, traceable to a clause, defensible in review — deterministic workflows built on real code and industry codes and standards.</p>
-                    <div class="row" style="margin-top:24px;">
-                        <div class="col-md-4 pillar">
-                            <div class="pill-emoji">&#9878;</div>
-                            <h3>Standards-traceable</h3>
-                            <p>Every result maps to a DNV / API / ISO / ASME clause. 42 standards implemented.</p>
-                        </div>
-                        <div class="col-md-4 pillar">
-                            <div class="pill-emoji">&#128290;</div>
-                            <h3>680 byte-identical cases</h3>
-                            <p>Reproducible by construction &mdash; same input, same output, no model drift.</p>
-                        </div>
-                        <div class="col-md-4 pillar">
-                            <div class="pill-emoji">&#128221;</div>
-                            <h3>Assumption ledger</h3>
-                            <p>It states what it assumed and where the scope ends &mdash; a workflow that shows its work.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Calculator Showcase Section -->
-    <section class="calculator-showcase-section">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-10 col-md-offset-1">
-                    <h2 class="section-title text-center">Try Our Engineering Calculators</h2>
-                    <p class="section-subtitle text-center">Free, browser-based tools built on international standards &mdash; the same engine Deckhand runs. No signup required.</p>
-                    <div class="row">
-                        <div class="col-md-4">
-                            <div class="showcase-card text-center">
-                                <h3>Pipeline Stability</h3>
-                                <p>On-bottom stability per DNV-RP-F109. Hydrodynamic loads, submerged weight, utilisation ratio.</p>
-                                <a href="calculators/on-bottom-stability.html" class="btn btn-info">Try Calculator</a>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="showcase-card text-center">
-                                <h3>Wall Thickness</h3>
-                                <p>Burst and collapse checks per ASME B31.4. Multi-code comparison with corrosion allowance.</p>
-                                <a href="calculators/wall-thickness.html" class="btn btn-info">Try Calculator</a>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="showcase-card text-center">
-                                <h3>Fatigue Life</h3>
-                                <p>S-N curve fatigue analysis per DNV-RP-C203, API RP 2A, BS 7608 with interactive plotting.</p>
-                                <a href="calculators/fatigue-sn-curve.html" class="btn btn-info">Try Calculator</a>
-                            </div>
-                        </div>
-                    </div>
-                    <p class="text-center" style="margin-top: 24px;">
-                        <a href="calculators/" class="btn btn-default">View All Calculators</a>
-                    </p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Pain Point Section -->
-    <section class="pain-section">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-10 col-md-offset-1">
-                    <h2 class="section-title text-center">Sound Familiar?</h2>
-                    <div class="row pain-cards">
-                        <div class="col-md-4">
-                            <div class="pain-card">
-                                <div class="pain-icon">&#9200;</div>
-                                <h3>Manual Iteration Hell</h3>
-                                <p>Your engineers spend 3+ hours per day on repetitive OrcaFlex model setup and results extraction. A 50-case sensitivity study takes a full week of tedious work.</p>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="pain-card">
-                                <div class="pain-icon">&#129302;</div>
-                                <h3>Black-Box Answers You Can't Defend</h3>
-                                <p>Generic chatbots give a different answer every time and cite nothing. You can't put that in a calculation note or hand it to a checker.</p>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="pain-card">
-                                <div class="pain-icon">&#128101;</div>
-                                <h3>Knowledge Concentration Risk</h3>
-                                <p>Your OrcaFlex and standards expertise lives in the heads of 1-2 senior engineers. When they're unavailable, projects stall.</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Metrics Section -->
-    <section class="metrics-section">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-10 col-md-offset-1">
-                    <div class="metrics-row">
-                        <div class="metric-box">
-                            <div class="metric-value">7,000+</div>
-                            <div class="metric-label">Standard-Mapped Functions</div>
-                            <div class="metric-detail">Across ~30 disciplines</div>
-                        </div>
-                        <div class="metric-box">
-                            <div class="metric-value">42</div>
-                            <div class="metric-label">Standards</div>
-                            <div class="metric-detail">DNV, API, ISO, ASME, BS&hellip;</div>
-                        </div>
-                        <div class="metric-box">
-                            <div class="metric-value">221</div>
-                            <div class="metric-label">S-N Curves</div>
-                            <div class="metric-detail">From 17 fatigue standards</div>
-                        </div>
-                        <div class="metric-box">
-                            <div class="metric-value">680</div>
-                            <div class="metric-label">Byte-Identical Cases</div>
-                            <div class="metric-detail">Deterministic by construction</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Solutions / Verticals Section -->
-    <section class="verticals-section">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-10 col-md-offset-1">
-                    <h2 class="section-title text-center">Solutions by domain</h2>
-                    <p class="section-subtitle text-center">Each maps to a live Deckhand channel you can try on Open Deck.</p>
-
-                    <div class="row vertical-cards">
-                        <div class="col-md-4">
-                            <div class="vertical-card">
-                                <h3>Subsea, Pipelines &amp; Integrity</h3>
-                                <p class="vertical-problem">Wall thickness, on-bottom stability, free-span / VIV, fitness-for-service, cathodic protection.</p>
-                                <a href="solutions/subsea-pipelines-integrity.html" class="btn btn-sm btn-info">Explore</a>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="vertical-card">
-                                <h3>Floating &amp; Marine Systems</h3>
-                                <p class="vertical-problem">Mooring fatigue, FPSO spread mooring, vessel motions &amp; stability, hydrodynamics.</p>
-                                <a href="solutions/floating-marine.html" class="btn btn-sm btn-info">Explore</a>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="vertical-card">
-                                <h3>Wells &amp; Subsurface</h3>
-                                <p class="vertical-problem">Production forecasting, field NPV / economics, nodal analysis, rod-pump diagnostics.</p>
-                                <a href="solutions/wells-subsurface.html" class="btn btn-sm btn-info">Explore</a>
-                            </div>
-                        </div>
-                    </div>
-                    <p class="text-center" style="margin-top:8px;"><a href="solutions/" class="btn btn-default">View all 7 solution domains</a></p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Case Study Highlight -->
-    <section class="case-highlight-section">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-10 col-md-offset-1">
-                    <h2 class="section-title text-center">Proven Results</h2>
-
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="case-highlight-card">
-                                <h3>Computational Fatigue Assessment</h3>
-                                <p>Gulf of Mexico platform life extension project</p>
-                                <div class="case-metrics">
-                                    <span class="case-metric"><strong>85%</strong> time reduction</span>
-                                    <span class="case-metric"><strong>23%</strong> accuracy improvement</span>
-                                </div>
-                                <a href="case-studies/offshore-platform-fatigue-optimization.html" class="btn btn-primary" aria-label="Read case study: Computational Fatigue Assessment">Read Case Study</a>
-                            </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="case-highlight-card">
-                                <h3>Automated FEA Post-Processing</h3>
-                                <p>Subsea equipment qualification pipeline</p>
-                                <div class="case-metrics">
-                                    <span class="case-metric"><strong>90%</strong> time reduction</span>
-                                    <span class="case-metric"><strong>50+</strong> reports/week</span>
-                                </div>
-                                <a href="case-studies/subsea-fea-automation.html" class="btn btn-primary" aria-label="Read case study: Automated FEA Post-Processing">Read Case Study</a>
-                            </div>
-                        </div>
-                    </div>
-                    <p class="text-center" style="margin-top: 24px;">
-                        <a href="proof.html" class="btn btn-default">See how we prove it</a>
-                    </p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Social Proof Section -->
-    <section class="social-proof-section">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-10 col-md-offset-1 text-center">
-                    <h2 class="section-title">Standards Compliance You Can Trust</h2>
-                    <p class="section-subtitle">International standards codified into automated, auditable workflows</p>
-                    <div class="standards-badges">
-                        <span class="standard-badge">DNV-RP-C203</span>
-                        <span class="standard-badge">DNV-ST-F101</span>
-                        <span class="standard-badge">API RP 2A</span>
-                        <span class="standard-badge">API 579</span>
-                        <span class="standard-badge">BS 7608</span>
-                        <span class="standard-badge">DNV-RP-F109</span>
-                        <span class="standard-badge">ASME B31.8</span>
-                        <span class="standard-badge">API RP 2RD</span>
-                    </div>
-                    <p style="margin-top:20px;"><a href="standards/" class="btn btn-default">Explore standards you can run</a></p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- CTA Section -->
-    <section class="cta-section">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-8 col-md-offset-2 text-center">
-                    <h2>Put a standards-traceable workflow to work &mdash; free</h2>
-                    <p>Open Deck is the free tier: bring a real offshore / oil &amp; gas question and watch Deckhand run it, traced to the standard, on open repos.</p>
-                    <!-- OPEN_DECK_CTA -->
-                    <a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn btn-primary btn-lg" data-cta="open-deck" data-src="src_web_home_footer">Join Open Deck on Telegram</a>
-                    <p class="cta-note">For private, client-confidential work we run isolated scopes &mdash; <a href="contact.html">talk to us</a>.</p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Blog Preview -->
-    <section class="blog-preview-section">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-10 col-md-offset-1">
-                    <h2 class="section-title text-center">Technical Insights</h2>
-                    <div class="row">
-                        <div class="col-md-4">
-                            <div class="blog-preview-card">
-                                <h3><a href="blog/cfd-offshore-engineering.html">CFD for Offshore Engineering</a></h3>
-                                <p>From wave loading to VIV analysis&mdash;when CFD adds value and how to get it right.</p>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="blog-preview-card">
-                                <h3><a href="blog/risk-based-inspection-planning.html">Risk-Based Inspection Planning</a></h3>
-                                <p>Data-driven RBI approaches for offshore structures with API 580/581 compliance.</p>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="blog-preview-card">
-                                <h3><a href="blog/digital-twins-offshore-assets.html">Digital Twins for Offshore Assets</a></h3>
-                                <p>From concept to implementation&mdash;practical guidance for asset integrity management.</p>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="text-center">
-                        <a href="blog/" class="btn btn-default">View All Articles</a>
-                    </div>
-                </div>
-            </div>
+    <!-- CTA + custom work -->
+    <section style="padding:44px 0 60px;background:var(--tint);">
+        <div class="container" style="max-width:760px;text-align:center;">
+            <h2 style="font-size:1.7rem;color:var(--navy);margin:0 0 10px;">Use it for free</h2>
+            <p style="color:var(--ink);margin:0 0 22px;">
+                Explore the live capabilities and put the workflows to work — no cost, no sign-up.
+            </p>
+            <a href="/capabilities/" class="btn-free">Explore capabilities →</a>
+            <p style="color:var(--muted);font-family:var(--font-ui);font-size:.9rem;margin:26px 0 0;">
+                Other custom work is currently unavailable — <a href="contact.html" class="link-quiet">reach out</a> and we'll tell you what's possible.
+            </p>
         </div>
     </section>
 

--- a/content/partials/nav.html
+++ b/content/partials/nav.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-inverse">
+<nav class="navbar navbar-inverse theme-nav">
     <div class="container-fluid">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#myNavbar" aria-expanded="false" aria-label="Toggle navigation">
@@ -7,24 +7,16 @@
                 <span class="icon-bar"></span>
             </button>
             <a href="{{ rootPath }}index.html" class="navbar-brand-link" aria-label="AceEngineer home">
-                <img src="{{ rootPath }}assets/img/logo.svg" class="navbar-logo" alt="AceEngineer — Analytical &amp; Computational Engineering">
+                <img src="{{ rootPath }}assets/img/logo.svg" class="navbar-logo" alt="AceEngineer — made deterministically simple">
             </a>
         </div>
         <div class="collapse navbar-collapse" id="myNavbar">
             <ul class="nav navbar-nav">
-                <li><a href="{{ rootPath }}index.html">Home</a></li>
-                <li><a href="{{ rootPath }}deckhand.html">Deckhand</a></li>
-                <li><a href="{{ rootPath }}platform.html">Platform</a></li>
-                <li><a href="{{ rootPath }}solutions/">Solutions</a></li>
-                <li><a href="{{ rootPath }}proof.html">Proof</a></li>
-                <li><a href="{{ rootPath }}vision.html">Vision</a></li>
-                <li><a href="{{ rootPath }}calculators/">Calculators</a></li>
                 <li><a href="{{ rootPath }}capabilities/">Capabilities</a></li>
                 <li><a href="{{ rootPath }}about.html">Company</a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <!-- OPEN_DECK_CTA: live group invite. Swap to https://t.me/the_deckhand_bot?start=src_web_nav once deckhand#432 handler is live. -->
-                <li><a href="https://t.me/+T6HF8jf-NGdmM2I5" target="_blank" rel="noopener" class="btn-nav-cta" data-cta="open-deck" data-src="src_web_nav">Try Open Deck</a></li>
+                <li><a href="{{ rootPath }}capabilities/" class="btn-nav-cta" data-cta="use-free" data-src="src_web_nav">Use it for free</a></li>
             </ul>
         </div>
     </div>

--- a/scripts/render-capabilities.js
+++ b/scripts/render-capabilities.js
@@ -20,8 +20,8 @@ const DOMAIN_LABELS = {
   digitalmodel: 'Digital Model',
 };
 const DOMAIN_COLORS = {
-  worldenergy: '#0b6e4f',
-  digitalmodel: '#1d4e89',
+  worldenergy: '#0e7e88',   /* teal-deep (theme accent) */
+  digitalmodel: '#0b3d5c',  /* navy (theme structure) */
 };
 
 function escapeHtml(s) {
@@ -87,7 +87,7 @@ function renderCard(cap) {
       renderStatStrip(cap) +
       `<p style="color:#777;font-size:.82rem;margin:6px 0 0;">${escapeHtml(cap.data_limits || '')}</p>`;
     cta =
-      `<a href="${escapeHtml(detailFileName(cap))}" ` +
+      `<a href="${escapeHtml(detailHref(cap))}" ` +
       `style="font-weight:600;color:${domainColor};">View capability →</a>` +
       `<a href="${escapeHtml(hfDatasetUrl(cap.hf_dataset))}" rel="noopener" ` +
       `style="margin-left:18px;color:#666;font-size:.9rem;">Dataset on Hugging Face ↗</a>`;
@@ -115,6 +115,12 @@ const MAX_BARS = 15;
 
 function detailFileName(cap) {
   return `${cap.id}.html`;
+}
+
+// Absolute, root-relative link to a capability's detail page — works whether the card
+// is rendered on the homepage (root) or on /capabilities/.
+function detailHref(cap) {
+  return `/capabilities/${cap.id}.html`;
 }
 
 function isNumericDtype(dtype) {
@@ -265,7 +271,7 @@ function capabilityDetailBody(cap) {
     `</div>`;
 
   return (
-    `<a href="./" style="color:#666;text-decoration:none;">← All capabilities</a>` +
+    `<a href="/capabilities/" style="color:#666;text-decoration:none;">← All capabilities</a>` +
     `<div style="margin:10px 0 6px;">${badge}</div>` +
     `<h1 style="margin:4px 0 8px;">${escapeHtml(cap.title)}</h1>` +
     `<p style="font-size:1.12rem;color:#444;max-width:760px;">${escapeHtml(cap.summary)}</p>` +
@@ -288,7 +294,7 @@ function capabilityDetailDocument(cap) {
     `<meta property="og:url" content="https://aceengineer.com/capabilities/${escapeHtml(cap.id)}.html">\n` +
     `<title>${escapeHtml(title)}</title>\n` +
     `<include src="partials/head-common.html"></include>\n` +
-    `</head>\n<body>\n` +
+    `</head>\n<body class="theme-page">\n` +
     `<include src="partials/nav.html"></include>\n` +
     `<section style="padding:40px 0 56px;"><div class="container">\n` +
     capabilityDetailBody(cap) +
@@ -313,7 +319,7 @@ function renderCards(registry) {
 module.exports = {
   escapeHtml, hfDatasetUrl, tableStats, hasData,
   renderStatStrip, renderCard, renderCards,
-  detailFileName, formatCell, orderedColumns, pickChartKeys,
+  detailFileName, detailHref, formatCell, orderedColumns, pickChartKeys,
   renderTable, renderBarChart, renderLineChart, renderChartFor,
   capabilityDetailBody, capabilityDetailDocument,
   DOMAIN_LABELS, MAX_TABLE_ROWS,

--- a/tests/js/render-capabilities.test.js
+++ b/tests/js/render-capabilities.test.js
@@ -34,7 +34,7 @@ describe('renderCard (live)', () => {
   test('links to the internal detail page and, secondarily, the HF dataset', () => {
     expect(html).toContain('World Energy Field Explorer');
     expect(html).toContain('World Energy');
-    expect(html).toContain('href="field-explorer.html"');
+    expect(html).toContain('href="/capabilities/field-explorer.html"');
     expect(html).toContain('View capability');
     expect(html).toContain(hfDatasetUrl('aceengineer/worldenergydata-explorer'));
   });


### PR DESCRIPTION
Applies the **Subsea7 "made deterministically simple" theme** to aceengineer.com and pivots the site to be **capabilities-first**, per direction. **Preview on the Vercel deploy below before merging** — this is a visible brand change.

> **Stacked on C4 (#58) → C3 (#57).** Base is `feat/capabilities-detail-c4`. Merge order: **#57 → #58 → this** (GitHub auto-retargets each as its parent merges).

## The theme (extracted from the FDG pre-read via subagent)
Deep petrol-navy `#0b3d5c` structure + teal `#2BB2A6` signature accent, white canvas, serif body (Georgia) + uppercase letter-spaced sans labels, understated tinted-underline links, and the signature **"anchor box"** callout (tint + thick left navy border). Reads like a typeset engineering memo — fresh and restrained, not SaaS.

## What changed
- **New logo** — the iceberg/lookup motif: a simple teal "lookup" surface resting on rigorous navy strata ("simple at the point of use, rigorous underneath"), AceEngineer wordmark + "MADE DETERMINISTICALLY SIMPLE". Solid fills (SVG-portable, no gradients/filters).
- **`assets/css/theme.css`** — theme tokens + reusable `.callout` / `.btn-free` / `.layers` / `.flow` / themed nav; bundled last so it overrides, and outside the bootstrap purge.
- **Homepage → capabilities-first**: mantra hero (*"Everyday complex engineering — made deterministically simple."*), the two-layer simple/rigorous panel, the **live capability cards**, the deterministic pipeline strip, and a **"Use it for free"** CTA with **"other custom work is currently unavailable — reach out."**
- **Copy** — dropped the *"AI-native"* framing per the theme's hard no-literal-AI rule; voice is now "deterministic engineering workflows / model-assisted composition."
- **Nav** simplified to **Capabilities · Company · Use it for free**, themed navy.
- Capability cards/pages adopt the navy/teal palette; internal capability links made **absolute** so cards render correctly on both the homepage and `/capabilities/`.

## Scope note (first cut)
This themes the **homepage + capabilities surfaces + nav + logo** — the high-traffic front door. Secondary pages (about, solutions, calculators, demos) still exist and pass tests but aren't yet re-themed; I'll iterate outward from your feedback on the preview. The stale root `index.html` (not served) is left untouched.

## Verification
- `npm run build` → homepage renders themed, cards live, no "AI-native" copy.
- `npm test` → **225/225 across 14 projects**; `python3 scripts/maintenance/verify_repo_structure.py` → OK.

Open questions for your steer (from the preview): logo direction, and how far to push the re-theme across secondary pages.
