### PR TITLE
feat(capabilities): per-capability detail pages with table + chart [C4]

### DIFF
--- a/build.js
+++ b/build.js
@@ -7,7 +7,7 @@ const yaml = require('js-yaml');
 const { PurgeCSS } = require('purgecss');
 const CleanCSS = require('clean-css');
 const hf = require('./scripts/hf-fetch');
-const { renderCards } = require('./scripts/render-capabilities');
+const { renderCards, capabilityDetailDocument, detailFileName } = require('./scripts/render-capabilities');
 
 const srcDir = './content';
 const distDir = './dist';
@@ -15,6 +15,10 @@ const distDir = './dist';
 // Rendered capability cards (C3, #51), computed once at build start from the hydrated
 // registry and injected into every page as the `capabilitiesCards` template local.
 let _capabilitiesCards = '';
+
+// The hydrated registry (C2), captured at build start so the detail-page pass (C4)
+// can reuse it without re-fetching.
+let _hydratedRegistry = null;
 
 // Load canonical firm-copy (brand/copy.yaml) — single source of truth (issue #9).
 // Exposed to every page as the `copy` template object, e.g. {{ copy.firm_lede }}.
@@ -126,15 +130,38 @@ async function processFile(filePath) {
     locals.capabilitiesCards = _capabilitiesCards;
   }
 
+  const html = await renderHtml(content, locals);
+
+  ensureDir(path.dirname(outputPath));
+  fs.writeFileSync(outputPath, html);
+  console.log(`Built: ${relativePath}`);
+}
+
+// Run a raw HTML string through the same pipeline pages use: resolve <include>
+// partials, then expand {{ }} expressions with `locals`. Shared by processFile and
+// the generated capability detail pages (C4) so they get identical chrome.
+async function renderHtml(content, locals) {
   // Process includes first, then expressions (so included content gets variables expanded)
   const result = await posthtml([
     include({ root: srcDir }),
     expressions({ locals })
   ]).process(content);
+  return result.html;
+}
 
-  ensureDir(path.dirname(outputPath));
-  fs.writeFileSync(outputPath, result.html);
-  console.log(`Built: ${relativePath}`);
+// Generate one detail page per non-withheld capability at dist/capabilities/<id>.html
+// (C4, #52). Pages live one level deep, so rootPath is '../' for the shared partials.
+async function buildCapabilityDetailPages(registry) {
+  const caps = (registry && registry.capabilities || []).filter(c => c.status !== 'withheld');
+  const outDir = path.join(distDir, 'capabilities');
+  ensureDir(outDir);
+  for (const cap of caps) {
+    const doc = capabilityDetailDocument(cap);
+    const html = await renderHtml(doc, { rootPath: '../', copy: loadCopy() });
+    fs.writeFileSync(path.join(outDir, detailFileName(cap)), html);
+    console.log(`Built: capabilities/${detailFileName(cap)}`);
+  }
+  return caps.length;
 }
 
 // Copy assets directory
@@ -185,6 +212,7 @@ async function build() {
   // pages, so content/capabilities/index.html can inject them. Never fails the build.
   try {
     const reg = await loadHydratedCapabilities();
+    _hydratedRegistry = reg;
     _capabilitiesCards = renderCards(reg);
     const tables = (reg.capabilities || []).flatMap(c => c.tables || []);
     const bySource = tables.reduce((a, t) => { a[t.data_source] = (a[t.data_source] || 0) + 1; return a; }, {});
@@ -198,6 +226,16 @@ async function build() {
   const files = getHtmlFiles(srcDir);
   for (const file of files) {
     await processFile(file);
+  }
+
+  // Generate per-capability detail pages (C4) from the hydrated registry.
+  if (_hydratedRegistry) {
+    try {
+      const n = await buildCapabilityDetailPages(_hydratedRegistry);
+      console.log(`Capability detail pages: ${n}`);
+    } catch (err) {
+      console.warn(`Capability detail pages skipped: ${err.message}`);
+    }
   }
 
   // Copy assets

--- a/scripts/render-capabilities.js
+++ b/scripts/render-capabilities.js
@@ -87,8 +87,10 @@ function renderCard(cap) {
       renderStatStrip(cap) +
       `<p style="color:#777;font-size:.82rem;margin:6px 0 0;">${escapeHtml(cap.data_limits || '')}</p>`;
     cta =
+      `<a href="${escapeHtml(detailFileName(cap))}" ` +
+      `style="font-weight:600;color:${domainColor};">View capability →</a>` +
       `<a href="${escapeHtml(hfDatasetUrl(cap.hf_dataset))}" rel="noopener" ` +
-      `style="font-weight:600;color:${domainColor};">Explore data on Hugging Face →</a>`;
+      `style="margin-left:18px;color:#666;font-size:.9rem;">Dataset on Hugging Face ↗</a>`;
   }
 
   return (
@@ -99,6 +101,200 @@ function renderCard(cap) {
     `<div style="flex:1 1 auto;">${body}</div>` +
     `<div style="margin-top:16px;">${cta}</div>` +
     `</article>`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Detail-page rendering (C4, #52): per-capability page with a data table + an
+// inline-SVG chart. SVG is generated at build time — no chart library, so it's
+// CSP-clean, SEO-indexable, and deterministic.
+// ---------------------------------------------------------------------------
+
+const MAX_TABLE_ROWS = 50;
+const MAX_BARS = 15;
+
+function detailFileName(cap) {
+  return `${cap.id}.html`;
+}
+
+function isNumericDtype(dtype) {
+  return /int|float|double|decimal|number/i.test(String(dtype || ''));
+}
+
+function formatCell(v) {
+  if (v === null || v === undefined || v === '') return '—';
+  if (typeof v === 'number') {
+    return Number.isInteger(v) ? v.toLocaleString('en-US') : v.toLocaleString('en-US', { maximumFractionDigits: 2 });
+  }
+  return escapeHtml(v);
+}
+
+// Column display order: highlight_columns first (in declared order), then the rest.
+function orderedColumns(table) {
+  const cols = (table.data && table.data.columns || []).map(c => c.name);
+  const hi = (table.highlight_columns || []).filter(c => cols.includes(c));
+  const rest = cols.filter(c => !hi.includes(c));
+  return [...hi, ...rest];
+}
+
+// Pick (labelKey, valueKey) for a chart: first non-numeric highlight col as label,
+// first numeric highlight col as value. Falls back across all columns.
+function pickChartKeys(table) {
+  const columns = table.data && table.data.columns || [];
+  const dtypeOf = name => (columns.find(c => c.name === name) || {}).dtype;
+  const pool = (table.highlight_columns && table.highlight_columns.length)
+    ? table.highlight_columns.filter(c => columns.some(col => col.name === c))
+    : columns.map(c => c.name);
+  const valueKey = pool.find(c => isNumericDtype(dtypeOf(c)));
+  const labelKey = pool.find(c => c !== valueKey && !isNumericDtype(dtypeOf(c))) || pool.find(c => c !== valueKey);
+  return { labelKey, valueKey };
+}
+
+function renderTable(table) {
+  const rows = (table.data && table.data.rows) || [];
+  const cols = orderedColumns(table);
+  if (!rows.length || !cols.length) {
+    return `<p style="color:#777;">No rows to display.</p>`;
+  }
+  const shown = rows.slice(0, MAX_TABLE_ROWS);
+  const head = cols.map(c => `<th style="text-align:left;padding:8px 12px;border-bottom:2px solid #dde1e5;white-space:nowrap;">${escapeHtml(c)}</th>`).join('');
+  const body = shown.map(r =>
+    `<tr>` + cols.map(c => `<td style="padding:7px 12px;border-bottom:1px solid #eef1f3;">${formatCell(r[c])}</td>`).join('') + `</tr>`
+  ).join('\n');
+  const total = table.data.total_rows != null ? table.data.total_rows : rows.length;
+  const note = shown.length < total
+    ? `<p style="color:#777;font-size:.85rem;margin:8px 0 0;">Showing ${shown.length} of ${total.toLocaleString('en-US')} rows — full table on Hugging Face.</p>`
+    : '';
+  return (
+    `<div style="overflow-x:auto;">` +
+    `<table style="border-collapse:collapse;width:100%;font-size:.92rem;">` +
+    `<thead><tr>${head}</tr></thead><tbody>${body}</tbody></table></div>${note}`
+  );
+}
+
+// Inline-SVG horizontal bar chart. `data` = [{label, value}].
+function renderBarChart(data, opts = {}) {
+  const { color = '#1d4e89' } = opts;
+  const items = data.filter(d => typeof d.value === 'number' && !Number.isNaN(d.value)).slice(0, MAX_BARS);
+  if (!items.length) return '';
+  const max = Math.max(...items.map(d => d.value), 0) || 1;
+  const rowH = 26, gap = 8, labelW = 160, chartW = 460, pad = 8;
+  const width = labelW + chartW + pad * 2;
+  const height = items.length * (rowH + gap) + pad * 2;
+  const bars = items.map((d, i) => {
+    const y = pad + i * (rowH + gap);
+    const w = Math.max(1, Math.round((d.value / max) * chartW));
+    const val = Number.isInteger(d.value) ? d.value.toLocaleString('en-US') : d.value.toLocaleString('en-US', { maximumFractionDigits: 2 });
+    return (
+      `<text x="${labelW - 6}" y="${y + rowH / 2 + 4}" text-anchor="end" font-size="12" fill="#333">${escapeHtml(String(d.label))}</text>` +
+      `<rect x="${labelW}" y="${y}" width="${w}" height="${rowH}" rx="3" fill="${color}"></rect>` +
+      `<text x="${labelW + w + 6}" y="${y + rowH / 2 + 4}" font-size="12" fill="#333">${val}</text>`
+    );
+  }).join('');
+  return (
+    `<svg viewBox="0 0 ${width} ${height}" width="100%" role="img" ` +
+    `style="max-width:${width}px;height:auto;font-family:inherit;" preserveAspectRatio="xMinYMin meet">${bars}</svg>`
+  );
+}
+
+// Inline-SVG line chart across the row order. `data` = [{label, value}].
+function renderLineChart(data, opts = {}) {
+  const { color = '#0b6e4f' } = opts;
+  const items = data.filter(d => typeof d.value === 'number' && !Number.isNaN(d.value));
+  if (items.length < 2) return renderBarChart(data, opts);
+  const max = Math.max(...items.map(d => d.value));
+  const min = Math.min(...items.map(d => d.value));
+  const span = (max - min) || 1;
+  const w = 640, h = 220, pad = 30;
+  const step = (w - pad * 2) / (items.length - 1);
+  const pts = items.map((d, i) => {
+    const x = pad + i * step;
+    const y = h - pad - ((d.value - min) / span) * (h - pad * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  }).join(' ');
+  return (
+    `<svg viewBox="0 0 ${w} ${h}" width="100%" role="img" style="max-width:${w}px;height:auto;" preserveAspectRatio="xMinYMin meet">` +
+    `<polyline fill="none" stroke="${color}" stroke-width="2" points="${pts}"></polyline>` +
+    `<text x="${pad}" y="16" font-size="12" fill="#666">max ${max.toLocaleString('en-US')}</text></svg>`
+  );
+}
+
+function renderChartFor(table) {
+  const viz = table.viz;
+  if (viz !== 'bar' && viz !== 'line') return '';
+  const { labelKey, valueKey } = pickChartKeys(table);
+  if (!labelKey || !valueKey) return '';
+  const rows = (table.data && table.data.rows) || [];
+  let data = rows.map(r => ({ label: r[labelKey], value: r[valueKey] }))
+    .filter(d => typeof d.value === 'number' && !Number.isNaN(d.value));
+  if (!data.length) return '';
+  if (viz === 'bar') {
+    data = data.sort((a, b) => b.value - a.value);
+    return `<div style="margin:10px 0 6px;">${renderBarChart(data)}</div>` +
+      `<p style="color:#777;font-size:.82rem;margin:0 0 4px;">${escapeHtml(valueKey)} by ${escapeHtml(labelKey)} (top ${Math.min(MAX_BARS, data.length)})</p>`;
+  }
+  return `<div style="margin:10px 0 6px;">${renderLineChart(data)}</div>` +
+    `<p style="color:#777;font-size:.82rem;margin:0 0 4px;">${escapeHtml(valueKey)} across ${escapeHtml(labelKey)}</p>`;
+}
+
+// The inner body of a capability detail page (no chrome).
+function capabilityDetailBody(cap) {
+  const domainLabel = DOMAIN_LABELS[cap.domain] || cap.domain;
+  const domainColor = DOMAIN_COLORS[cap.domain] || '#444';
+  const badge =
+    `<span style="display:inline-block;background:${domainColor};color:#fff;font-size:.72rem;font-weight:600;` +
+    `letter-spacing:.04em;text-transform:uppercase;padding:3px 10px;border-radius:999px;">${escapeHtml(domainLabel)}</span>`;
+
+  const tables = (cap.tables || []).map(t => {
+    const chart = renderChartFor(t);
+    return (
+      `<section style="margin:28px 0;">` +
+      `<h2 style="font-size:1.3rem;color:#111;">${escapeHtml(t.label || t.config)}</h2>` +
+      chart +
+      renderTable(t) +
+      `</section>`
+    );
+  }).join('\n');
+
+  const provenance =
+    `<div style="margin-top:32px;padding:18px 20px;background:#f8f9fa;border-radius:8px;">` +
+    `<p style="margin:0 0 6px;"><strong>Source:</strong> ` +
+    `<a href="${escapeHtml(hfDatasetUrl(cap.hf_dataset))}" rel="noopener">${escapeHtml(cap.hf_dataset)}</a> on Hugging Face` +
+    (cap.provenance_url ? ` · <a href="${escapeHtml(cap.provenance_url)}" rel="noopener">pipeline</a>` : '') + `</p>` +
+    (cap.data_limits ? `<p style="margin:0;color:#555;font-size:.9rem;"><strong>Data limits:</strong> ${escapeHtml(cap.data_limits)}</p>` : '') +
+    `</div>`;
+
+  return (
+    `<a href="./" style="color:#666;text-decoration:none;">← All capabilities</a>` +
+    `<div style="margin:10px 0 6px;">${badge}</div>` +
+    `<h1 style="margin:4px 0 8px;">${escapeHtml(cap.title)}</h1>` +
+    `<p style="font-size:1.12rem;color:#444;max-width:760px;">${escapeHtml(cap.summary)}</p>` +
+    tables +
+    provenance
+  );
+}
+
+// A full detail-page HTML document (with <include> chrome; rootPath resolved by build.js
+// via posthtml expressions). One page per capability, written to dist/capabilities/<id>.html.
+function capabilityDetailDocument(cap) {
+  const title = `${cap.title} — AceEngineer Capabilities`;
+  return (
+    `<!DOCTYPE html>\n<html lang="en">\n<head>\n` +
+    `<meta charset="UTF-8">\n<meta name="viewport" content="width=device-width, initial-scale=1">\n` +
+    `<meta name="description" content="${escapeHtml(cap.summary)}">\n` +
+    `<meta property="og:title" content="${escapeHtml(title)}">\n` +
+    `<meta property="og:description" content="${escapeHtml(cap.summary)}">\n` +
+    `<meta property="og:type" content="website">\n` +
+    `<meta property="og:url" content="https://aceengineer.com/capabilities/${escapeHtml(cap.id)}.html">\n` +
+    `<title>${escapeHtml(title)}</title>\n` +
+    `<include src="partials/head-common.html"></include>\n` +
+    `</head>\n<body>\n` +
+    `<include src="partials/nav.html"></include>\n` +
+    `<section style="padding:40px 0 56px;"><div class="container">\n` +
+    capabilityDetailBody(cap) +
+    `\n</div></section>\n` +
+    `<include src="partials/footer.html"></include>\n` +
+    `</body>\n</html>\n`
   );
 }
 
@@ -117,5 +313,8 @@ function renderCards(registry) {
 module.exports = {
   escapeHtml, hfDatasetUrl, tableStats, hasData,
   renderStatStrip, renderCard, renderCards,
-  DOMAIN_LABELS,
+  detailFileName, formatCell, orderedColumns, pickChartKeys,
+  renderTable, renderBarChart, renderLineChart, renderChartFor,
+  capabilityDetailBody, capabilityDetailDocument,
+  DOMAIN_LABELS, MAX_TABLE_ROWS,
 };

--- a/tests/js/render-capabilities.test.js
+++ b/tests/js/render-capabilities.test.js
@@ -1,6 +1,10 @@
 const fs = require('fs');
 const path = require('path');
-const { escapeHtml, renderCard, renderCards, hfDatasetUrl } = require('../../scripts/render-capabilities');
+const {
+  escapeHtml, renderCard, renderCards, hfDatasetUrl,
+  renderTable, pickChartKeys, renderChartFor, renderBarChart,
+  capabilityDetailDocument, detailFileName, orderedColumns,
+} = require('../../scripts/render-capabilities');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
 
@@ -27,11 +31,12 @@ describe('escapeHtml', () => {
 
 describe('renderCard (live)', () => {
   const html = renderCard(liveCap());
-  test('shows title, domain label, and the HF explore link', () => {
+  test('links to the internal detail page and, secondarily, the HF dataset', () => {
     expect(html).toContain('World Energy Field Explorer');
     expect(html).toContain('World Energy');
+    expect(html).toContain('href="field-explorer.html"');
+    expect(html).toContain('View capability');
     expect(html).toContain(hfDatasetUrl('aceengineer/worldenergydata-explorer'));
-    expect(html).toContain('Explore data on Hugging Face');
   });
   test('shows per-table stat counts and the data-limits note', () => {
     expect(html).toContain('>10<');
@@ -59,6 +64,92 @@ describe('renderCards', () => {
   });
   test('handles an empty registry', () => {
     expect(renderCards({ capabilities: [] })).toContain('No capabilities');
+  });
+});
+
+// A table fixture in the hydrated shape (columns carry dtypes; rows are objects).
+function tableFixture(over = {}) {
+  return {
+    config: 'countries', label: 'Countries', viz: 'bar',
+    highlight_columns: ['country', 'fields', 'facilities'],
+    data: {
+      columns: [
+        { name: 'country', dtype: 'string' },
+        { name: 'fields', dtype: 'int64' },
+        { name: 'facilities', dtype: 'int64' },
+        { name: 'badge', dtype: 'string' },
+      ],
+      rows: [
+        { country: 'USA', fields: 30, facilities: 12, badge: 'x' },
+        { country: 'Norway', fields: 18, facilities: 9, badge: 'y' },
+      ],
+      total_rows: 84,
+    },
+    ...over,
+  };
+}
+
+describe('renderTable', () => {
+  test('orders highlight columns first, then the rest', () => {
+    expect(orderedColumns(tableFixture())).toEqual(['country', 'fields', 'facilities', 'badge']);
+  });
+  test('renders cells and a truncation note when rows exceed the cap', () => {
+    const html = renderTable(tableFixture());
+    expect(html).toContain('USA');
+    expect(html).toContain('Showing 2 of 84 rows');
+  });
+  test('escapes cell content', () => {
+    const t = tableFixture();
+    t.data.rows = [{ country: '<script>', fields: 1, facilities: 1, badge: '' }];
+    expect(renderTable(t)).toContain('&lt;script&gt;');
+    expect(renderTable(t)).not.toContain('<script>');
+  });
+});
+
+describe('charts', () => {
+  test('pickChartKeys chooses a string label and a numeric value', () => {
+    expect(pickChartKeys(tableFixture())).toEqual({ labelKey: 'country', valueKey: 'fields' });
+  });
+  test('renderChartFor emits an SVG bar chart for viz:bar', () => {
+    const html = renderChartFor(tableFixture());
+    expect(html).toContain('<svg');
+    expect(html).toContain('<rect');
+    expect(html).toContain('fields by country');
+  });
+  test('renderChartFor returns empty for viz:table', () => {
+    expect(renderChartFor(tableFixture({ viz: 'table' }))).toBe('');
+  });
+  test('renderBarChart sorts by value and caps bars', () => {
+    const svg = renderBarChart([{ label: 'a', value: 1 }, { label: 'b', value: 5 }]);
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('>a<');
+    expect(svg).toContain('>b<');
+  });
+});
+
+describe('capabilityDetailDocument', () => {
+  const cap = {
+    id: 'field-explorer', title: 'World Energy Field Explorer', domain: 'worldenergy',
+    summary: 'Global drill-down.', hf_dataset: 'aceengineer/worldenergydata-explorer',
+    provenance_url: 'https://github.com/vamseeachanta/worldenergydata', status: 'live',
+    data_limits: 'GoM-focused.', tables: [tableFixture()],
+  };
+  const doc = capabilityDetailDocument(cap);
+  test('is a full document with chrome includes and the title', () => {
+    expect(doc).toContain('<!DOCTYPE html>');
+    expect(doc).toContain('partials/nav.html');
+    expect(doc).toContain('partials/footer.html');
+    expect(doc).toContain('World Energy Field Explorer — AceEngineer Capabilities');
+  });
+  test('includes the table, chart, back-link, and provenance', () => {
+    expect(doc).toContain('All capabilities');
+    expect(doc).toContain('<svg');
+    expect(doc).toContain('<table');
+    expect(doc).toContain('aceengineer/worldenergydata-explorer');
+    expect(doc).toContain('Data limits');
+  });
+  test('detailFileName is <id>.html', () => {
+    expect(detailFileName(cap)).toBe('field-explorer.html');
   });
 });
 


### PR DESCRIPTION
Recovers C4 (was PR #58, auto-closed when its stacked base branch `feat/capabilities-index-c3` was deleted on #57 merge — no code lost, re-targeted to main).

Per-capability detail pages rendered from the registry: data table + inline-SVG chart per capability. Stacked originally on C3 (#57, now merged).

Supersedes #58.