### PR TITLE
feat(capabilities): going-forward CI gate on the registry [C7]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!-- Thanks for the change! Keep this short — link the issue and check the boxes that apply. -->
+
+## What & why
+
+<!-- One or two sentences. Link the issue: Closes #___ -->
+
+## Checklist
+
+- [ ] Tests pass locally (`npm test`) and the build is clean (`npm run build`).
+- [ ] Copy follows the house rules (`npm run lint:copy`).
+
+### New algorithm / capability? (the going-forward contract — C7)
+
+If this PR surfaces a new algorithm or dataset on the site, **both** must be true:
+
+- [ ] The result is a **published Hugging Face dataset** (public, `/splits`-resolvable).
+- [ ] A matching entry was added to **`config/capabilities.yaml`** (scaffold it with
+      `node scripts/scaffold-capability-entry.js <hf_dataset>`), and
+      `npm run validate:registry` passes — the dataset + every config/column resolves,
+      and no `withheld` column is surfaced.
+
+<!-- Not adding a capability? Leave the three boxes above unchecked — CI still runs the
+     registry gate against any capabilities.yaml change. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Build site
         run: npm run build
 
+      # C7 going-forward gate (#54): the registry must be structurally valid AND true
+      # against Hugging Face — every live capability's dataset/config/columns resolve, no
+      # withheld column is surfaced. Genuine "not found" fails here; a transient HF outage
+      # only warns (see scripts/verify-capabilities-online.js), so this never flakes a PR.
+      - name: Validate capabilities registry (schema + live HF resolution)
+        run: npm run validate:registry
+
       - name: Run Jest suite
         run: npm test -- --runInBand
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "serve": "npx serve dist",
     "lint:copy": "node scripts/lint-copy.js",
     "validate:capabilities": "node scripts/validate-capabilities.js",
+    "validate:capabilities:online": "node scripts/verify-capabilities-online.js",
+    "validate:registry": "npm run validate:capabilities && npm run validate:capabilities:online",
+    "scaffold:capability": "node scripts/scaffold-capability-entry.js",
     "refresh:hf": "node scripts/refresh-hf-data.js",
     "test": "jest",
     "test:coverage": "jest --coverage"
@@ -30,6 +33,11 @@
         "displayName": "hf-fetch",
         "testEnvironment": "node",
         "testMatch": ["<rootDir>/tests/js/hf-fetch.test.js"]
+      },
+      {
+        "displayName": "capabilities-online",
+        "testEnvironment": "node",
+        "testMatch": ["<rootDir>/tests/js/capabilities-online.test.js"]
       },
       {
         "displayName": "render-capabilities",
@@ -86,6 +94,7 @@
       "build.js",
       "scripts/hf-fetch.js",
       "scripts/render-capabilities.js",
+      "scripts/verify-capabilities-online.js",
       "assets/js/navbar-toggle.js",
       "assets/js/cta-tracking.js",
       "assets/js/npv-calculator-engine.js",

--- a/scripts/scaffold-capability-entry.js
+++ b/scripts/scaffold-capability-entry.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * scaffold-capability-entry.js — emit a ready-to-paste capabilities.yaml block for a
+ * freshly published Hugging Face dataset. Closes the C7 loop (aceengineer-website#54):
+ * registering a new algorithm becomes the path of least resistance, so the going-forward
+ * contract ("new algorithm → HF dataset + registry entry") is easy to satisfy.
+ *
+ * It introspects the dataset live (datasets-server /splits + first row of each config)
+ * and pre-fills configs and highlight_columns, leaving human-judgement fields as TODOs.
+ *
+ *   node scripts/scaffold-capability-entry.js <hf_dataset> [--domain worldenergy|digitalmodel]
+ *   # e.g. node scripts/scaffold-capability-entry.js aceengineer/mooring-fatigue --domain digitalmodel
+ *
+ * Prints YAML to stdout — review, fill the TODOs, and paste under `capabilities:` in
+ * config/capabilities.yaml, then run `npm run validate:registry` to confirm it resolves.
+ */
+const { datasetConfigs, fetchTable } = require('./hf-fetch');
+
+const VIZ_HINT = { table: 'table', bar: 'bar', line: 'line', map: 'map' };
+
+function slugFromDataset(dataset) {
+  const name = String(dataset).split('/').pop() || 'capability';
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+// YAML-safe scalar: quote if it could be misparsed. Kept minimal — scaffold output is
+// meant to be reviewed by a human before commit.
+function y(v) {
+  const s = String(v);
+  return /^[A-Za-z0-9_][A-Za-z0-9_ .\/-]*$/.test(s) ? s : JSON.stringify(s);
+}
+
+async function scaffold(dataset, { domain = 'TODO(one of: worldenergy|digitalmodel)', maxCols = 5 } = {}) {
+  const configs = await datasetConfigs(dataset);
+  if (!configs.length) throw new Error(`dataset '${dataset}' resolved but has no configs`);
+
+  const id = slugFromDataset(dataset);
+  const lines = [];
+  lines.push(`  - id: ${id}`);
+  lines.push(`    title: TODO(human-readable capability name)`);
+  lines.push(`    domain: ${domain}`);
+  lines.push(`    summary: >-`);
+  lines.push(`      TODO(one-sentence description shown on the card + detail page).`);
+  lines.push(`    hf_dataset: ${dataset}`);
+  lines.push(`    provenance_url: TODO(link to the repo/report that produced the data)`);
+  lines.push(`    status: live`);
+  lines.push(`    primary_config: ${configs[0]}`);
+  lines.push(`    tables:`);
+
+  for (const config of configs) {
+    let cols = [];
+    try {
+      const t = await fetchTable(dataset, config, { maxRows: 1 });
+      cols = t.columns.map(c => c.name);
+    } catch (err) {
+      cols = [`TODO(columns — could not read: ${err.message})`];
+    }
+    const highlight = cols.slice(0, maxCols).map(y).join(', ');
+    lines.push(`      - config: ${config}`);
+    lines.push(`        label: ${config.charAt(0).toUpperCase() + config.slice(1)}`);
+    lines.push(`        viz: ${VIZ_HINT.table}   # TODO(one of: table|bar|line|map)`);
+    lines.push(`        highlight_columns: [${highlight}]`);
+  }
+
+  lines.push(`    # withheld_columns: []   # columns that must NEVER be surfaced (CI blocks them)`);
+  lines.push(`    data_limits: >-`);
+  lines.push(`      TODO(honest disclosure of coverage + known limitations).`);
+  return lines.join('\n');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dataset = args.find(a => !a.startsWith('--'));
+  const di = args.indexOf('--domain');
+  const domain = di >= 0 ? args[di + 1] : undefined;
+
+  if (!dataset) {
+    console.error('usage: node scripts/scaffold-capability-entry.js <hf_dataset> [--domain worldenergy|digitalmodel]');
+    process.exit(2);
+  }
+  try {
+    const block = await scaffold(dataset, domain ? { domain } : {});
+    console.log('# Paste under `capabilities:` in config/capabilities.yaml, fill the TODOs,');
+    console.log('# then run `npm run validate:registry` to confirm it resolves.');
+    console.log(block);
+  } catch (err) {
+    console.error(`scaffold failed: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = { scaffold, slugFromDataset };

--- a/scripts/verify-capabilities-online.js
+++ b/scripts/verify-capabilities-online.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * verify-capabilities-online.js — the C7 going-forward CI gate (aceengineer-website#54).
+ *
+ * The offline structural gate (scripts/validate-capabilities.js, enforced by the
+ * `capabilities-registry` jest project) proves the registry is well-formed. This gate
+ * proves it is TRUE against Hugging Face — so "every new algorithm surfaces on the
+ * website" is enforced by CI, not left to good intentions:
+ *
+ *   - each `live` capability's `hf_dataset` resolves via the datasets-server /splits API;
+ *   - each table's `config` actually exists in that dataset;
+ *   - every `highlight_columns` entry exists in the dataset's columns (a typo'd column
+ *     would render an empty column — caught here, not in production);
+ *   - no `withheld_columns` value can reach rendered output (renderers only emit
+ *     highlight_columns, and the offline gate already forbids overlap — re-asserted here).
+ *
+ * Only `status: live` entries are resolved online — `pending` renders a placeholder and
+ * `withheld` isn't surfaced, so neither requires a resolvable dataset yet.
+ *
+ * Resilience: a genuine "not found" (HTTP 404 — dataset/config really absent) is a hard
+ * ERROR that fails CI. A transient failure (timeout, 5xx, network) is a WARNING that does
+ * NOT fail CI, so a Hugging Face outage never red-lights an unrelated PR.
+ *
+ *   node scripts/verify-capabilities-online.js        # or: npm run validate:capabilities:online
+ *
+ * Exit 0 = no blocking errors, exit 1 = one or more resolution errors printed.
+ */
+const path = require('path');
+const { loadRegistry, validateRegistry, DEFAULT_REGISTRY } = require('./validate-capabilities');
+const { datasetConfigs, fetchTable } = require('./hf-fetch');
+
+// Classify an hf-fetch error: a 404 means the dataset/config is genuinely absent
+// (blocking); anything else (timeout, 5xx, DNS) is transient (non-blocking warning).
+function classify(err) {
+  return /HTTP 404\b/.test(err.message) ? 'not_found' : 'transient';
+}
+
+// Real network resolvers, built on the C2 datasets-server client. Each rethrows with a
+// `.code` so the pure checker can decide blocking-vs-transient without knowing about HTTP.
+function liveResolvers(timeoutMs) {
+  return {
+    async resolveConfigs(dataset) {
+      try {
+        return await datasetConfigs(dataset, timeoutMs);
+      } catch (err) {
+        const e = new Error(err.message); e.code = classify(err); throw e;
+      }
+    },
+    async fetchColumns(dataset, config) {
+      try {
+        const t = await fetchTable(dataset, config, { maxRows: 1, timeoutMs });
+        return t.columns.map(c => c.name);
+      } catch (err) {
+        const e = new Error(err.message); e.code = classify(err); throw e;
+      }
+    },
+  };
+}
+
+/**
+ * Pure resolution check. `resolvers` is { resolveConfigs, fetchColumns } — injected so
+ * this is unit-testable offline with mocks. Returns { errors, warnings } (string arrays).
+ * A resolver rejection with `.code === 'not_found'` is an error; anything else is a warning.
+ */
+async function checkResolution(registry, resolvers) {
+  const errors = [];
+  const warnings = [];
+  const caps = (registry && registry.capabilities) || [];
+
+  for (const cap of caps) {
+    if (cap.status !== 'live') continue; // pending/withheld don't render live data
+    const ds = cap.hf_dataset;
+
+    let configs;
+    try {
+      configs = await resolvers.resolveConfigs(ds);
+    } catch (err) {
+      if (err.code === 'not_found') {
+        errors.push(`${cap.id}: hf_dataset '${ds}' does not resolve on Hugging Face (dataset not found)`);
+      } else {
+        warnings.push(`${cap.id}: could not reach Hugging Face for '${ds}' (${err.message}) — skipping live checks`);
+      }
+      continue;
+    }
+
+    const configSet = new Set(configs);
+    const withheld = new Set(Array.isArray(cap.withheld_columns) ? cap.withheld_columns : []);
+
+    for (const table of cap.tables || []) {
+      if (!configSet.has(table.config)) {
+        errors.push(
+          `${cap.id}: config '${table.config}' not found in '${ds}' (available: ${configs.join(', ') || 'none'})`,
+        );
+        continue;
+      }
+
+      let columns;
+      try {
+        columns = await resolvers.fetchColumns(ds, table.config);
+      } catch (err) {
+        if (err.code === 'not_found') {
+          errors.push(`${cap.id}: config '${table.config}' rows not found in '${ds}'`);
+        } else {
+          warnings.push(`${cap.id}/${table.config}: could not read columns (${err.message}) — skipping column checks`);
+        }
+        continue;
+      }
+
+      const colSet = new Set(columns);
+      for (const hc of table.highlight_columns || []) {
+        if (!colSet.has(hc)) {
+          errors.push(
+            `${cap.id}/${table.config}: highlight column '${hc}' is not a column of the dataset ` +
+            `(would render empty). Present columns: ${columns.join(', ')}`,
+          );
+        }
+        // Belt-and-suspenders: a withheld column must never be surfaced (offline gate also forbids this).
+        if (withheld.has(hc)) {
+          errors.push(`${cap.id}/${table.config}: highlight column '${hc}' is withheld — would leak into rendered output`);
+        }
+      }
+    }
+  }
+
+  return { errors, warnings };
+}
+
+async function main() {
+  const registryFile = process.argv[2] || DEFAULT_REGISTRY;
+  const timeoutMs = Number(process.env.HF_TIMEOUT_MS) || 15000;
+
+  let registry;
+  try {
+    registry = loadRegistry(registryFile);
+  } catch (err) {
+    console.error(`validate:capabilities:online FAIL — cannot read/parse ${registryFile}: ${err.message}`);
+    process.exit(1);
+  }
+
+  // Fail fast if the registry isn't even structurally valid — online checks assume shape.
+  const structural = validateRegistry(registry);
+  if (structural.length) {
+    console.error('validate:capabilities:online FAIL — registry is not structurally valid; fix these first:');
+    structural.forEach(e => console.error(`  - ${e}`));
+    process.exit(1);
+  }
+
+  const { errors, warnings } = await checkResolution(registry, liveResolvers(timeoutMs));
+
+  warnings.forEach(w => console.warn(`  ~ (warning, non-blocking) ${w}`));
+
+  if (errors.length) {
+    console.error('validate:capabilities:online FAIL');
+    errors.forEach(e => console.error(`  - ${e}`));
+    process.exit(1);
+  }
+
+  const live = registry.capabilities.filter(c => c.status === 'live').length;
+  const note = warnings.length ? ` (${warnings.length} transient warning${warnings.length === 1 ? '' : 's'})` : '';
+  console.log(`validate:capabilities:online PASS — ${live} live capabilit${live === 1 ? 'y' : 'ies'} resolve${live === 1 ? 's' : ''} against Hugging Face${note}`);
+}
+
+if (require.main === module) main();
+
+module.exports = { checkResolution, classify, liveResolvers };

--- a/tests/js/capabilities-online.test.js
+++ b/tests/js/capabilities-online.test.js
@@ -1,0 +1,98 @@
+const { checkResolution, classify } = require('../../scripts/verify-capabilities-online');
+
+// A live capability with two configs; `main` has columns [a, b], `aux` has [c].
+function baseRegistry(overrides = {}) {
+  return {
+    version: 1,
+    capabilities: [{
+      id: 'demo', title: 'Demo', domain: 'worldenergy', summary: 's',
+      hf_dataset: 'aceengineer/demo', provenance_url: 'u', status: 'live',
+      primary_config: 'main', data_limits: 'd',
+      withheld_columns: overrides.withheld || [],
+      tables: [
+        { config: 'main', label: 'Main', viz: 'table', highlight_columns: overrides.mainCols || ['a', 'b'] },
+        { config: 'aux', label: 'Aux', viz: 'bar', highlight_columns: ['c'] },
+      ],
+    }],
+  };
+}
+
+// A resolver set that "knows" demo -> {main:[a,b], aux:[c]}. Individual behaviours are
+// overridable to simulate not-found / transient failures.
+function resolvers(opts = {}) {
+  const schema = { main: ['a', 'b'], aux: ['c'] };
+  return {
+    resolveConfigs: opts.resolveConfigs || (async (ds) => {
+      if (opts.datasetNotFound) { const e = new Error('HTTP 404'); e.code = 'not_found'; throw e; }
+      if (opts.datasetTransient) { const e = new Error('timeout'); e.code = 'transient'; throw e; }
+      return Object.keys(schema);
+    }),
+    fetchColumns: opts.fetchColumns || (async (ds, config) => {
+      if (opts.colsTransient) { const e = new Error('HTTP 503'); e.code = 'transient'; throw e; }
+      return schema[config] || [];
+    }),
+  };
+}
+
+describe('checkResolution (online gate, mocked)', () => {
+  test('passes when dataset, configs, and highlight columns all resolve', async () => {
+    const { errors, warnings } = await checkResolution(baseRegistry(), resolvers());
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  test('errors when the dataset does not resolve (404)', async () => {
+    const { errors } = await checkResolution(baseRegistry(), resolvers({ datasetNotFound: true }));
+    expect(errors.some(e => /does not resolve/.test(e))).toBe(true);
+  });
+
+  test('warns (does NOT error) on a transient dataset failure', async () => {
+    const { errors, warnings } = await checkResolution(baseRegistry(), resolvers({ datasetTransient: true }));
+    expect(errors).toEqual([]);
+    expect(warnings.some(w => /could not reach Hugging Face/.test(w))).toBe(true);
+  });
+
+  test('errors when a listed config is absent from the dataset', async () => {
+    const reg = baseRegistry();
+    reg.capabilities[0].tables[0].config = 'ghost';
+    reg.capabilities[0].primary_config = 'ghost';
+    const { errors } = await checkResolution(reg, resolvers());
+    expect(errors.some(e => /config 'ghost' not found/.test(e))).toBe(true);
+  });
+
+  test('errors when a highlight column is not a real dataset column', async () => {
+    const { errors } = await checkResolution(baseRegistry({ mainCols: ['a', 'nope'] }), resolvers());
+    expect(errors.some(e => /highlight column 'nope' is not a column/.test(e))).toBe(true);
+  });
+
+  test('errors when a highlight column is also withheld (leak guard, online)', async () => {
+    const { errors } = await checkResolution(baseRegistry({ mainCols: ['a'], withheld: ['a'] }), resolvers());
+    expect(errors.some(e => /is withheld — would leak/.test(e))).toBe(true);
+  });
+
+  test('warns (does NOT error) on transient column-read failure', async () => {
+    const { errors, warnings } = await checkResolution(baseRegistry(), resolvers({ colsTransient: true }));
+    expect(errors).toEqual([]);
+    expect(warnings.some(w => /could not read columns/.test(w))).toBe(true);
+  });
+
+  test('skips non-live entries (pending/withheld need no resolvable dataset)', async () => {
+    const reg = baseRegistry();
+    reg.capabilities[0].status = 'pending';
+    reg.capabilities[0].hf_dataset = 'aceengineer/does-not-exist-yet';
+    const spy = { resolveConfigs: jest.fn(), fetchColumns: jest.fn() };
+    const { errors } = await checkResolution(reg, spy);
+    expect(errors).toEqual([]);
+    expect(spy.resolveConfigs).not.toHaveBeenCalled();
+  });
+});
+
+describe('classify', () => {
+  test('404 → not_found (blocking)', () => {
+    expect(classify(new Error('HTTP 404 for https://x'))).toBe('not_found');
+  });
+  test('503 / timeout → transient (non-blocking)', () => {
+    expect(classify(new Error('HTTP 503 for https://x'))).toBe('transient');
+    expect(classify(new Error('The operation was aborted'))).toBe('transient');
+  });
+});


### PR DESCRIPTION
Part of epic **workspace-hub#3485** — **C7, the going-forward gate.** Closes #54.

Makes *"every new algorithm surfaces on the website"* a **contract enforced by CI**, not a good intention.

## What lands
- **`scripts/verify-capabilities-online.js`** — live registry gate. For each `status: live` capability it asserts: the `hf_dataset` resolves via the datasets-server `/splits` API, every table `config` exists, every `highlight_columns` entry is a real dataset column (a typo'd column would render empty — caught here), and no `withheld` column can reach rendered output. Reuses the C2 datasets-server client (`hf-fetch.js`).
  - **Outage-resilient:** a genuine *not found* (HTTP 404) is a **blocking error**; a transient failure (timeout/5xx/network) is a **non-blocking warning**, so a Hugging Face outage never red-lights an unrelated PR.
  - Only `live` entries are resolved — `pending` renders a placeholder, `withheld` isn't surfaced.
- **`tests/js/capabilities-online.test.js`** — offline unit tests of the pure checker via injected mock resolvers (registered as its own jest project so it actually runs).
- **`scripts/scaffold-capability-entry.js`** (`npm run scaffold:capability <hf_dataset>`) — introspects a published dataset and prints a ready-to-paste `capabilities.yaml` block, so registration is the path of least resistance.
- **`.github/pull_request_template.md`** — *new algorithm? → HF dataset + registry entry + `validate:registry`* checklist.
- **`ci.yml`** — runs `npm run validate:registry` as a **step inside the always-run `javascript` job** (not a skippable separate job — a skipped required check deadlocks PRs).
- **`package.json`** — `validate:capabilities:online`, `validate:registry`, `scaffold:capability` + jest project + coverage entry.

## Acceptance (from #54)
- ✅ A registry entry with a non-resolving dataset/config **fails CI** (404 → blocking error).
- ✅ A `withheld` column surfaced in `highlight_columns` **fails CI** (offline gate + re-asserted online).
- ✅ PR template shows the checklist; `scaffold:capability` emits a ready-to-paste entry.

## Verified locally
- 235/235 jest tests across 15 projects (adds the `capabilities-online` project).
- `npm run validate:registry` PASS — offline schema **and** live HF resolution against `aceengineer/worldenergydata-explorer`.
- `scaffold:capability` introspects the live dataset (3 configs) and emits a valid block.
- repo-structure contract checker: OK.

The offline structural gate was already enforced via the `capabilities-registry` jest project; C7 adds the **live** half + the going-forward machinery (template + scaffolder) that closes the loop.