### PR TITLE
feat(capabilities): CSP + optional client-side live refresh [C6]

### DIFF
--- a/assets/js/capabilities-refresh.js
+++ b/assets/js/capabilities-refresh.js
@@ -1,0 +1,235 @@
+/* capabilities-refresh.js — optional "Refresh to latest" for capability detail pages.
+ *
+ * C6 (aceengineer-website#53), epic workspace-hub#3485. Progressive enhancement ONLY:
+ * the page ships with build-time-baked data (the deterministic backbone). If JS is on and
+ * the visitor clicks "Refresh to latest", we re-fetch the same Hugging Face datasets-server
+ * /rows endpoint client-side and re-render the table + chart in place. If the fetch fails
+ * (or JS is off), the baked data stands untouched — the backbone never depends on this.
+ *
+ * Render logic mirrors scripts/render-capabilities.js (build time) closely enough that a
+ * refresh looks identical to a rebuild. Kept dependency-free and inline-string based so it
+ * needs no bundler and no CSP relaxation beyond adding the datasets-server origin to
+ * connect-src (see vercel.json).
+ */
+(function () {
+    'use strict';
+
+    var API = 'https://datasets-server.huggingface.co';
+    var FETCH_ROWS = 100;   // datasets-server /rows hard max per request; also what build materializes
+    var TABLE_ROWS = 50;    // rows shown in the table (matches MAX_TABLE_ROWS at build)
+    var MAX_BARS = 15;
+
+    function esc(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+
+    function isNumericDtype(dtype) {
+        return /int|float|double|decimal|number/i.test(String(dtype || ''));
+    }
+
+    function fmtCell(v) {
+        if (v === null || v === undefined || v === '') return '—'; // em dash
+        if (typeof v === 'number') {
+            return Number.isInteger(v)
+                ? v.toLocaleString('en-US')
+                : v.toLocaleString('en-US', { maximumFractionDigits: 2 });
+        }
+        return esc(v);
+    }
+
+    function fmtNum(v) {
+        return Number.isInteger(v) ? v.toLocaleString('en-US') : v.toLocaleString('en-US', { maximumFractionDigits: 2 });
+    }
+
+    // Mirror of hf-fetch.js normalize(): datasets-server /rows JSON -> { columns, rows, total_rows }.
+    function normalize(apiJson) {
+        var features = (apiJson && apiJson.features) || [];
+        var columns = features.slice()
+            .sort(function (a, b) { return a.feature_idx - b.feature_idx; })
+            .map(function (f) { return { name: f.name, dtype: (f.type && f.type.dtype) || 'string' }; });
+        var rows = ((apiJson && apiJson.rows) || []).map(function (r) { return r.row; });
+        var total = typeof (apiJson && apiJson.num_rows_total) === 'number' ? apiJson.num_rows_total : rows.length;
+        return { columns: columns, rows: rows, total_rows: total };
+    }
+
+    // highlight_columns first (declared order), then the rest — matches build orderedColumns().
+    function orderColumns(columns, highlight) {
+        var names = columns.map(function (c) { return c.name; });
+        var hi = (highlight || []).filter(function (c) { return names.indexOf(c) !== -1; });
+        var rest = names.filter(function (c) { return hi.indexOf(c) === -1; });
+        return hi.concat(rest);
+    }
+
+    function tableHtml(data, highlight) {
+        var cols = orderColumns(data.columns, highlight);
+        var rows = data.rows || [];
+        if (!rows.length || !cols.length) return '<p style="color:#777;">No rows to display.</p>';
+        var shown = rows.slice(0, TABLE_ROWS);
+        var head = cols.map(function (c) {
+            return '<th style="text-align:left;padding:8px 12px;border-bottom:2px solid #dde1e5;white-space:nowrap;">' + esc(c) + '</th>';
+        }).join('');
+        var body = shown.map(function (r) {
+            return '<tr>' + cols.map(function (c) {
+                return '<td style="padding:7px 12px;border-bottom:1px solid #eef1f3;">' + fmtCell(r[c]) + '</td>';
+            }).join('') + '</tr>';
+        }).join('\n');
+        var total = data.total_rows != null ? data.total_rows : rows.length;
+        var note = shown.length < total
+            ? '<p style="color:#777;font-size:.85rem;margin:8px 0 0;">Showing ' + shown.length + ' of ' +
+              total.toLocaleString('en-US') + ' rows — full table on Hugging Face.</p>'
+            : '';
+        return '<div style="overflow-x:auto;"><table style="border-collapse:collapse;width:100%;font-size:.92rem;">' +
+            '<thead><tr>' + head + '</tr></thead><tbody>' + body + '</tbody></table></div>' + note;
+    }
+
+    // (labelKey, valueKey): first non-numeric highlight col = label, first numeric = value.
+    function pickKeys(columns, highlight) {
+        var dtypeOf = function (name) {
+            var col = columns.filter(function (c) { return c.name === name; })[0];
+            return col && col.dtype;
+        };
+        var pool = (highlight && highlight.length)
+            ? highlight.filter(function (c) { return columns.some(function (col) { return col.name === c; }); })
+            : columns.map(function (c) { return c.name; });
+        var valueKey = pool.filter(function (c) { return isNumericDtype(dtypeOf(c)); })[0];
+        var labelKey = pool.filter(function (c) { return c !== valueKey && !isNumericDtype(dtypeOf(c)); })[0]
+            || pool.filter(function (c) { return c !== valueKey; })[0];
+        return { labelKey: labelKey, valueKey: valueKey };
+    }
+
+    function barSvg(items) {
+        items = items.filter(function (d) { return typeof d.value === 'number' && !isNaN(d.value); }).slice(0, MAX_BARS);
+        if (!items.length) return '';
+        var max = Math.max.apply(null, items.map(function (d) { return d.value; }).concat([0])) || 1;
+        var rowH = 26, gap = 8, labelW = 160, chartW = 460, pad = 8;
+        var width = labelW + chartW + pad * 2;
+        var height = items.length * (rowH + gap) + pad * 2;
+        var bars = items.map(function (d, i) {
+            var y = pad + i * (rowH + gap);
+            var w = Math.max(1, Math.round((d.value / max) * chartW));
+            return '<text x="' + (labelW - 6) + '" y="' + (y + rowH / 2 + 4) + '" text-anchor="end" font-size="12" fill="#333">' +
+                esc(String(d.label)) + '</text>' +
+                '<rect x="' + labelW + '" y="' + y + '" width="' + w + '" height="' + rowH + '" rx="3" fill="#1d4e89"></rect>' +
+                '<text x="' + (labelW + w + 6) + '" y="' + (y + rowH / 2 + 4) + '" font-size="12" fill="#333">' + fmtNum(d.value) + '</text>';
+        }).join('');
+        return '<svg viewBox="0 0 ' + width + ' ' + height + '" width="100%" role="img" style="max-width:' + width +
+            'px;height:auto;font-family:inherit;" preserveAspectRatio="xMinYMin meet">' + bars + '</svg>';
+    }
+
+    function lineSvg(items) {
+        items = items.filter(function (d) { return typeof d.value === 'number' && !isNaN(d.value); });
+        if (items.length < 2) return barSvg(items);
+        var values = items.map(function (d) { return d.value; });
+        var max = Math.max.apply(null, values), min = Math.min.apply(null, values);
+        var span = (max - min) || 1;
+        var w = 640, h = 220, pad = 30;
+        var step = (w - pad * 2) / (items.length - 1);
+        var pts = items.map(function (d, i) {
+            var x = pad + i * step;
+            var y = h - pad - ((d.value - min) / span) * (h - pad * 2);
+            return x.toFixed(1) + ',' + y.toFixed(1);
+        }).join(' ');
+        return '<svg viewBox="0 0 ' + w + ' ' + h + '" width="100%" role="img" style="max-width:' + w +
+            'px;height:auto;" preserveAspectRatio="xMinYMin meet">' +
+            '<polyline fill="none" stroke="#0b6e4f" stroke-width="2" points="' + pts + '"></polyline>' +
+            '<text x="' + pad + '" y="16" font-size="12" fill="#666">max ' + max.toLocaleString('en-US') + '</text></svg>';
+    }
+
+    function chartHtml(viz, data, highlight) {
+        if (viz !== 'bar' && viz !== 'line') return '';
+        var keys = pickKeys(data.columns, highlight);
+        if (!keys.labelKey || !keys.valueKey) return '';
+        var series = (data.rows || []).map(function (r) { return { label: r[keys.labelKey], value: r[keys.valueKey] }; })
+            .filter(function (d) { return typeof d.value === 'number' && !isNaN(d.value); });
+        if (!series.length) return '';
+        if (viz === 'bar') {
+            series.sort(function (a, b) { return b.value - a.value; });
+            return '<div style="margin:10px 0 6px;">' + barSvg(series) + '</div>' +
+                '<p style="color:#777;font-size:.82rem;margin:0 0 4px;">' + esc(keys.valueKey) + ' by ' + esc(keys.labelKey) +
+                ' (top ' + Math.min(MAX_BARS, series.length) + ')</p>';
+        }
+        return '<div style="margin:10px 0 6px;">' + lineSvg(series) + '</div>' +
+            '<p style="color:#777;font-size:.82rem;margin:0 0 4px;">' + esc(keys.valueKey) + ' across ' + esc(keys.labelKey) + '</p>';
+    }
+
+    function rowsUrl(dataset, config, split, length) {
+        return API + '/rows?dataset=' + encodeURIComponent(dataset) + '&config=' + encodeURIComponent(config) +
+            '&split=' + encodeURIComponent(split || 'train') + '&offset=0&length=' + Math.min(FETCH_ROWS, length || FETCH_ROWS);
+    }
+
+    function readHighlight(section) {
+        try { return JSON.parse(section.getAttribute('data-highlight') || '[]'); } catch (e) { return []; }
+    }
+
+    // Re-fetch + re-render one table section. Resolves true on success, false on any failure
+    // (leaving the baked markup untouched). Never throws.
+    function refreshSection(section, fetchImpl) {
+        var doFetch = fetchImpl || (typeof window !== 'undefined' && window.fetch ? window.fetch.bind(window) : null);
+        if (!doFetch) return Promise.resolve(false);
+        var dataset = section.getAttribute('data-hf-dataset');
+        var config = section.getAttribute('data-hf-config');
+        var split = section.getAttribute('data-hf-split') || 'train';
+        var viz = section.getAttribute('data-viz') || 'table';
+        var highlight = readHighlight(section);
+        var target = section.querySelector('[data-cap-render]');
+        if (!dataset || !config || !target) return Promise.resolve(false);
+
+        return doFetch(rowsUrl(dataset, config, split, FETCH_ROWS), { headers: { accept: 'application/json' } })
+            .then(function (res) {
+                if (!res || !res.ok) throw new Error('HTTP ' + (res && res.status));
+                return res.json();
+            })
+            .then(function (json) {
+                var data = normalize(json);
+                if (!data.rows.length) throw new Error('empty');
+                target.innerHTML = chartHtml(viz, data, highlight) + tableHtml(data, highlight);
+                return true;
+            })
+            .catch(function () { return false; });
+    }
+
+    function setStatus(statusEl, text, tone) {
+        if (!statusEl) return;
+        statusEl.textContent = text;
+        statusEl.style.color = tone === 'error' ? '#a15c00' : (tone === 'ok' ? '#0e7e88' : '#777');
+    }
+
+    function onRefresh(root, btn, statusEl, fetchImpl) {
+        var sections = root.querySelectorAll('[data-cap-table]');
+        if (!sections.length) return Promise.resolve();
+        btn.disabled = true;
+        setStatus(statusEl, 'Refreshing…', 'muted');
+        var jobs = [];
+        for (var i = 0; i < sections.length; i++) jobs.push(refreshSection(sections[i], fetchImpl));
+        return Promise.all(jobs).then(function (results) {
+            var ok = results.filter(Boolean).length;
+            btn.disabled = false;
+            if (ok === results.length) setStatus(statusEl, 'Updated just now.', 'ok');
+            else if (ok === 0) setStatus(statusEl, 'Live refresh unavailable — showing baked data.', 'error');
+            else setStatus(statusEl, 'Updated ' + ok + ' of ' + results.length + ' — rest showing baked data.', 'error');
+        });
+    }
+
+    function init() {
+        var btn = document.querySelector('[data-refresh-capabilities]');
+        if (!btn) return;
+        var root = document.querySelector('[data-capability-detail]') || document;
+        var statusEl = document.querySelector('[data-refresh-status]');
+        btn.addEventListener('click', function () { onRefresh(root, btn, statusEl); });
+    }
+
+    if (typeof document !== 'undefined') {
+        if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+        else init();
+    }
+
+    // Exposed for unit testing (isomorphic pattern, cf. assets/js/cta-tracking.js).
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+            normalize: normalize, orderColumns: orderColumns, tableHtml: tableHtml,
+            pickKeys: pickKeys, chartHtml: chartHtml, rowsUrl: rowsUrl,
+            refreshSection: refreshSection, onRefresh: onRefresh, init: init,
+        };
+    }
+})();

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
         "testMatch": ["<rootDir>/tests/js/render-capabilities.test.js"]
       },
       {
+        "displayName": "capabilities-refresh",
+        "testEnvironment": "jsdom",
+        "testMatch": ["<rootDir>/tests/js/capabilities-refresh.test.js"]
+      },
+      {
         "displayName": "jsdom",
         "testEnvironment": "jsdom",
         "testMatch": ["<rootDir>/tests/js/navbar-toggle.test.js"]
@@ -97,6 +102,7 @@
       "scripts/verify-capabilities-online.js",
       "assets/js/navbar-toggle.js",
       "assets/js/cta-tracking.js",
+      "assets/js/capabilities-refresh.js",
       "assets/js/npv-calculator-engine.js",
       "assets/js/mooring-fatigue-engine.js",
       "assets/js/decline-curve-engine.js",

--- a/scripts/render-capabilities.js
+++ b/scripts/render-capabilities.js
@@ -253,14 +253,31 @@ function capabilityDetailBody(cap) {
 
   const tables = (cap.tables || []).map(t => {
     const chart = renderChartFor(t);
+    // Data attributes let the optional client-side "Refresh to latest" (C6,
+    // assets/js/capabilities-refresh.js) re-fetch this exact table and re-render into
+    // [data-cap-render]. Inert without JS — the baked chart+table below is the default.
+    const attrs =
+      ` data-cap-table data-hf-dataset="${escapeHtml(cap.hf_dataset)}" data-hf-config="${escapeHtml(t.config)}"` +
+      ` data-hf-split="train" data-viz="${escapeHtml(t.viz)}"` +
+      ` data-highlight="${escapeHtml(JSON.stringify(t.highlight_columns || []))}"`;
     return (
-      `<section style="margin:28px 0;">` +
+      `<section style="margin:28px 0;"${attrs}>` +
       `<h2 style="font-size:1.3rem;color:#111;">${escapeHtml(t.label || t.config)}</h2>` +
-      chart +
-      renderTable(t) +
+      `<div data-cap-render>` + chart + renderTable(t) + `</div>` +
       `</section>`
     );
   }).join('\n');
+
+  // Progressive-enhancement affordance — only where there is live data to refresh.
+  const refresh = hasData(cap)
+    ? `<div style="margin:14px 0 4px;">` +
+      `<button type="button" data-refresh-capabilities ` +
+      `style="background:${domainColor};color:#fff;border:none;border-radius:6px;padding:8px 16px;` +
+      `font-size:.9rem;font-weight:600;letter-spacing:.02em;cursor:pointer;">Refresh to latest</button>` +
+      `<span data-refresh-status role="status" aria-live="polite" ` +
+      `style="margin-left:12px;font-size:.9rem;color:#777;"></span>` +
+      `</div>`
+    : '';
 
   const provenance =
     `<div style="margin-top:32px;padding:18px 20px;background:#f8f9fa;border-radius:8px;">` +
@@ -275,7 +292,8 @@ function capabilityDetailBody(cap) {
     `<div style="margin:10px 0 6px;">${badge}</div>` +
     `<h1 style="margin:4px 0 8px;">${escapeHtml(cap.title)}</h1>` +
     `<p style="font-size:1.12rem;color:#444;max-width:760px;">${escapeHtml(cap.summary)}</p>` +
-    tables +
+    refresh +
+    `<div data-capability-detail>` + tables + `</div>` +
     provenance
   );
 }
@@ -300,6 +318,7 @@ function capabilityDetailDocument(cap) {
     capabilityDetailBody(cap) +
     `\n</div></section>\n` +
     `<include src="partials/footer.html"></include>\n` +
+    `<script src="/assets/js/capabilities-refresh.js" defer></script>\n` +
     `</body>\n</html>\n`
   );
 }

--- a/tests/js/capabilities-refresh.test.js
+++ b/tests/js/capabilities-refresh.test.js
@@ -1,0 +1,189 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require('fs');
+const path = require('path');
+const R = require('../../assets/js/capabilities-refresh');
+const { capabilityDetailBody, capabilityDetailDocument } = require('../../scripts/render-capabilities');
+
+describe('CSP allows the datasets-server origin (C6)', () => {
+  test('vercel.json connect-src includes the Hugging Face datasets-server', () => {
+    const vercel = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', '..', 'vercel.json'), 'utf8'));
+    const csp = vercel.headers
+      .flatMap(h => h.headers)
+      .find(h => h.key === 'Content-Security-Policy').value;
+    const connectSrc = csp.split(';').map(s => s.trim()).find(s => s.startsWith('connect-src'));
+    expect(connectSrc).toContain('https://datasets-server.huggingface.co');
+    // the refresh script itself is self-hosted, so script-src needs no new origin
+    const scriptSrc = csp.split(';').map(s => s.trim()).find(s => s.startsWith('script-src'));
+    expect(scriptSrc).toContain("'self'");
+  });
+});
+
+// A datasets-server /rows payload with two columns (label + numeric) and two rows.
+function rowsPayload() {
+  return {
+    features: [
+      { feature_idx: 1, name: 'sn_curve', type: { dtype: 'string' } },
+      { feature_idx: 0, name: 'damage', type: { dtype: 'float64' } },
+    ],
+    rows: [
+      { row: { sn_curve: 'B1', damage: 0.42 } },
+      { row: { sn_curve: 'D', damage: 0.91 } },
+    ],
+    num_rows_total: 312,
+  };
+}
+
+describe('pure render helpers', () => {
+  test('normalize sorts columns by feature_idx and unwraps rows', () => {
+    const d = R.normalize(rowsPayload());
+    expect(d.columns.map(c => c.name)).toEqual(['damage', 'sn_curve']); // feature_idx 0,1
+    expect(d.rows).toEqual([{ sn_curve: 'B1', damage: 0.42 }, { sn_curve: 'D', damage: 0.91 }]);
+    expect(d.total_rows).toBe(312);
+  });
+
+  test('orderColumns puts highlight columns first', () => {
+    const cols = [{ name: 'a' }, { name: 'b' }, { name: 'c' }];
+    expect(R.orderColumns(cols, ['c', 'a'])).toEqual(['c', 'a', 'b']);
+  });
+
+  test('tableHtml renders a header, cells, and a truncation note', () => {
+    const data = R.normalize(rowsPayload());
+    const html = R.tableHtml(data, ['sn_curve', 'damage']);
+    expect(html).toContain('<th');
+    expect(html).toContain('B1');
+    expect(html).toContain('Showing 2 of 312 rows');
+  });
+
+  test('pickKeys picks non-numeric label + numeric value', () => {
+    const data = R.normalize(rowsPayload());
+    const keys = R.pickKeys(data.columns, ['sn_curve', 'damage']);
+    expect(keys.labelKey).toBe('sn_curve');
+    expect(keys.valueKey).toBe('damage');
+  });
+
+  test('chartHtml emits an SVG for a bar viz', () => {
+    const data = R.normalize(rowsPayload());
+    const html = R.chartHtml('bar', data, ['sn_curve', 'damage']);
+    expect(html).toContain('<svg');
+    expect(html).toContain('damage by sn_curve');
+  });
+
+  test('chartHtml is empty for a plain table viz', () => {
+    const data = R.normalize(rowsPayload());
+    expect(R.chartHtml('table', data, ['sn_curve', 'damage'])).toBe('');
+  });
+
+  test('rowsUrl targets the datasets-server /rows endpoint with encoding', () => {
+    const url = R.rowsUrl('aceengineer/demo', 'main', 'train', 100);
+    expect(url).toContain('https://datasets-server.huggingface.co/rows');
+    expect(url).toContain('dataset=aceengineer%2Fdemo');
+    expect(url).toContain('config=main');
+    expect(url).toContain('length=100');
+  });
+});
+
+// Build a detail-page-style section with a [data-cap-render] target holding baked markup.
+function makeSection() {
+  const section = document.createElement('section');
+  section.setAttribute('data-cap-table', '');
+  section.setAttribute('data-hf-dataset', 'aceengineer/demo');
+  section.setAttribute('data-hf-config', 'mooring_fatigue');
+  section.setAttribute('data-hf-split', 'train');
+  section.setAttribute('data-viz', 'bar');
+  section.setAttribute('data-highlight', JSON.stringify(['sn_curve', 'damage']));
+  section.innerHTML = '<div data-cap-render><p>BAKED PLACEHOLDER</p></div>';
+  document.body.appendChild(section);
+  return section;
+}
+
+describe('refreshSection (client fetch + re-render)', () => {
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  test('re-renders the target from a successful fetch', async () => {
+    const section = makeSection();
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true, json: async () => rowsPayload() });
+    const ok = await R.refreshSection(section, fetchImpl);
+    expect(ok).toBe(true);
+    const target = section.querySelector('[data-cap-render]');
+    expect(target.innerHTML).not.toContain('BAKED PLACEHOLDER');
+    expect(target.innerHTML).toContain('B1');
+    expect(target.innerHTML).toContain('<svg'); // chart re-rendered too
+    // requested the right dataset/config
+    expect(fetchImpl.mock.calls[0][0]).toContain('config=mooring_fatigue');
+  });
+
+  test('graceful degradation: a failed fetch leaves the baked markup intact', async () => {
+    const section = makeSection();
+    const fetchImpl = jest.fn().mockRejectedValue(new Error('offline'));
+    const ok = await R.refreshSection(section, fetchImpl);
+    expect(ok).toBe(false);
+    expect(section.querySelector('[data-cap-render]').innerHTML).toContain('BAKED PLACEHOLDER');
+  });
+
+  test('a non-ok HTTP response also leaves baked markup intact', async () => {
+    const section = makeSection();
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) });
+    const ok = await R.refreshSection(section, fetchImpl);
+    expect(ok).toBe(false);
+    expect(section.querySelector('[data-cap-render]').innerHTML).toContain('BAKED PLACEHOLDER');
+  });
+});
+
+describe('onRefresh (status + button state)', () => {
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  test('reports success status when all sections refresh', async () => {
+    makeSection();
+    const btn = document.createElement('button');
+    const statusEl = document.createElement('span');
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true, json: async () => rowsPayload() });
+    await R.onRefresh(document, btn, statusEl, fetchImpl);
+    expect(statusEl.textContent).toMatch(/Updated just now/);
+    expect(btn.disabled).toBe(false);
+  });
+
+  test('reports a graceful failure status when refresh is unavailable', async () => {
+    makeSection();
+    const btn = document.createElement('button');
+    const statusEl = document.createElement('span');
+    const fetchImpl = jest.fn().mockRejectedValue(new Error('offline'));
+    await R.onRefresh(document, btn, statusEl, fetchImpl);
+    expect(statusEl.textContent).toMatch(/showing baked data/);
+  });
+});
+
+describe('detail page wires the refresh affordance', () => {
+  const cap = {
+    id: 'mooring-fatigue', title: 'Mooring Fatigue', domain: 'digitalmodel',
+    summary: 's', hf_dataset: 'aceengineer/demo', provenance_url: 'https://x', status: 'live',
+    primary_config: 'mooring_fatigue', data_limits: 'd',
+    tables: [{
+      config: 'mooring_fatigue', label: 'Mooring Fatigue', viz: 'bar',
+      highlight_columns: ['sn_curve', 'damage'],
+      data: {
+        columns: [{ name: 'sn_curve', dtype: 'string' }, { name: 'damage', dtype: 'float64' }],
+        rows: [{ sn_curve: 'B1', damage: 0.42 }], total_rows: 312,
+      },
+    }],
+  };
+
+  test('body includes data attributes, a swap target, and a refresh button', () => {
+    const body = capabilityDetailBody(cap);
+    expect(body).toContain('data-cap-table');
+    expect(body).toContain('data-hf-config="mooring_fatigue"');
+    expect(body).toContain('data-cap-render');
+    expect(body).toContain('data-refresh-capabilities');
+    expect(body).toContain('data-highlight="[&quot;sn_curve&quot;,&quot;damage&quot;]"');
+  });
+
+  test('document includes the refresh script', () => {
+    expect(capabilityDetailDocument(cap)).toContain('/assets/js/capabilities-refresh.js');
+  });
+
+  test('a pending capability (no data) gets no refresh button', () => {
+    const pending = Object.assign({}, cap, { status: 'pending', tables: [Object.assign({}, cap.tables[0], { data: null })] });
+    expect(capabilityDetailBody(pending)).not.toContain('data-refresh-capabilities');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -55,7 +55,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.plot.ly https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.web3forms.com https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com; form-action 'self' https://api.web3forms.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.plot.ly https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.web3forms.com https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com https://datasets-server.huggingface.co; form-action 'self' https://api.web3forms.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; upgrade-insecure-requests"
         }
       ]
     }


### PR DESCRIPTION
Part of epic **workspace-hub#3485** — **C6 (enhancement).** Closes #53.

Progressive-enhancement **"Refresh to latest"** on capability detail pages. The build-time-baked data remains the deterministic backbone; this only *enhances* it when JS is on and the visitor asks for it.

## What lands
- **`assets/js/capabilities-refresh.js`** — isomorphic (runs in the browser; unit-testable in jest via the `module.exports` guard, same pattern as `cta-tracking.js`). On click it re-fetches the same datasets-server `/rows` endpoint per table and re-renders the **table + inline-SVG chart** into `[data-cap-render]`. Render logic mirrors `scripts/render-capabilities.js` so a refresh looks identical to a rebuild. **Never throws** — any fetch/HTTP failure leaves the baked markup untouched.
- **`scripts/render-capabilities.js`** — detail sections now carry `data-*` (dataset/config/split/viz/highlight) + a `[data-cap-render]` swap target; a **"Refresh to latest"** button + `aria-live` status render **only where there is live data**; the detail document includes the script (`defer`).
- **`vercel.json`** — adds `https://datasets-server.huggingface.co` to CSP `connect-src`. The refresh script is **self-hosted**, so `script-src` is unchanged (no CSP weakening).
- **`tests/js/capabilities-refresh.test.js`** (new jsdom project) — pure helpers, the fetch/re-render path, **graceful degradation** (failed fetch *and* non-ok HTTP both leave baked data), status transitions, detail-page wiring, and a CSP guard.

## Acceptance (from #53)
- ✅ CSP allows the datasets-server origin (guarded by a test); security posture otherwise unchanged (self-hosted script, no `script-src` change).
- ✅ Refresh button updates the view live; **failure leaves the baked data intact** (tested two failure modes).
- ✅ SEO/Lighthouse unaffected — baked content is the default render; the button is inert without JS.

## Verified locally
- 251/251 jest tests across 16 projects (adds the `capabilities-refresh` jsdom project).
- `npm run build` → generated `dist/capabilities/field-explorer.html` contains the button, `data-cap-table` sections (fields/wells/countries), swap targets, and the script; script copied to `dist/assets/js/`.
- repo-structure contract checker: OK.

This also lets C7's live gate and C6's live refresh reinforce each other: the data a visitor can pull on demand is the same data CI proves resolves.