### PR TITLE
feat(capabilities): surface digitalmodel parametric atlases [C8]

### DIFF
--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -61,3 +61,33 @@ capabilities:
       Coverage is primarily US Gulf of Mexico deepwater (BSEE) plus selected
       international basins; not a complete global census. Economics (NPV, breakeven)
       are withheld pending correctness re-verification (worldenergydata#978).
+
+  - id: atlas-explorer
+    title: Digital Model Parametric Atlases
+    domain: digitalmodel
+    summary: >-
+      Standard-traceable parametric result grids — mooring fatigue (S-N), synthetic-rope
+      fatigue (T-N), and riser code-check utilisation — from digitalmodel's validated
+      reduced-order atlases.
+    hf_dataset: aceengineer/digitalmodel-atlas-explorer
+    provenance_url: https://github.com/vamseeachanta/digitalmodel
+    status: live
+    primary_config: mooring_fatigue
+    tables:
+      - config: mooring_fatigue
+        label: Mooring Fatigue (DNV-RP-C203 S-N)
+        viz: table
+        highlight_columns: [sn_curve, stress_MPa, n_cycles, damage]
+      - config: synthetic_rope_mooring_fatigue
+        label: Synthetic Rope Fatigue (DNV-OS-E301 T-N)
+        viz: table
+        highlight_columns: [tension_range_kN, n_cycles, MBL_kN, damage]
+      - config: code_check
+        label: Riser Code Check (API-RP-2RD)
+        viz: table
+        highlight_columns: [outer_diameter, wall_thickness, effective_tension_kN, bending_moment_kNm, smys, utilisation]
+    data_limits: >-
+      Synthetic parametric sweeps generated from the cited standards (DNV-RP-C203,
+      DNV-OS-E301, API-RP-2RD) and validated to under 10% max relative error against
+      held-out samples. For screening and capability demonstration — not a substitute
+      for a project-specific engineering check.

--- a/data/hf-cache/aceengineer__digitalmodel-atlas-explorer__code_check.json
+++ b/data/hf-cache/aceengineer__digitalmodel-atlas-explorer__code_check.json
@@ -1,0 +1,835 @@
+{
+  "dataset": "aceengineer/digitalmodel-atlas-explorer",
+  "config": "code_check",
+  "columns": [
+    {
+      "name": "outer_diameter",
+      "dtype": "float64"
+    },
+    {
+      "name": "wall_thickness",
+      "dtype": "float64"
+    },
+    {
+      "name": "effective_tension_kN",
+      "dtype": "float64"
+    },
+    {
+      "name": "bending_moment_kNm",
+      "dtype": "float64"
+    },
+    {
+      "name": "smys",
+      "dtype": "float64"
+    },
+    {
+      "name": "utilisation",
+      "dtype": "float64"
+    }
+  ],
+  "rows": [
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 0,
+      "smys": 359000000,
+      "utilisation": 0
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 0,
+      "smys": 448000000,
+      "utilisation": 0
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 0,
+      "smys": 552000000,
+      "utilisation": 0
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 80,
+      "smys": 359000000,
+      "utilisation": 0.6465
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 80,
+      "smys": 448000000,
+      "utilisation": 0.518
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 80,
+      "smys": 552000000,
+      "utilisation": 0.4204
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 160,
+      "smys": 359000000,
+      "utilisation": 1.2929
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 160,
+      "smys": 448000000,
+      "utilisation": 1.0361
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 160,
+      "smys": 552000000,
+      "utilisation": 0.8409
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 240,
+      "smys": 359000000,
+      "utilisation": 1.9394
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 240,
+      "smys": 448000000,
+      "utilisation": 1.5541
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 240,
+      "smys": 552000000,
+      "utilisation": 1.2613
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 320,
+      "smys": 359000000,
+      "utilisation": 2.5858
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 320,
+      "smys": 448000000,
+      "utilisation": 2.0721
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 320,
+      "smys": 552000000,
+      "utilisation": 1.6817
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 400,
+      "smys": 359000000,
+      "utilisation": 3.2323
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 400,
+      "smys": 448000000,
+      "utilisation": 2.5901
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 0,
+      "bending_moment_kNm": 400,
+      "smys": 552000000,
+      "utilisation": 2.1021
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 0,
+      "smys": 359000000,
+      "utilisation": 0.1908
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 0,
+      "smys": 448000000,
+      "utilisation": 0.1529
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 0,
+      "smys": 552000000,
+      "utilisation": 0.1241
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 80,
+      "smys": 359000000,
+      "utilisation": 0.674
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 80,
+      "smys": 448000000,
+      "utilisation": 0.5401
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 80,
+      "smys": 552000000,
+      "utilisation": 0.4383
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 160,
+      "smys": 359000000,
+      "utilisation": 1.3069
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 160,
+      "smys": 448000000,
+      "utilisation": 1.0473
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 160,
+      "smys": 552000000,
+      "utilisation": 0.85
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 240,
+      "smys": 359000000,
+      "utilisation": 1.9487
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 240,
+      "smys": 448000000,
+      "utilisation": 1.5616
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 240,
+      "smys": 552000000,
+      "utilisation": 1.2674
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 320,
+      "smys": 359000000,
+      "utilisation": 2.5928
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 320,
+      "smys": 448000000,
+      "utilisation": 2.0777
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 320,
+      "smys": 552000000,
+      "utilisation": 1.6863
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 400,
+      "smys": 359000000,
+      "utilisation": 3.2379
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 400,
+      "smys": 448000000,
+      "utilisation": 2.5946
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 400,
+      "bending_moment_kNm": 400,
+      "smys": 552000000,
+      "utilisation": 2.1058
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 0,
+      "smys": 359000000,
+      "utilisation": 0.3815
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 0,
+      "smys": 448000000,
+      "utilisation": 0.3057
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 0,
+      "smys": 552000000,
+      "utilisation": 0.2481
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 80,
+      "smys": 359000000,
+      "utilisation": 0.7506
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 80,
+      "smys": 448000000,
+      "utilisation": 0.6015
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 80,
+      "smys": 552000000,
+      "utilisation": 0.4882
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 160,
+      "smys": 359000000,
+      "utilisation": 1.348
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 160,
+      "smys": 448000000,
+      "utilisation": 1.0802
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 160,
+      "smys": 552000000,
+      "utilisation": 0.8767
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 240,
+      "smys": 359000000,
+      "utilisation": 1.9765
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 240,
+      "smys": 448000000,
+      "utilisation": 1.5839
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 240,
+      "smys": 552000000,
+      "utilisation": 1.2855
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 320,
+      "smys": 359000000,
+      "utilisation": 2.6138
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 320,
+      "smys": 448000000,
+      "utilisation": 2.0945
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 320,
+      "smys": 552000000,
+      "utilisation": 1.6999
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 400,
+      "smys": 359000000,
+      "utilisation": 3.2547
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 400,
+      "smys": 448000000,
+      "utilisation": 2.6081
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 800,
+      "bending_moment_kNm": 400,
+      "smys": 552000000,
+      "utilisation": 2.1167
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 0,
+      "smys": 359000000,
+      "utilisation": 0.5723
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 0,
+      "smys": 448000000,
+      "utilisation": 0.4586
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 0,
+      "smys": 552000000,
+      "utilisation": 0.3722
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 80,
+      "smys": 359000000,
+      "utilisation": 0.8634
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 80,
+      "smys": 448000000,
+      "utilisation": 0.6918
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 80,
+      "smys": 552000000,
+      "utilisation": 0.5615
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 160,
+      "smys": 359000000,
+      "utilisation": 1.4139
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 160,
+      "smys": 448000000,
+      "utilisation": 1.133
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 160,
+      "smys": 552000000,
+      "utilisation": 0.9195
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 240,
+      "smys": 359000000,
+      "utilisation": 2.022
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 240,
+      "smys": 448000000,
+      "utilisation": 1.6203
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 240,
+      "smys": 552000000,
+      "utilisation": 1.315
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 320,
+      "smys": 359000000,
+      "utilisation": 2.6484
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 320,
+      "smys": 448000000,
+      "utilisation": 2.1222
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 320,
+      "smys": 552000000,
+      "utilisation": 1.7224
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 400,
+      "smys": 359000000,
+      "utilisation": 3.2825
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 400,
+      "smys": 448000000,
+      "utilisation": 2.6304
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1200,
+      "bending_moment_kNm": 400,
+      "smys": 552000000,
+      "utilisation": 2.1348
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 0,
+      "smys": 359000000,
+      "utilisation": 0.763
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 0,
+      "smys": 448000000,
+      "utilisation": 0.6114
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 0,
+      "smys": 552000000,
+      "utilisation": 0.4962
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 80,
+      "smys": 359000000,
+      "utilisation": 1.0001
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 80,
+      "smys": 448000000,
+      "utilisation": 0.8014
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 80,
+      "smys": 552000000,
+      "utilisation": 0.6504
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 160,
+      "smys": 359000000,
+      "utilisation": 1.5013
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 160,
+      "smys": 448000000,
+      "utilisation": 1.203
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 160,
+      "smys": 552000000,
+      "utilisation": 0.9764
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 240,
+      "smys": 359000000,
+      "utilisation": 2.0841
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 240,
+      "smys": 448000000,
+      "utilisation": 1.67
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 240,
+      "smys": 552000000,
+      "utilisation": 1.3554
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 320,
+      "smys": 359000000,
+      "utilisation": 2.696
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 320,
+      "smys": 448000000,
+      "utilisation": 2.1604
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 320,
+      "smys": 552000000,
+      "utilisation": 1.7534
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 400,
+      "smys": 359000000,
+      "utilisation": 3.3211
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 400,
+      "smys": 448000000,
+      "utilisation": 2.6613
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 1600,
+      "bending_moment_kNm": 400,
+      "smys": 552000000,
+      "utilisation": 2.1599
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 2000,
+      "bending_moment_kNm": 0,
+      "smys": 359000000,
+      "utilisation": 0.9538
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 2000,
+      "bending_moment_kNm": 0,
+      "smys": 448000000,
+      "utilisation": 0.7643
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 2000,
+      "bending_moment_kNm": 0,
+      "smys": 552000000,
+      "utilisation": 0.6203
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 2000,
+      "bending_moment_kNm": 80,
+      "smys": 359000000,
+      "utilisation": 1.1522
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 2000,
+      "bending_moment_kNm": 80,
+      "smys": 448000000,
+      "utilisation": 0.9233
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 2000,
+      "bending_moment_kNm": 80,
+      "smys": 552000000,
+      "utilisation": 0.7494
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 2000,
+      "bending_moment_kNm": 160,
+      "smys": 359000000,
+      "utilisation": 1.6066
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 2000,
+      "bending_moment_kNm": 160,
+      "smys": 448000000,
+      "utilisation": 1.2875
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 2000,
+      "bending_moment_kNm": 160,
+      "smys": 552000000,
+      "utilisation": 1.0449
+    },
+    {
+      "outer_diameter": 0.2,
+      "wall_thickness": 0.015,
+      "effective_tension_kN": 2000,
+      "bending_moment_kNm": 240,
+      "smys": 359000000,
+      "utilisation": 2.1612
+    }
+  ],
+  "total_rows": 2700,
+  "fetched": 100,
+  "truncated": true
+}

--- a/data/hf-cache/aceengineer__digitalmodel-atlas-explorer__mooring_fatigue.json
+++ b/data/hf-cache/aceengineer__digitalmodel-atlas-explorer__mooring_fatigue.json
@@ -1,0 +1,627 @@
+{
+  "dataset": "aceengineer/digitalmodel-atlas-explorer",
+  "config": "mooring_fatigue",
+  "columns": [
+    {
+      "name": "stress_MPa",
+      "dtype": "float64"
+    },
+    {
+      "name": "n_cycles",
+      "dtype": "float64"
+    },
+    {
+      "name": "sn_curve",
+      "dtype": "string"
+    },
+    {
+      "name": "damage",
+      "dtype": "float64"
+    }
+  ],
+  "rows": [
+    {
+      "stress_MPa": 11,
+      "n_cycles": 10000,
+      "sn_curve": "B1",
+      "damage": 2.045094712124789e-8
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 10000,
+      "sn_curve": "B2",
+      "damage": 3.9876168804302464e-8
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 10000,
+      "sn_curve": "C",
+      "damage": 3.5779156061357486e-7
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 10000,
+      "sn_curve": "C1",
+      "damage": 6.193889109018637e-7
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 10000,
+      "sn_curve": "C2",
+      "damage": 0.00000109302499264874
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 10000,
+      "sn_curve": "D",
+      "damage": 0.000001849112888956947
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 10000,
+      "sn_curve": "E",
+      "damage": 0.000003339105127314875
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 10000,
+      "sn_curve": "F",
+      "damage": 0.000006052898979805815
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 100000,
+      "sn_curve": "B1",
+      "damage": 2.045094712124789e-7
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 100000,
+      "sn_curve": "B2",
+      "damage": 3.9876168804302466e-7
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 100000,
+      "sn_curve": "C",
+      "damage": 0.0000035779156061357486
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 100000,
+      "sn_curve": "C1",
+      "damage": 0.000006193889109018637
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 100000,
+      "sn_curve": "C2",
+      "damage": 0.000010930249926487399
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 100000,
+      "sn_curve": "D",
+      "damage": 0.00001849112888956947
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 100000,
+      "sn_curve": "E",
+      "damage": 0.00003339105127314875
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 100000,
+      "sn_curve": "F",
+      "damage": 0.00006052898979805815
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 1000000,
+      "sn_curve": "B1",
+      "damage": 0.000002045094712124789
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 1000000,
+      "sn_curve": "B2",
+      "damage": 0.000003987616880430247
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 1000000,
+      "sn_curve": "C",
+      "damage": 0.000035779156061357485
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 1000000,
+      "sn_curve": "C1",
+      "damage": 0.00006193889109018637
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 1000000,
+      "sn_curve": "C2",
+      "damage": 0.00010930249926487398
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 1000000,
+      "sn_curve": "D",
+      "damage": 0.0001849112888956947
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 1000000,
+      "sn_curve": "E",
+      "damage": 0.0003339105127314875
+    },
+    {
+      "stress_MPa": 11,
+      "n_cycles": 1000000,
+      "sn_curve": "F",
+      "damage": 0.0006052898979805816
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 10000,
+      "sn_curve": "B1",
+      "damage": 6.829519956124477e-8
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 10000,
+      "sn_curve": "B2",
+      "damage": 1.3316502605389086e-7
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 10000,
+      "sn_curve": "C",
+      "damage": 0.000001194831999152041
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 10000,
+      "sn_curve": "C1",
+      "damage": 0.0000020684269058676066
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 10000,
+      "sn_curve": "C2",
+      "damage": 0.000003650117500955076
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 10000,
+      "sn_curve": "D",
+      "damage": 0.000006175045733279406
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 10000,
+      "sn_curve": "E",
+      "damage": 0.000011150821019385138
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 10000,
+      "sn_curve": "F",
+      "damage": 0.00002021343761240279
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 100000,
+      "sn_curve": "B1",
+      "damage": 6.829519956124477e-7
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 100000,
+      "sn_curve": "B2",
+      "damage": 0.0000013316502605389087
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 100000,
+      "sn_curve": "C",
+      "damage": 0.000011948319991520411
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 100000,
+      "sn_curve": "C1",
+      "damage": 0.00002068426905867607
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 100000,
+      "sn_curve": "C2",
+      "damage": 0.000036501175009550764
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 100000,
+      "sn_curve": "D",
+      "damage": 0.00006175045733279405
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 100000,
+      "sn_curve": "E",
+      "damage": 0.00011150821019385138
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 100000,
+      "sn_curve": "F",
+      "damage": 0.0002021343761240279
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 1000000,
+      "sn_curve": "B1",
+      "damage": 0.000006829519956124478
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 1000000,
+      "sn_curve": "B2",
+      "damage": 0.000013316502605389087
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 1000000,
+      "sn_curve": "C",
+      "damage": 0.00011948319991520411
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 1000000,
+      "sn_curve": "C1",
+      "damage": 0.00020684269058676068
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 1000000,
+      "sn_curve": "C2",
+      "damage": 0.0003650117500955076
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 1000000,
+      "sn_curve": "D",
+      "damage": 0.0006175045733279406
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 1000000,
+      "sn_curve": "E",
+      "damage": 0.0011150821019385137
+    },
+    {
+      "stress_MPa": 14,
+      "n_cycles": 1000000,
+      "sn_curve": "F",
+      "damage": 0.0020213437612402792
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 10000,
+      "sn_curve": "B1",
+      "damage": 2.399454536140859e-7
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 10000,
+      "sn_curve": "B2",
+      "damage": 4.6785634696591915e-7
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 10000,
+      "sn_curve": "C",
+      "damage": 0.000004197872000828755
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 10000,
+      "sn_curve": "C1",
+      "damage": 0.000007267123244158758
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 10000,
+      "sn_curve": "C2",
+      "damage": 0.000012824167805908037
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 10000,
+      "sn_curve": "D",
+      "damage": 0.000021695143422646255
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 10000,
+      "sn_curve": "E",
+      "damage": 0.000039176820989687236
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 10000,
+      "sn_curve": "F",
+      "damage": 0.00007101703323465059
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 100000,
+      "sn_curve": "B1",
+      "damage": 0.000002399454536140859
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 100000,
+      "sn_curve": "B2",
+      "damage": 0.0000046785634696591915
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 100000,
+      "sn_curve": "C",
+      "damage": 0.000041978720008287546
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 100000,
+      "sn_curve": "C1",
+      "damage": 0.00007267123244158758
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 100000,
+      "sn_curve": "C2",
+      "damage": 0.00012824167805908037
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 100000,
+      "sn_curve": "D",
+      "damage": 0.00021695143422646254
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 100000,
+      "sn_curve": "E",
+      "damage": 0.00039176820989687236
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 100000,
+      "sn_curve": "F",
+      "damage": 0.0007101703323465059
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 1000000,
+      "sn_curve": "B1",
+      "damage": 0.00002399454536140859
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 1000000,
+      "sn_curve": "B2",
+      "damage": 0.000046785634696591915
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 1000000,
+      "sn_curve": "C",
+      "damage": 0.0004197872000828755
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 1000000,
+      "sn_curve": "C1",
+      "damage": 0.0007267123244158758
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 1000000,
+      "sn_curve": "C2",
+      "damage": 0.0012824167805908038
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 1000000,
+      "sn_curve": "D",
+      "damage": 0.0021695143422646255
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 1000000,
+      "sn_curve": "E",
+      "damage": 0.003917682098968723
+    },
+    {
+      "stress_MPa": 18,
+      "n_cycles": 1000000,
+      "sn_curve": "F",
+      "damage": 0.0071017033234650586
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 10000,
+      "sn_curve": "B1",
+      "damage": 6.544303078799325e-7
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 10000,
+      "sn_curve": "B2",
+      "damage": 0.0000012760374017376789
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 10000,
+      "sn_curve": "C",
+      "damage": 0.000011449329939634396
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 10000,
+      "sn_curve": "C1",
+      "damage": 0.000019820445148859638
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 10000,
+      "sn_curve": "C2",
+      "damage": 0.00003497679976475968
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 10000,
+      "sn_curve": "D",
+      "damage": 0.000059171612446622307
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 10000,
+      "sn_curve": "E",
+      "damage": 0.000106851364074076
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 10000,
+      "sn_curve": "F",
+      "damage": 0.0001936927673537861
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 100000,
+      "sn_curve": "B1",
+      "damage": 0.000006544303078799325
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 100000,
+      "sn_curve": "B2",
+      "damage": 0.000012760374017376789
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 100000,
+      "sn_curve": "C",
+      "damage": 0.00011449329939634396
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 100000,
+      "sn_curve": "C1",
+      "damage": 0.00019820445148859638
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 100000,
+      "sn_curve": "C2",
+      "damage": 0.00034976799764759676
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 100000,
+      "sn_curve": "D",
+      "damage": 0.0005917161244662231
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 100000,
+      "sn_curve": "E",
+      "damage": 0.00106851364074076
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 100000,
+      "sn_curve": "F",
+      "damage": 0.0019369276735378609
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 1000000,
+      "sn_curve": "B1",
+      "damage": 0.00006544303078799325
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 1000000,
+      "sn_curve": "B2",
+      "damage": 0.0001276037401737679
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 1000000,
+      "sn_curve": "C",
+      "damage": 0.0011449329939634395
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 1000000,
+      "sn_curve": "C1",
+      "damage": 0.001982044514885964
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 1000000,
+      "sn_curve": "C2",
+      "damage": 0.0034976799764759674
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 1000000,
+      "sn_curve": "D",
+      "damage": 0.00591716124466223
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 1000000,
+      "sn_curve": "E",
+      "damage": 0.0106851364074076
+    },
+    {
+      "stress_MPa": 22,
+      "n_cycles": 1000000,
+      "sn_curve": "F",
+      "damage": 0.01936927673537861
+    },
+    {
+      "stress_MPa": 27,
+      "n_cycles": 10000,
+      "sn_curve": "B1",
+      "damage": 0.0000018220857883819648
+    },
+    {
+      "stress_MPa": 27,
+      "n_cycles": 10000,
+      "sn_curve": "B2",
+      "damage": 0.0000035527841347724482
+    },
+    {
+      "stress_MPa": 27,
+      "n_cycles": 10000,
+      "sn_curve": "C",
+      "damage": 0.00003187759050629334
+    },
+    {
+      "stress_MPa": 27,
+      "n_cycles": 10000,
+      "sn_curve": "C1",
+      "damage": 0.00005518471713533058
+    }
+  ],
+  "total_rows": 312,
+  "fetched": 100,
+  "truncated": true
+}

--- a/data/hf-cache/aceengineer__digitalmodel-atlas-explorer__synthetic_rope_mooring_fatigue.json
+++ b/data/hf-cache/aceengineer__digitalmodel-atlas-explorer__synthetic_rope_mooring_fatigue.json
@@ -1,0 +1,627 @@
+{
+  "dataset": "aceengineer/digitalmodel-atlas-explorer",
+  "config": "synthetic_rope_mooring_fatigue",
+  "columns": [
+    {
+      "name": "tension_range_kN",
+      "dtype": "float64"
+    },
+    {
+      "name": "n_cycles",
+      "dtype": "float64"
+    },
+    {
+      "name": "MBL_kN",
+      "dtype": "float64"
+    },
+    {
+      "name": "damage",
+      "dtype": "float64"
+    }
+  ],
+  "rows": [
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 10000,
+      "MBL_kN": 5000,
+      "damage": 5.894238694905509e-15
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 10000,
+      "MBL_kN": 10000,
+      "damage": 5.230750166576258e-19
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 10000,
+      "MBL_kN": 20000,
+      "damage": 4.641947624005439e-23
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 10000,
+      "MBL_kN": 35000,
+      "damage": 2.4854675682664397e-26
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 10000,
+      "MBL_kN": 50000,
+      "damage": 2.043749760886973e-28
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 100000,
+      "MBL_kN": 5000,
+      "damage": 5.894238694905509e-14
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 100000,
+      "MBL_kN": 10000,
+      "damage": 5.2307501665762575e-18
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 100000,
+      "MBL_kN": 20000,
+      "damage": 4.6419476240054385e-22
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 100000,
+      "MBL_kN": 35000,
+      "damage": 2.4854675682664396e-25
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 100000,
+      "MBL_kN": 50000,
+      "damage": 2.043749760886973e-27
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 1000000,
+      "MBL_kN": 5000,
+      "damage": 5.89423869490551e-13
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 1000000,
+      "MBL_kN": 10000,
+      "damage": 5.2307501665762576e-17
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 1000000,
+      "MBL_kN": 20000,
+      "damage": 4.641947624005439e-21
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 1000000,
+      "MBL_kN": 35000,
+      "damage": 2.4854675682664395e-24
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 1000000,
+      "MBL_kN": 50000,
+      "damage": 2.043749760886973e-26
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 10000000,
+      "MBL_kN": 5000,
+      "damage": 5.8942386949055095e-12
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 10000000,
+      "MBL_kN": 10000,
+      "damage": 5.2307501665762575e-16
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 10000000,
+      "MBL_kN": 20000,
+      "damage": 4.641947624005439e-20
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 10000000,
+      "MBL_kN": 35000,
+      "damage": 2.4854675682664397e-23
+    },
+    {
+      "tension_range_kN": 200,
+      "n_cycles": 10000000,
+      "MBL_kN": 50000,
+      "damage": 2.043749760886973e-25
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 10000,
+      "MBL_kN": 5000,
+      "damage": 6.641886667522015e-11
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 10000,
+      "MBL_kN": 10000,
+      "damage": 5.894238694905509e-15
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 10000,
+      "MBL_kN": 20000,
+      "damage": 5.230750166576258e-19
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 10000,
+      "MBL_kN": 35000,
+      "damage": 2.800733862117858e-22
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 10000,
+      "MBL_kN": 50000,
+      "damage": 2.3029868641592397e-24
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 100000,
+      "MBL_kN": 5000,
+      "damage": 6.641886667522015e-10
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 100000,
+      "MBL_kN": 10000,
+      "damage": 5.894238694905509e-14
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 100000,
+      "MBL_kN": 20000,
+      "damage": 5.2307501665762575e-18
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 100000,
+      "MBL_kN": 35000,
+      "damage": 2.800733862117858e-21
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 100000,
+      "MBL_kN": 50000,
+      "damage": 2.3029868641592398e-23
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 1000000,
+      "MBL_kN": 5000,
+      "damage": 6.641886667522015e-9
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 1000000,
+      "MBL_kN": 10000,
+      "damage": 5.89423869490551e-13
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 1000000,
+      "MBL_kN": 20000,
+      "damage": 5.2307501665762576e-17
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 1000000,
+      "MBL_kN": 35000,
+      "damage": 2.800733862117858e-20
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 1000000,
+      "MBL_kN": 50000,
+      "damage": 2.3029868641592396e-22
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 10000000,
+      "MBL_kN": 5000,
+      "damage": 6.641886667522015e-8
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 10000000,
+      "MBL_kN": 10000,
+      "damage": 5.8942386949055095e-12
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 10000000,
+      "MBL_kN": 20000,
+      "damage": 5.2307501665762575e-16
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 10000000,
+      "MBL_kN": 35000,
+      "damage": 2.800733862117858e-19
+    },
+    {
+      "tension_range_kN": 400,
+      "n_cycles": 10000000,
+      "MBL_kN": 50000,
+      "damage": 2.3029868641592397e-21
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 10000,
+      "MBL_kN": 5000,
+      "damage": 1.240462375323666e-7
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 10000,
+      "MBL_kN": 10000,
+      "damage": 1.1008289810122565e-11
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 10000,
+      "MBL_kN": 20000,
+      "damage": 9.769135038217419e-16
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 10000,
+      "MBL_kN": 35000,
+      "damage": 5.230750166576258e-19
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 10000,
+      "MBL_kN": 50000,
+      "damage": 4.301140171245928e-21
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 100000,
+      "MBL_kN": 5000,
+      "damage": 0.000001240462375323666
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 100000,
+      "MBL_kN": 10000,
+      "damage": 1.1008289810122566e-10
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 100000,
+      "MBL_kN": 20000,
+      "damage": 9.769135038217419e-15
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 100000,
+      "MBL_kN": 35000,
+      "damage": 5.2307501665762575e-18
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 100000,
+      "MBL_kN": 50000,
+      "damage": 4.3011401712459284e-20
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 1000000,
+      "MBL_kN": 5000,
+      "damage": 0.00001240462375323666
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 1000000,
+      "MBL_kN": 10000,
+      "damage": 1.1008289810122565e-9
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 1000000,
+      "MBL_kN": 20000,
+      "damage": 9.769135038217419e-14
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 1000000,
+      "MBL_kN": 35000,
+      "damage": 5.2307501665762576e-17
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 1000000,
+      "MBL_kN": 50000,
+      "damage": 4.3011401712459285e-19
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 10000000,
+      "MBL_kN": 5000,
+      "damage": 0.0001240462375323666
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 10000000,
+      "MBL_kN": 10000,
+      "damage": 1.1008289810122566e-8
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 10000000,
+      "MBL_kN": 20000,
+      "damage": 9.76913503821742e-13
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 10000000,
+      "MBL_kN": 35000,
+      "damage": 5.2307501665762575e-16
+    },
+    {
+      "tension_range_kN": 700,
+      "n_cycles": 10000000,
+      "MBL_kN": 50000,
+      "damage": 4.301140171245928e-18
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 10000,
+      "MBL_kN": 5000,
+      "damage": 0.00017552684607693623
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 10000,
+      "MBL_kN": 10000,
+      "damage": 1.55768560942247e-8
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 10000,
+      "MBL_kN": 20000,
+      "damage": 1.38234379072608e-12
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 10000,
+      "MBL_kN": 35000,
+      "damage": 7.401571362581454e-16
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 10000,
+      "MBL_kN": 50000,
+      "damage": 6.086162577858311e-18
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 100000,
+      "MBL_kN": 5000,
+      "damage": 0.0017552684607693623
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 100000,
+      "MBL_kN": 10000,
+      "damage": 1.5576856094224704e-7
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 100000,
+      "MBL_kN": 20000,
+      "damage": 1.3823437907260802e-11
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 100000,
+      "MBL_kN": 35000,
+      "damage": 7.401571362581454e-15
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 100000,
+      "MBL_kN": 50000,
+      "damage": 6.08616257785831e-17
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 1000000,
+      "MBL_kN": 5000,
+      "damage": 0.017552684607693624
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 1000000,
+      "MBL_kN": 10000,
+      "damage": 0.0000015576856094224703
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 1000000,
+      "MBL_kN": 20000,
+      "damage": 1.38234379072608e-10
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 1000000,
+      "MBL_kN": 35000,
+      "damage": 7.401571362581454e-14
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 1000000,
+      "MBL_kN": 50000,
+      "damage": 6.086162577858311e-16
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 10000000,
+      "MBL_kN": 5000,
+      "damage": 0.17552684607693622
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 10000000,
+      "MBL_kN": 10000,
+      "damage": 0.000015576856094224704
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 10000000,
+      "MBL_kN": 20000,
+      "damage": 1.38234379072608e-9
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 10000000,
+      "MBL_kN": 35000,
+      "damage": 7.401571362581453e-13
+    },
+    {
+      "tension_range_kN": 1200,
+      "n_cycles": 10000000,
+      "MBL_kN": 50000,
+      "damage": 6.086162577858311e-15
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 10000,
+      "MBL_kN": 5000,
+      "damage": 0.1699917008305538
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 10000,
+      "MBL_kN": 10000,
+      "damage": 0.000015085648265390706
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 10000,
+      "MBL_kN": 20000,
+      "damage": 1.3387523183495414e-9
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 10000,
+      "MBL_kN": 35000,
+      "damage": 7.1681667668799e-13
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 10000,
+      "MBL_kN": 50000,
+      "damage": 5.894238694905509e-15
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 100000,
+      "MBL_kN": 5000,
+      "damage": 1.699917008305538
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 100000,
+      "MBL_kN": 10000,
+      "damage": 0.00015085648265390704
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 100000,
+      "MBL_kN": 20000,
+      "damage": 1.3387523183495413e-8
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 100000,
+      "MBL_kN": 35000,
+      "damage": 7.168166766879901e-12
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 100000,
+      "MBL_kN": 50000,
+      "damage": 5.894238694905509e-14
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 1000000,
+      "MBL_kN": 5000,
+      "damage": 16.99917008305538
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 1000000,
+      "MBL_kN": 10000,
+      "damage": 0.0015085648265390705
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 1000000,
+      "MBL_kN": 20000,
+      "damage": 1.3387523183495414e-7
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 1000000,
+      "MBL_kN": 35000,
+      "damage": 7.1681667668799e-11
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 1000000,
+      "MBL_kN": 50000,
+      "damage": 5.89423869490551e-13
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 10000000,
+      "MBL_kN": 5000,
+      "damage": 169.9917008305538
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 10000000,
+      "MBL_kN": 10000,
+      "damage": 0.015085648265390706
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 10000000,
+      "MBL_kN": 20000,
+      "damage": 0.0000013387523183495413
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 10000000,
+      "MBL_kN": 35000,
+      "damage": 7.1681667668799e-10
+    },
+    {
+      "tension_range_kN": 2000,
+      "n_cycles": 10000000,
+      "MBL_kN": 50000,
+      "damage": 5.8942386949055095e-12
+    }
+  ],
+  "total_rows": 120,
+  "fetched": 100,
+  "truncated": true
+}


### PR DESCRIPTION
Part of epic **workspace-hub#3485** — **C8.** Closes dm#1551 (digitalmodel side) — this is the *website* half.

**digitalmodel's first HF-backed capability on the site** — proving the registry is genuinely cross-repo, not worldenergydata-specific. This is the other half of the original ask: showing **digitalmodel** richness alongside world-energy-data.

## New dataset
Published **[aceengineer/digitalmodel-atlas-explorer](https://huggingface.co/datasets/aceengineer/digitalmodel-atlas-explorer)** from digitalmodel's committed `atlases/` parametric grids, three configs:

| config | standard | rows | website domain |
|---|---|---|---|
| `mooring_fatigue` | DNV-RP-C203 (S-N) | 312 | mooring-fatigue |
| `synthetic_rope_mooring_fatigue` | DNV-OS-E301 (T-N) | 120 | mooring-fatigue |
| `code_check` | API-RP-2RD (utilisation) | 2,700 | wall-thickness |

All synthetic, standard-traceable sweeps validated to **<10% max relative error** against held-out samples — **no client/project data**. Each config ships its `manifest.yaml` (cited standard + validation) as a provenance sidecar on HF.

## Changes
- **`config/capabilities.yaml`** — `atlas-explorer` entry (domain `digitalmodel`), `viz: table` (honest for multi-axis parametric grids), `data_limits` disclosing the screening scope.
- **`data/hf-cache/*.json`** — committed build-time snapshots for the three configs (deterministic offline backbone; C6's "Refresh to latest" pulls the newest rows live).

## Going-forward checklist (C7 contract)
- [x] Published Hugging Face dataset (public, `/splits`-resolvable).
- [x] Added `capabilities.yaml` entry; `npm run validate:registry` passes.

## Verified locally
- `npm run validate:registry` PASS — offline schema + **live HF resolution** (C7's gate resolved all three configs against datasets-server; one transient timeout warned, non-blocking by design).
- 251/251 jest across 16 projects; repo-structure OK.
- `npm run build` → `dist/capabilities/atlas-explorer.html` renders all three tables; cards appear on the homepage and `/capabilities/`.

The publish is reproducible from a committed script (`atlases/` grids → HF), landing separately on the digitalmodel side.