### PR TITLE
ci(capabilities): nightly Vercel rebuild backstop [C5]

### DIFF
--- a/.github/workflows/nightly-rebuild.yml
+++ b/.github/workflows/nightly-rebuild.yml
@@ -1,0 +1,27 @@
+name: Nightly rebuild
+
+# C5 backstop (epic workspace-hub#3485, #3488): a scheduled Vercel rebuild so the site
+# picks up HF datasets updated out-of-band (i.e. not through a publish that fired the
+# deploy hook itself). The publish-time trigger lives in workspace-hub's
+# save_results_to_hf.py; this is the safety net.
+on:
+  schedule:
+    - cron: '17 7 * * *'   # 07:17 UTC daily
+  workflow_dispatch:        # allow a manual "refresh now"
+
+jobs:
+  rebuild:
+    name: Trigger Vercel Deploy Hook
+    runs-on: ubuntu-latest
+    steps:
+      - name: POST the deploy hook (if configured)
+        env:
+          HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "$HOOK" ]; then
+            echo "VERCEL_DEPLOY_HOOK_URL secret not set — skipping."
+            echo "Configure it (repo Settings → Secrets → Actions) to enable nightly rebuilds."
+            exit 0
+          fi
+          curl -fsS -X POST "$HOOK" -o /dev/null -w "deploy hook POST → HTTP %{http_code}\n"
+          echo "triggered nightly Vercel rebuild"


### PR DESCRIPTION
Part of epic **workspace-hub#3485** — **C5 (freshness).** Pairs with workspace-hub#3509 (the publish-time trigger).

Adds `.github/workflows/nightly-rebuild.yml`: a scheduled (07:17 UTC daily) + `workflow_dispatch` job that POSTs the Vercel **Deploy Hook** so the site refreshes daily — covering HF datasets updated **out-of-band** (not through a publish that already fired the hook).

- Reads the hook URL from the **`VERCEL_DEPLOY_HOOK_URL` GitHub Actions secret** — never committed.
- **Inert until configured:** skips gracefully (`exit 0`) when the secret is unset, so it never fails and does nothing until the owner adds the secret.

## Owner action to activate
Add `VERCEL_DEPLOY_HOOK_URL` under repo **Settings → Secrets and variables → Actions** (the same Deploy Hook URL from Vercel → Settings → Git → Deploy Hooks). Until then this workflow is a no-op.

Together with workspace-hub#3509, this closes the "new/updated data auto-pops live" loop: publishes trigger an immediate rebuild, and the nightly job catches anything updated out-of-band.