### PR TITLE
feat(capabilities): friendly display labels for dataset columns

### DIFF
--- a/assets/js/capabilities-refresh.js
+++ b/assets/js/capabilities-refresh.js
@@ -42,6 +42,41 @@
         return Number.isInteger(v) ? v.toLocaleString('en-US') : v.toLocaleString('en-US', { maximumFractionDigits: 2 });
     }
 
+    // Human-friendly column headers — mirror of humanizeColumn() in
+    // scripts/render-capabilities.js so a live refresh matches the baked page. Only the
+    // DISPLAYED header text changes; the raw name is still used for data lookup.
+    var COLUMN_LABELS = {
+        npv_mm: 'NPV ($MM)',
+        breakeven_wti: 'Breakeven WTI ($/bbl)',
+        economics_basis: 'Basis',
+        sens_mm_per_dollar: 'NPV sensitivity ($MM/$)',
+        wells_count: 'Wells',
+        api_gravity: 'API°',
+        cum_oil_mmbbl: 'Cum oil (MMbbl)',
+        eur_mmbbl: 'EUR (MMbbl)',
+        avg_uptime_pct: 'Uptime %',
+        uptime_pct: 'Uptime %',
+        field_id: 'Field',
+    };
+
+    var COLUMN_TOKENS = {
+        api: 'API', eur: 'EUR', wti: 'WTI', npv: 'NPV', id: 'ID', mbl: 'MBL',
+        smys: 'SMYS', sn: 'S-N', tvd: 'TVD', hpht: 'HPHT',
+        kn: 'kN', knm: 'kN·m', mpa: 'MPa', psi: 'psi', ppg: 'ppg', ft: 'ft', mm: 'MM',
+    };
+
+    function humanizeColumn(name) {
+        if (name == null) return '';
+        var key = String(name);
+        if (Object.prototype.hasOwnProperty.call(COLUMN_LABELS, key)) return COLUMN_LABELS[key];
+        return key.split('_').map(function (w) {
+            if (!w) return w;
+            var lower = w.toLowerCase();
+            if (Object.prototype.hasOwnProperty.call(COLUMN_TOKENS, lower)) return COLUMN_TOKENS[lower];
+            return lower.charAt(0).toUpperCase() + lower.slice(1);
+        }).join(' ');
+    }
+
     // Mirror of hf-fetch.js normalize(): datasets-server /rows JSON -> { columns, rows, total_rows }.
     function normalize(apiJson) {
         var features = (apiJson && apiJson.features) || [];
@@ -67,7 +102,7 @@
         if (!rows.length || !cols.length) return '<p style="color:#777;">No rows to display.</p>';
         var shown = rows.slice(0, TABLE_ROWS);
         var head = cols.map(function (c) {
-            return '<th style="text-align:left;padding:8px 12px;border-bottom:2px solid #dde1e5;white-space:nowrap;">' + esc(c) + '</th>';
+            return '<th style="text-align:left;padding:8px 12px;border-bottom:2px solid #dde1e5;white-space:nowrap;">' + esc(humanizeColumn(c)) + '</th>';
         }).join('');
         var body = shown.map(function (r) {
             return '<tr>' + cols.map(function (c) {
@@ -227,7 +262,7 @@
     // Exposed for unit testing (isomorphic pattern, cf. assets/js/cta-tracking.js).
     if (typeof module !== 'undefined' && module.exports) {
         module.exports = {
-            normalize: normalize, orderColumns: orderColumns, tableHtml: tableHtml,
+            normalize: normalize, orderColumns: orderColumns, humanizeColumn: humanizeColumn, tableHtml: tableHtml,
             pickKeys: pickKeys, chartHtml: chartHtml, rowsUrl: rowsUrl,
             refreshSection: refreshSection, onRefresh: onRefresh, init: init,
         };

--- a/scripts/render-capabilities.js
+++ b/scripts/render-capabilities.js
@@ -135,6 +135,44 @@ function formatCell(v) {
   return escapeHtml(v);
 }
 
+// Human-friendly display labels for raw dataset column names. Only the DISPLAYED header
+// text changes — the raw snake_case name is still used for data lookup everywhere.
+// COLUMN_LABELS holds explicit overrides; anything else falls back to Title-Case of the
+// snake_case name, with COLUMN_TOKENS keeping domain acronyms/units correctly cased.
+// Mirror any change here in assets/js/capabilities-refresh.js (humanizeColumn) so a live
+// "Refresh to latest" re-render matches the baked page.
+const COLUMN_LABELS = {
+  npv_mm: 'NPV ($MM)',
+  breakeven_wti: 'Breakeven WTI ($/bbl)',
+  economics_basis: 'Basis',
+  sens_mm_per_dollar: 'NPV sensitivity ($MM/$)',
+  wells_count: 'Wells',
+  api_gravity: 'API°',
+  cum_oil_mmbbl: 'Cum oil (MMbbl)',
+  eur_mmbbl: 'EUR (MMbbl)',
+  avg_uptime_pct: 'Uptime %',
+  uptime_pct: 'Uptime %',
+  field_id: 'Field',
+};
+
+const COLUMN_TOKENS = {
+  api: 'API', eur: 'EUR', wti: 'WTI', npv: 'NPV', id: 'ID', mbl: 'MBL',
+  smys: 'SMYS', sn: 'S-N', tvd: 'TVD', hpht: 'HPHT',
+  kn: 'kN', knm: 'kN·m', mpa: 'MPa', psi: 'psi', ppg: 'ppg', ft: 'ft', mm: 'MM',
+};
+
+function humanizeColumn(name) {
+  if (name == null) return '';
+  const key = String(name);
+  if (Object.prototype.hasOwnProperty.call(COLUMN_LABELS, key)) return COLUMN_LABELS[key];
+  return key.split('_').map(w => {
+    if (!w) return w;
+    const lower = w.toLowerCase();
+    if (Object.prototype.hasOwnProperty.call(COLUMN_TOKENS, lower)) return COLUMN_TOKENS[lower];
+    return lower.charAt(0).toUpperCase() + lower.slice(1);
+  }).join(' ');
+}
+
 // Column display order: highlight_columns first (in declared order), then the rest.
 function orderedColumns(table) {
   const cols = (table.data && table.data.columns || []).map(c => c.name);
@@ -163,7 +201,7 @@ function renderTable(table) {
     return `<p style="color:#777;">No rows to display.</p>`;
   }
   const shown = rows.slice(0, MAX_TABLE_ROWS);
-  const head = cols.map(c => `<th style="text-align:left;padding:8px 12px;border-bottom:2px solid #dde1e5;white-space:nowrap;">${escapeHtml(c)}</th>`).join('');
+  const head = cols.map(c => `<th style="text-align:left;padding:8px 12px;border-bottom:2px solid #dde1e5;white-space:nowrap;">${escapeHtml(humanizeColumn(c))}</th>`).join('');
   const body = shown.map(r =>
     `<tr>` + cols.map(c => `<td style="padding:7px 12px;border-bottom:1px solid #eef1f3;">${formatCell(r[c])}</td>`).join('') + `</tr>`
   ).join('\n');
@@ -338,7 +376,7 @@ function renderCards(registry) {
 module.exports = {
   escapeHtml, hfDatasetUrl, tableStats, hasData,
   renderStatStrip, renderCard, renderCards,
-  detailFileName, detailHref, formatCell, orderedColumns, pickChartKeys,
+  detailFileName, detailHref, formatCell, humanizeColumn, orderedColumns, pickChartKeys,
   renderTable, renderBarChart, renderLineChart, renderChartFor,
   capabilityDetailBody, capabilityDetailDocument,
   DOMAIN_LABELS, MAX_TABLE_ROWS,

--- a/tests/js/capabilities-refresh.test.js
+++ b/tests/js/capabilities-refresh.test.js
@@ -56,6 +56,24 @@ describe('pure render helpers', () => {
     expect(html).toContain('Showing 2 of 312 rows');
   });
 
+  test('humanizeColumn matches the build-time helper (friendly headers)', () => {
+    expect(R.humanizeColumn('npv_mm')).toBe('NPV ($MM)');
+    expect(R.humanizeColumn('wells_count')).toBe('Wells');
+    expect(R.humanizeColumn('tvd_ft')).toBe('TVD ft');
+  });
+
+  test('tableHtml shows friendly labels in <th>, not raw column names', () => {
+    const data = {
+      columns: [{ name: 'npv_mm', dtype: 'float64' }, { name: 'field_id', dtype: 'string' }],
+      rows: [{ npv_mm: 1200, field_id: 'GC-825' }],
+      total_rows: 1,
+    };
+    const html = R.tableHtml(data, ['npv_mm', 'field_id']);
+    expect(html).toContain('NPV ($MM)');
+    expect(html).toContain('>Field<');
+    expect(html).not.toContain('>npv_mm<');
+  });
+
   test('pickKeys picks non-numeric label + numeric value', () => {
     const data = R.normalize(rowsPayload());
     const keys = R.pickKeys(data.columns, ['sn_curve', 'damage']);

--- a/tests/js/render-capabilities.test.js
+++ b/tests/js/render-capabilities.test.js
@@ -3,7 +3,7 @@ const path = require('path');
 const {
   escapeHtml, renderCard, renderCards, hfDatasetUrl,
   renderTable, pickChartKeys, renderChartFor, renderBarChart,
-  capabilityDetailDocument, detailFileName, orderedColumns,
+  capabilityDetailDocument, detailFileName, orderedColumns, humanizeColumn,
 } = require('../../scripts/render-capabilities');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
@@ -103,6 +103,45 @@ describe('renderTable', () => {
     t.data.rows = [{ country: '<script>', fields: 1, facilities: 1, badge: '' }];
     expect(renderTable(t)).toContain('&lt;script&gt;');
     expect(renderTable(t)).not.toContain('<script>');
+  });
+  test('renders friendly display labels in the <th> headers, not raw column names', () => {
+    const t = tableFixture({
+      highlight_columns: ['npv_mm', 'breakeven_wti', 'wells_count'],
+      data: {
+        columns: [
+          { name: 'npv_mm', dtype: 'float64' },
+          { name: 'breakeven_wti', dtype: 'float64' },
+          { name: 'wells_count', dtype: 'int64' },
+        ],
+        rows: [{ npv_mm: 1200, breakeven_wti: 42, wells_count: 5 }],
+        total_rows: 1,
+      },
+    });
+    const html = renderTable(t);
+    expect(html).toContain('<th');
+    expect(html).toContain('NPV ($MM)');
+    expect(html).toContain('Breakeven WTI ($/bbl)');
+    expect(html).toContain('Wells');
+    // Raw snake_case names must not leak into the header text.
+    expect(html).not.toContain('>npv_mm<');
+    expect(html).not.toContain('>wells_count<');
+  });
+});
+
+describe('humanizeColumn', () => {
+  test('uses explicit overrides for known columns', () => {
+    expect(humanizeColumn('npv_mm')).toBe('NPV ($MM)');
+    expect(humanizeColumn('cum_oil_mmbbl')).toBe('Cum oil (MMbbl)');
+    expect(humanizeColumn('field_id')).toBe('Field');
+    expect(humanizeColumn('uptime_pct')).toBe('Uptime %');
+  });
+  test('falls back to Title-Case with acronym/unit tokens preserved', () => {
+    expect(humanizeColumn('tree_type')).toBe('Tree Type');
+    expect(humanizeColumn('tvd_ft')).toBe('TVD ft');
+    expect(humanizeColumn('effective_tension_kN')).toBe('Effective Tension kN');
+  });
+  test('handles nullish input', () => {
+    expect(humanizeColumn(null)).toBe('');
   });
 });
 


### PR DESCRIPTION
## What

Capability detail pages rendered Hugging Face dataset **column names raw** in table headers (`npv_mm`, `breakeven_wti`, `wells_count`, `cum_oil_mmbbl`, …). This adds human-friendly display labels so the public site reads cleanly.

## How

- **`scripts/render-capabilities.js`**: new `humanizeColumn(name)` helper — an explicit `COLUMN_LABELS` override map for known columns, falling back to Title-Case of the snake_case name with a `COLUMN_TOKENS` map that keeps acronyms/units correctly cased (API, EUR, WTI, NPV, TVD, kN, MPa, psi, …). Applied in the `<th>` header rendering of `renderTable`. The **raw** column name is still used for data lookup — only the displayed header text changes.
- **`assets/js/capabilities-refresh.js`**: the isomorphic client-side "Refresh to latest" re-render mirrors the same `humanizeColumn` + maps in its `tableHtml`, so a live refresh matches the baked page exactly.
- **Tests**: extended both suites to assert headers show friendly labels (e.g. `NPV (\$MM)` in a `<th>`, not `npv_mm`), plus override / fallback / nullish coverage.

## Verification

- `npm test -- --runInBand`: **257/257 passed** (16 suites).
- `npm run build`: succeeds (93 pages); built `dist/capabilities/field-explorer.html` contains `<th …>NPV (\$MM)</th>`; no raw `npv_mm` in a `<th>`.
- `python3 scripts/maintenance/verify_repo_structure.py`: `repo-structure: OK`.

Did not touch `config/capabilities.yaml` (owned by another lane).