### PR TITLE
feat(capabilities): field economics sensitivity (parametric_economics) [follow-on]

### DIFF
--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -92,3 +92,26 @@ capabilities:
       DNV-OS-E301, API-RP-2RD) and validated to under 10% max relative error against
       held-out samples. For screening and capability demonstration — not a substitute
       for a project-specific engineering check.
+
+  - id: field-economics-sensitivity
+    title: Field Economics Sensitivity
+    domain: worldenergy
+    summary: >-
+      Field-economics sensitivity sweep — how life-to-date pretax NPV moves with WTI
+      price and discount rate, on public BSEE production.
+    hf_dataset: aceengineer/worldenergydata-explorer
+    provenance_url: https://github.com/vamseeachanta/worldenergydata
+    status: live
+    primary_config: parametric_economics
+    tables:
+      - config: parametric_economics
+        label: Price × Discount-Rate Sweep
+        viz: table
+        highlight_columns: [field, wti_price_multiplier, discount_rate, npv_musd, breakeven_multiplier]
+    data_limits: >-
+      Life-to-date pretax NPV at various discount rates, computed on public BSEE
+      production — a sensitivity to WTI price (via wti_price_multiplier) and discount
+      rate, NOT full-cycle economics or forward projections. Because it reflects value
+      realized to date, mature fields can show a negative life-to-date NPV. The basis
+      travels with each value (economics_basis). A multi-dimensional field × price ×
+      rate grid, honestly shown as a table rather than a single headline number.

--- a/data/hf-cache/aceengineer__worldenergydata-explorer__parametric_economics.json
+++ b/data/hf-cache/aceengineer__worldenergydata-explorer__parametric_economics.json
@@ -1,0 +1,275 @@
+{
+  "dataset": "aceengineer/worldenergydata-explorer",
+  "config": "parametric_economics",
+  "columns": [
+    {
+      "name": "field",
+      "dtype": "large_string"
+    },
+    {
+      "name": "wti_price_multiplier",
+      "dtype": "float64"
+    },
+    {
+      "name": "discount_rate",
+      "dtype": "float64"
+    },
+    {
+      "name": "npv_musd",
+      "dtype": "float64"
+    },
+    {
+      "name": "breakeven_multiplier",
+      "dtype": "float64"
+    },
+    {
+      "name": "economics_basis",
+      "dtype": "large_string"
+    }
+  ],
+  "rows": [
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 0.8,
+      "discount_rate": 0.08,
+      "npv_musd": -1485.2,
+      "breakeven_multiplier": 1.1108,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 0.9,
+      "discount_rate": 0.08,
+      "npv_musd": -1007.3,
+      "breakeven_multiplier": 1.1108,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 1.0,
+      "discount_rate": 0.08,
+      "npv_musd": -529.5,
+      "breakeven_multiplier": 1.1108,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 1.1,
+      "discount_rate": 0.08,
+      "npv_musd": -51.6,
+      "breakeven_multiplier": 1.1108,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 1.2,
+      "discount_rate": 0.08,
+      "npv_musd": 426.2,
+      "breakeven_multiplier": 1.1108,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 0.8,
+      "discount_rate": 0.1,
+      "npv_musd": -1469.0,
+      "breakeven_multiplier": 1.2421,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 0.9,
+      "discount_rate": 0.1,
+      "npv_musd": -1136.8,
+      "breakeven_multiplier": 1.2421,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 1.0,
+      "discount_rate": 0.1,
+      "npv_musd": -804.5,
+      "breakeven_multiplier": 1.2421,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 1.1,
+      "discount_rate": 0.1,
+      "npv_musd": -472.2,
+      "breakeven_multiplier": 1.2421,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 1.2,
+      "discount_rate": 0.1,
+      "npv_musd": -139.9,
+      "breakeven_multiplier": 1.2421,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 0.8,
+      "discount_rate": 0.125,
+      "npv_musd": -1350.9,
+      "breakeven_multiplier": 1.4318,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 0.9,
+      "discount_rate": 0.125,
+      "npv_musd": -1137.1,
+      "breakeven_multiplier": 1.4318,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 1.0,
+      "discount_rate": 0.125,
+      "npv_musd": -923.3,
+      "breakeven_multiplier": 1.4318,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 1.1,
+      "discount_rate": 0.125,
+      "npv_musd": -709.5,
+      "breakeven_multiplier": 1.4318,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "jack_st_malo",
+      "wti_price_multiplier": 1.2,
+      "discount_rate": 0.125,
+      "npv_musd": -495.7,
+      "breakeven_multiplier": 1.4318,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 0.8,
+      "discount_rate": 0.08,
+      "npv_musd": -747.8,
+      "breakeven_multiplier": 1.3094,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 0.9,
+      "discount_rate": 0.08,
+      "npv_musd": -601.0,
+      "breakeven_multiplier": 1.3094,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 1.0,
+      "discount_rate": 0.08,
+      "npv_musd": -454.2,
+      "breakeven_multiplier": 1.3094,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 1.1,
+      "discount_rate": 0.08,
+      "npv_musd": -307.4,
+      "breakeven_multiplier": 1.3094,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 1.2,
+      "discount_rate": 0.08,
+      "npv_musd": -160.6,
+      "breakeven_multiplier": 1.3094,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 0.8,
+      "discount_rate": 0.1,
+      "npv_musd": -712.7,
+      "breakeven_multiplier": 1.4201,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 0.9,
+      "discount_rate": 0.1,
+      "npv_musd": -597.8,
+      "breakeven_multiplier": 1.4201,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 1.0,
+      "discount_rate": 0.1,
+      "npv_musd": -482.8,
+      "breakeven_multiplier": 1.4201,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 1.1,
+      "discount_rate": 0.1,
+      "npv_musd": -367.9,
+      "breakeven_multiplier": 1.4201,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 1.2,
+      "discount_rate": 0.1,
+      "npv_musd": -252.9,
+      "breakeven_multiplier": 1.4201,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 0.8,
+      "discount_rate": 0.125,
+      "npv_musd": -658.0,
+      "breakeven_multiplier": 1.5702,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 0.9,
+      "discount_rate": 0.125,
+      "npv_musd": -572.5,
+      "breakeven_multiplier": 1.5702,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 1.0,
+      "discount_rate": 0.125,
+      "npv_musd": -487.1,
+      "breakeven_multiplier": 1.5702,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 1.1,
+      "discount_rate": 0.125,
+      "npv_musd": -401.7,
+      "breakeven_multiplier": 1.5702,
+      "economics_basis": "life_to_date_pretax_npv"
+    },
+    {
+      "field": "julia",
+      "wti_price_multiplier": 1.2,
+      "discount_rate": 0.125,
+      "npv_musd": -316.3,
+      "breakeven_multiplier": 1.5702,
+      "economics_basis": "life_to_date_pretax_npv"
+    }
+  ],
+  "total_rows": 30,
+  "fetched": 30,
+  "truncated": false
+}


### PR DESCRIPTION
## What

Registers a **new** worldenergy capability — **Field Economics Sensitivity** (`field-economics-sensitivity`) — surfacing the HF dataset config `parametric_economics` (30-row field × WTI-price × discount-rate sweep).

- `config/capabilities.yaml`: new entry only (existing `field-explorer` untouched). One table (`parametric_economics`, `viz: table`, highlight cols `field, wti_price_multiplier, discount_rate, npv_musd, breakeven_multiplier`).
- `data/hf-cache/aceengineer__worldenergydata-explorer__parametric_economics.json`: committed snapshot (30 rows, 6 cols).

## Honest framing (house rule: one result, clean product language, no version labels)

Summary + `data_limits` state plainly: this is **life-to-date pretax NPV at various discount rates on public BSEE production — a sensitivity to WTI price, NOT full-cycle economics or forward projections**. Mature fields can show negative life-to-date NPV. Multi-dimensional grid honestly shown as a table, not a single headline number.

## Snapshot provenance

The HF **datasets-server was returning 503** during this work, so `npm run refresh:hf` could not run. The snapshot was generated **directly from the source parquet** (`parametric_economics.parquet`, xet-backed, pulled via `huggingface_hub`) in the exact hf-fetch snapshot format (2-space JSON, `large_string`/`int64`/`float64` dtypes, column order preserved, NaN→null). It is **byte-regenerable via `npm run refresh:hf`** once HF recovers.

## Verification (local)

- `npm run validate:capabilities` → PASS (3 capabilities valid)
- `npm test -- --runInBand` → **251 passed / 16 suites**
- `npm run build` → 93 pages, `dist/capabilities/field-economics-sensitivity.html` renders **30 real data rows** (e.g. `jack_st_malo, 0.8, 0.08, -1,485.2`)
- `python3 scripts/maintenance/verify_repo_structure.py` → `repo-structure: OK`