### PR TITLE
fix(nav): link the drill-down from the QA/QC hub

### DIFF
--- a/scripts/templates/dc-qaqc-hub.html
+++ b/scripts/templates/dc-qaqc-hub.html
@@ -230,6 +230,7 @@
     </span>
     <nav class="capability" aria-label="D&amp;C QA/QC report navigation">
       <a href="#" class="active">QA/QC</a>
+      <a href="/capabilities/dc-drilldown.html">Drill-down</a>
       <a href="https://vamseeachanta.github.io/worldenergydata/wo-april-2026-validation.html">Matrix</a>
       <a href="https://vamseeachanta.github.io/worldenergydata/wo-april-2026-per-well-dc.html">Per-well</a>
       <a href="https://vamseeachanta.github.io/worldenergydata/fdas-revision-comparison.html">Lineage</a>
@@ -350,6 +351,13 @@
     <div class="tier">
       <div class="tier-label"><p class="eyebrow">Explore the data</p><span class="rule"></span></div>
       <div class="cards">
+        <a class="card" href="/capabilities/dc-drilldown.html">
+          <div class="top"><span class="kind">Interactive</span><span class="badge idx"><span class="d"></span>253 bores</span></div>
+          <h3>Drill-Down</h3>
+          <p>Browse by field or OCS block, drill to the bores, then to a single wellbore&rsquo;s full record.</p>
+          <ul><li>11 fields &middot; 23 blocks &middot; 253 bores</li><li>Every level deep-linkable</li><li>Out to life-cycle, economics, assets</li></ul>
+          <div class="foot"><span></span><span class="arrow">Open &rarr;</span></div>
+        </a>
         <a class="card" href="https://vamseeachanta.github.io/worldenergydata/wo-april-2026-per-well-dc.html">
           <div class="top"><span class="kind">Bore-level index</span><span class="badge idx"><span class="d"></span>253 bores</span></div>
           <h3>Per-Well Listing</h3>


### PR DESCRIPTION
The hub shipped without a route to the drill-down: its nav and card tiers pointed only at the Pages reports, so the two interactive surfaces on aceengineer.com didn't reference each other — a dead end in the family.

- Adds a **Drill-down** nav item to the hub
- Promotes the drill-down to the **first card** of the "Explore the data" tier (11 fields · 23 blocks · 253 bores · every level deep-linkable)

Caught by checking the deployed page rather than assuming: my earlier link rewrite targeted markup that only exists on the drill-down page, so the hub silently kept its original nav.

Verified: 302 tests green · build renders both pages · repo-structure OK · lint:copy PASS.

Refs worldenergydata#1059 (navigability lane), aceengineer-website#76.