### PR TITLE
feat(capabilities): parity with the sloshing report standard — discoverability, cross-nav, release-backed registry

### DIFF
--- a/build.js
+++ b/build.js
@@ -7,7 +7,7 @@ const yaml = require('js-yaml');
 const { PurgeCSS } = require('purgecss');
 const CleanCSS = require('clean-css');
 const hf = require('./scripts/hf-fetch');
-const { renderCards, capabilityDetailDocument, detailFileName } = require('./scripts/render-capabilities');
+const { renderCards, capabilityDetailDocument, detailFileName, isReleaseBacked } = require('./scripts/render-capabilities');
 
 const srcDir = './content';
 const distDir = './dist';
@@ -176,15 +176,19 @@ async function renderHtml(content, locals) {
 // (C4, #52). Pages live one level deep, so rootPath is '../' for the shared partials.
 async function buildCapabilityDetailPages(registry) {
   const caps = (registry && registry.capabilities || []).filter(c => c.status !== 'withheld');
+  // Release-backed capabilities have no generated detail page — their canonical
+  // destination is an existing hub on this site (see render-capabilities detailHref).
+  const generated = caps.filter(c => !isReleaseBacked(c));
   const outDir = path.join(distDir, 'capabilities');
   ensureDir(outDir);
-  for (const cap of caps) {
-    const doc = capabilityDetailDocument(cap, caps);
+  const renderedAt = new Date().toISOString().slice(0, 10);
+  for (const cap of generated) {
+    const doc = capabilityDetailDocument(cap, caps, { renderedAt });
     const html = await renderHtml(doc, { rootPath: '../', copy: loadCopy() });
     fs.writeFileSync(path.join(outDir, detailFileName(cap)), html);
     console.log(`Built: capabilities/${detailFileName(cap)}`);
   }
-  return caps.length;
+  return generated.length;
 }
 
 // Copy assets directory

--- a/build.js
+++ b/build.js
@@ -179,7 +179,7 @@ async function buildCapabilityDetailPages(registry) {
   const outDir = path.join(distDir, 'capabilities');
   ensureDir(outDir);
   for (const cap of caps) {
-    const doc = capabilityDetailDocument(cap);
+    const doc = capabilityDetailDocument(cap, caps);
     const html = await renderHtml(doc, { rootPath: '../', copy: loadCopy() });
     fs.writeFileSync(path.join(outDir, detailFileName(cap)), html);
     console.log(`Built: capabilities/${detailFileName(cap)}`);

--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -145,3 +145,37 @@ capabilities:
       under ~250 d) with WAR-union rig-days (longer spans), so batch-drilled wells
       undercount drilling days — disclosed rather than corrected pending resolution.
       Producer markers cover the seven core Lower-Tertiary fields only.
+
+  # Release-backed: the upstream dataset is private (CFD review artifacts), so this
+  # capability is pinned to the immutable, content-addressed release this site publishes
+  # rather than to live datasets-server configs. The digest/revision chain below is the
+  # same one cited on the report pages and is checkable end to end.
+  - id: tank-sloshing-cfd
+    title: Tank Sloshing CFD
+    domain: digitalmodel
+    summary: >-
+      OpenFOAM VOF sloshing analysis for partially filled tanks — free-decay validation
+      against closed-form theory, a forced-roll period sweep, and the connected twin-tank
+      U-tube exchange mode with its inter-tank mass shift and roll moment.
+    backing: release
+    hf_dataset: aceengineer/digitalmodel-sloshing
+    provenance_url: https://www.aceengineer.com/reports/sloshing/validation.html
+    status: live
+    release:
+      hub_url: /reports/sloshing/
+      digest: a0da3df2d32f03e5dd7014dc81af6aeb6f332a8570738eecca4a3c62c6f9af97
+      revision: aa37e6d365f3059674a49dc4bafbe4d64d12e5fd
+      stats:
+        - count: 24
+          label: accepted cases
+        - count: 89
+          label: metrics
+        - count: 9933
+          label: response samples
+    data_limits: >-
+      Source-neutral reference geometry only — no vessel-specific dimensions are
+      published here. Free-decay frequency matches closed-form theory to 0.30%; the
+      conduit-area scaling law matches CFD to ~1-2%. Absolute forced magnitudes carry a
+      single dynamic-amplification factor (x1.34 to x1.45) measured near resonance, and
+      the connected-tank mass shift and roll moment are derived from the CFD-measured
+      level difference rather than predicted independently.

--- a/scripts/render-capabilities.js
+++ b/scripts/render-capabilities.js
@@ -113,6 +113,34 @@ function renderCard(cap) {
 const MAX_TABLE_ROWS = 50;
 const MAX_BARS = 15;
 
+// Cross-navigation between capability pages. A detail page previously offered only a
+// "← All capabilities" back-link, so the sibling capabilities were reachable exclusively
+// by going back to the index — and nothing marked which page you were on. `siblings` is
+// the surfaced (non-withheld) capability list; passing none degrades to the back-link.
+function renderCapabilityNav(cap, siblings = []) {
+  const link = (href, label, current) =>
+    `<a href="${escapeHtml(href)}"` +
+    (current ? ' aria-current="page"' : '') +
+    ` style="text-decoration:none;color:${current ? '#111' : '#666'};` +
+    `font-weight:${current ? '600' : '400'};` +
+    (current ? 'border-bottom:2px solid #111;padding-bottom:2px;' : '') +
+    `">${escapeHtml(label)}</a>`;
+
+  const others = siblings.filter(s => s && s.id);
+  if (!others.length) return link('/capabilities/', '← All capabilities', false);
+
+  const items = others.map(s => link(detailHref(s), s.title || s.id, s.id === cap.id));
+  return (
+    `<nav aria-label="Capabilities" style="display:flex;flex-wrap:wrap;gap:6px 18px;` +
+    `align-items:baseline;font-size:.92rem;margin-bottom:14px;padding-bottom:12px;` +
+    `border-bottom:1px solid #e6e8eb;">` +
+    link('/capabilities/', 'All capabilities', false) +
+    `<span aria-hidden="true" style="color:#c7ccd1;">|</span>` +
+    items.join(`<span aria-hidden="true" style="color:#c7ccd1;">·</span>`) +
+    `</nav>`
+  );
+}
+
 function detailFileName(cap) {
   return `${cap.id}.html`;
 }
@@ -282,7 +310,7 @@ function renderChartFor(table) {
 }
 
 // The inner body of a capability detail page (no chrome).
-function capabilityDetailBody(cap) {
+function capabilityDetailBody(cap, siblings = []) {
   const domainLabel = DOMAIN_LABELS[cap.domain] || cap.domain;
   const domainColor = DOMAIN_COLORS[cap.domain] || '#444';
   const badge =
@@ -326,7 +354,7 @@ function capabilityDetailBody(cap) {
     `</div>`;
 
   return (
-    `<a href="/capabilities/" style="color:#666;text-decoration:none;">← All capabilities</a>` +
+    renderCapabilityNav(cap, siblings) +
     `<div style="margin:10px 0 6px;">${badge}</div>` +
     `<h1 style="margin:4px 0 8px;">${escapeHtml(cap.title)}</h1>` +
     `<p style="font-size:1.12rem;color:#444;max-width:760px;">${escapeHtml(cap.summary)}</p>` +
@@ -338,7 +366,7 @@ function capabilityDetailBody(cap) {
 
 // A full detail-page HTML document (with <include> chrome; rootPath resolved by build.js
 // via posthtml expressions). One page per capability, written to dist/capabilities/<id>.html.
-function capabilityDetailDocument(cap) {
+function capabilityDetailDocument(cap, siblings = []) {
   const title = `${cap.title} — AceEngineer Capabilities`;
   return (
     `<!DOCTYPE html>\n<html lang="en">\n<head>\n` +
@@ -353,7 +381,7 @@ function capabilityDetailDocument(cap) {
     `</head>\n<body class="theme-page">\n` +
     `<include src="partials/nav.html"></include>\n` +
     `<section style="padding:40px 0 56px;"><div class="container">\n` +
-    capabilityDetailBody(cap) +
+    capabilityDetailBody(cap, siblings) +
     `\n</div></section>\n` +
     `<include src="partials/footer.html"></include>\n` +
     `<script src="/assets/js/capabilities-refresh.js" defer></script>\n` +
@@ -378,6 +406,6 @@ module.exports = {
   renderStatStrip, renderCard, renderCards,
   detailFileName, detailHref, formatCell, humanizeColumn, orderedColumns, pickChartKeys,
   renderTable, renderBarChart, renderLineChart, renderChartFor,
-  capabilityDetailBody, capabilityDetailDocument,
+  capabilityDetailBody, capabilityDetailDocument, renderCapabilityNav,
   DOMAIN_LABELS, MAX_TABLE_ROWS,
 };

--- a/scripts/render-capabilities.js
+++ b/scripts/render-capabilities.js
@@ -50,8 +50,21 @@ function hasData(cap) {
   return (cap.tables || []).some(t => t.data && Array.isArray(t.data.rows) && t.data.rows.length);
 }
 
-function renderStatStrip(cap) {
-  const stats = tableStats(cap).filter(s => s.count != null);
+// Release-backed capabilities are pinned to an immutable release published by this site
+// instead of live datasets-server tables (see validate-capabilities.js). They have no
+// `tables`, so they must not be mistaken for "data pending publication".
+function isReleaseBacked(cap) {
+  return cap && cap.backing === 'release' && !!cap.release;
+}
+
+// Stat strip figures for a release-backed capability, declared in the registry.
+function releaseStats(cap) {
+  return ((cap.release && cap.release.stats) || [])
+    .filter(s => s && typeof s.count === 'number')
+    .map(s => ({ count: s.count, label: s.label, truncated: false }));
+}
+
+function renderStats(stats) {
   if (!stats.length) return '';
   const items = stats.map(s =>
     `<span style="display:inline-block;margin-right:18px;">` +
@@ -61,10 +74,15 @@ function renderStatStrip(cap) {
   return `<div style="margin:14px 0 10px;">${items}</div>`;
 }
 
+function renderStatStrip(cap) {
+  return renderStats(tableStats(cap).filter(s => s.count != null));
+}
+
 function renderCard(cap) {
   const domainLabel = DOMAIN_LABELS[cap.domain] || cap.domain;
   const domainColor = DOMAIN_COLORS[cap.domain] || '#444';
-  const pending = cap.status === 'pending' || !hasData(cap);
+  const released = isReleaseBacked(cap);
+  const pending = !released && (cap.status === 'pending' || !hasData(cap));
 
   const badge =
     `<span style="display:inline-block;background:${domainColor};color:#fff;font-size:.72rem;` +
@@ -81,6 +99,18 @@ function renderCard(cap) {
     cta =
       `<a href="${escapeHtml(cap.provenance_url)}" style="font-weight:600;color:${domainColor};">` +
       `Follow progress →</a>`;
+  } else if (released) {
+    // The pinned digest is the checkable claim here — not a Hugging Face link, whose
+    // upstream dataset is private and would 401 for a visitor.
+    body =
+      `<p style="color:#555;margin:12px 0 4px;">${escapeHtml(cap.summary)}</p>` +
+      renderStats(releaseStats(cap)) +
+      `<p style="color:#777;font-size:.82rem;margin:6px 0 0;">${escapeHtml(cap.data_limits || '')}</p>`;
+    cta =
+      `<a href="${escapeHtml(detailHref(cap))}" ` +
+      `style="font-weight:600;color:${domainColor};">View capability →</a>` +
+      `<span style="margin-left:18px;color:#666;font-size:.9rem;">Immutable release ` +
+      `<code>${escapeHtml(String(cap.release.digest).slice(0, 12))}</code></span>`;
   } else {
     body =
       `<p style="color:#555;margin:12px 0 4px;">${escapeHtml(cap.summary)}</p>` +
@@ -141,13 +171,42 @@ function renderCapabilityNav(cap, siblings = []) {
   );
 }
 
+// What the reader is actually looking at. These pages are baked at build time and then
+// optionally re-fetched client-side via "Refresh to latest", so — unlike the immutable
+// sloshing release — the honest claim is a dated snapshot, not a pinned digest. Says
+// which mode the build got its rows from, so a stale or degraded render is visible
+// rather than silently indistinguishable from a live one.
+function dataSourceMode(cap) {
+  const sources = (cap.tables || []).map(t => t.data_source).filter(Boolean);
+  if (!sources.length) return null;
+  if (sources.some(s => s === 'unavailable')) return 'unavailable';
+  if (sources.every(s => s === 'live')) return 'live';
+  return 'snapshot';
+}
+
+function renderSnapshotStamp(cap, renderedAt) {
+  const mode = dataSourceMode(cap);
+  if (!mode) return '';
+  const when = renderedAt ? ` on ${escapeHtml(renderedAt)}` : '';
+  const text = {
+    live: `Rendered from a live datasets-server fetch${when}. Use “Refresh to latest” for current data.`,
+    snapshot: `Rendered from a cached snapshot${when}; the upstream dataset may have moved since. Use “Refresh to latest” for current data.`,
+    unavailable: `The dataset could not be reached at build time${when}; figures below may be incomplete. Use “Refresh to latest” to retry.`,
+  }[mode];
+  const color = mode === 'unavailable' ? '#a15c00' : '#555';
+  return `<p style="margin:0 0 6px;color:${color};font-size:.9rem;">` +
+    `<strong>Snapshot:</strong> ${text}</p>`;
+}
+
 function detailFileName(cap) {
   return `${cap.id}.html`;
 }
 
 // Absolute, root-relative link to a capability's detail page — works whether the card
-// is rendered on the homepage (root) or on /capabilities/.
+// is rendered on the homepage (root) or on /capabilities/. Release-backed capabilities
+// have no generated detail page; their hub on this site is the canonical destination.
 function detailHref(cap) {
+  if (isReleaseBacked(cap)) return cap.release.hub_url;
   return `/capabilities/${cap.id}.html`;
 }
 
@@ -310,7 +369,7 @@ function renderChartFor(table) {
 }
 
 // The inner body of a capability detail page (no chrome).
-function capabilityDetailBody(cap, siblings = []) {
+function capabilityDetailBody(cap, siblings = [], options = {}) {
   const domainLabel = DOMAIN_LABELS[cap.domain] || cap.domain;
   const domainColor = DOMAIN_COLORS[cap.domain] || '#444';
   const badge =
@@ -350,6 +409,7 @@ function capabilityDetailBody(cap, siblings = []) {
     `<p style="margin:0 0 6px;"><strong>Source:</strong> ` +
     `<a href="${escapeHtml(hfDatasetUrl(cap.hf_dataset))}" rel="noopener">${escapeHtml(cap.hf_dataset)}</a> on Hugging Face` +
     (cap.provenance_url ? ` · <a href="${escapeHtml(cap.provenance_url)}" rel="noopener">pipeline</a>` : '') + `</p>` +
+    renderSnapshotStamp(cap, options.renderedAt) +
     (cap.data_limits ? `<p style="margin:0;color:#555;font-size:.9rem;"><strong>Data limits:</strong> ${escapeHtml(cap.data_limits)}</p>` : '') +
     `</div>`;
 
@@ -366,7 +426,7 @@ function capabilityDetailBody(cap, siblings = []) {
 
 // A full detail-page HTML document (with <include> chrome; rootPath resolved by build.js
 // via posthtml expressions). One page per capability, written to dist/capabilities/<id>.html.
-function capabilityDetailDocument(cap, siblings = []) {
+function capabilityDetailDocument(cap, siblings = [], options = {}) {
   const title = `${cap.title} — AceEngineer Capabilities`;
   return (
     `<!DOCTYPE html>\n<html lang="en">\n<head>\n` +
@@ -381,7 +441,7 @@ function capabilityDetailDocument(cap, siblings = []) {
     `</head>\n<body class="theme-page">\n` +
     `<include src="partials/nav.html"></include>\n` +
     `<section style="padding:40px 0 56px;"><div class="container">\n` +
-    capabilityDetailBody(cap, siblings) +
+    capabilityDetailBody(cap, siblings, options) +
     `\n</div></section>\n` +
     `<include src="partials/footer.html"></include>\n` +
     `<script src="/assets/js/capabilities-refresh.js" defer></script>\n` +
@@ -407,5 +467,6 @@ module.exports = {
   detailFileName, detailHref, formatCell, humanizeColumn, orderedColumns, pickChartKeys,
   renderTable, renderBarChart, renderLineChart, renderChartFor,
   capabilityDetailBody, capabilityDetailDocument, renderCapabilityNav,
+  isReleaseBacked, releaseStats, dataSourceMode, renderSnapshotStamp,
   DOMAIN_LABELS, MAX_TABLE_ROWS,
 };

--- a/scripts/validate-capabilities.js
+++ b/scripts/validate-capabilities.js
@@ -29,6 +29,14 @@ const DOMAINS = ['worldenergy', 'digitalmodel'];
 const STATUSES = ['live', 'pending', 'withheld'];
 const VIZ = ['table', 'bar', 'line', 'map'];
 const KEBAB = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+// How a capability is backed. 'dataset' (default) = live datasets-server configs.
+// 'release' = an immutable, content-addressed release published by this site, for work
+// whose upstream dataset is private or whose evidence is not datasets-server shaped
+// (e.g. CFD review artifacts). Release-backed entries declare a pinned digest+revision
+// instead of tables, and are skipped by the online datasets-server gate.
+const BACKINGS = ['dataset', 'release'];
+const SHA256 = /^[0-9a-f]{64}$/;
+const GITSHA = /^[0-9a-f]{40}$/;
 
 // Load + parse the registry. Returns the parsed object (throws on unreadable/invalid YAML).
 function loadRegistry(registryFile = DEFAULT_REGISTRY) {
@@ -80,6 +88,34 @@ function validateRegistry(registry) {
     }
     if (req('status') && !STATUSES.includes(cap.status)) {
       errors.push(`${where}: status must be one of ${STATUSES.join('|')} (got '${cap.status}')`);
+    }
+
+    const backing = cap.backing === undefined ? 'dataset' : cap.backing;
+    if (!BACKINGS.includes(backing)) {
+      errors.push(`${where}: backing must be one of ${BACKINGS.join('|')} (got '${cap.backing}')`);
+    }
+
+    // Release-backed: the evidence is a pinned release on this site, so `tables` /
+    // `primary_config` do not apply. Require the chain a reader can actually check.
+    if (backing === 'release') {
+      const rel = cap.release;
+      if (!rel || typeof rel !== 'object' || Array.isArray(rel)) {
+        errors.push(`${where}: backing 'release' requires a 'release' block`);
+      } else {
+        if (!rel.hub_url || !String(rel.hub_url).startsWith('/')) {
+          errors.push(`${where}.release: hub_url must be a site-root path (got '${rel.hub_url}')`);
+        }
+        if (!SHA256.test(String(rel.digest || ''))) {
+          errors.push(`${where}.release: digest must be a 64-hex content digest`);
+        }
+        if (!GITSHA.test(String(rel.revision || ''))) {
+          errors.push(`${where}.release: revision must be a 40-hex source revision`);
+        }
+      }
+      if (cap.tables !== undefined) {
+        errors.push(`${where}: release-backed capabilities declare 'release', not 'tables'`);
+      }
+      return;
     }
 
     const withheld = new Set(Array.isArray(cap.withheld_columns) ? cap.withheld_columns : []);
@@ -135,4 +171,13 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { loadRegistry, validateRegistry, DEFAULT_REGISTRY, DOMAINS, STATUSES, VIZ };
+// A capability the online datasets-server gate should resolve: live, and dataset-backed.
+// Release-backed entries carry their own pinned digest and have no datasets-server config.
+function isDatasetBacked(cap) {
+  return (cap.backing === undefined ? 'dataset' : cap.backing) === 'dataset';
+}
+
+module.exports = {
+  loadRegistry, validateRegistry, DEFAULT_REGISTRY,
+  DOMAINS, STATUSES, VIZ, BACKINGS, isDatasetBacked,
+};

--- a/scripts/verify-capabilities-online.js
+++ b/scripts/verify-capabilities-online.js
@@ -26,7 +26,7 @@
  * Exit 0 = no blocking errors, exit 1 = one or more resolution errors printed.
  */
 const path = require('path');
-const { loadRegistry, validateRegistry, DEFAULT_REGISTRY } = require('./validate-capabilities');
+const { loadRegistry, validateRegistry, DEFAULT_REGISTRY, isDatasetBacked } = require('./validate-capabilities');
 const { datasetConfigs, fetchTable } = require('./hf-fetch');
 
 // Classify an hf-fetch error: a 404 means the dataset/config is genuinely absent
@@ -69,6 +69,10 @@ async function checkResolution(registry, resolvers) {
 
   for (const cap of caps) {
     if (cap.status !== 'live') continue; // pending/withheld don't render live data
+    // Release-backed capabilities are pinned to an immutable release published by this
+    // site; their upstream dataset may be private and has no datasets-server config to
+    // resolve. The offline gate checks their digest/revision chain instead.
+    if (!isDatasetBacked(cap)) continue;
     const ds = cap.hf_dataset;
 
     let configs;
@@ -155,7 +159,7 @@ async function main() {
     process.exit(1);
   }
 
-  const live = registry.capabilities.filter(c => c.status === 'live').length;
+  const live = registry.capabilities.filter(c => c.status === 'live' && isDatasetBacked(c)).length;
   const note = warnings.length ? ` (${warnings.length} transient warning${warnings.length === 1 ? '' : 's'})` : '';
   console.log(`validate:capabilities:online PASS — ${live} live capabilit${live === 1 ? 'y' : 'ies'} resolve${live === 1 ? 's' : ''} against Hugging Face${note}`);
 }

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -663,4 +663,36 @@
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
+
+  <!-- Capabilities (registry-driven; locked by tests/js/capabilities-registry.test.js) -->
+  <url>
+    <loc>https://www.aceengineer.com/capabilities/</loc>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/capabilities/field-explorer.html</loc>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/capabilities/atlas-explorer.html</loc>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/capabilities/dc-days-qaqc.html</loc>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.aceengineer.com/capabilities/field-economics-sensitivity.html</loc>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>

--- a/tests/js/capabilities-registry.test.js
+++ b/tests/js/capabilities-registry.test.js
@@ -101,3 +101,25 @@ describe('validateRegistry catches malformed entries', () => {
     }
   });
 });
+
+// Every surfaced capability must be discoverable. Five live capability pages once served
+// 200 while being wholly absent from sitemap.xml, so search engines never saw them; this
+// ties the sitemap to the registry rather than to anyone remembering to edit both.
+describe('capability discoverability', () => {
+  const sitemap = fs.readFileSync(path.join(repoRoot, 'sitemap.xml'), 'utf8');
+  const surfaced = loadRegistry(DEFAULT_REGISTRY).capabilities.filter(c => c.status !== 'withheld');
+
+  test('the capabilities index is in the sitemap', () => {
+    expect(sitemap).toContain('<loc>https://www.aceengineer.com/capabilities/</loc>');
+  });
+
+  test.each(surfaced.map(c => [c.id]))('capability %s has a sitemap entry', id => {
+    expect(sitemap).toContain(`<loc>https://www.aceengineer.com/capabilities/${id}.html</loc>`);
+  });
+
+  test('no sitemap entry points at a capability that is withheld or absent from the registry', () => {
+    const listed = [...sitemap.matchAll(/capabilities\/([a-z0-9-]+)\.html/g)].map(m => m[1]);
+    const allowed = new Set(surfaced.map(c => c.id));
+    expect(listed.filter(id => !allowed.has(id))).toEqual([]);
+  });
+});

--- a/tests/js/capabilities-registry.test.js
+++ b/tests/js/capabilities-registry.test.js
@@ -5,6 +5,7 @@ const {
   loadRegistry,
   validateRegistry,
   DEFAULT_REGISTRY,
+  isDatasetBacked,
 } = require('../../scripts/validate-capabilities');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
@@ -102,24 +103,90 @@ describe('validateRegistry catches malformed entries', () => {
   });
 });
 
+// Release-backed capabilities: pinned to an immutable release published by this site,
+// for work whose upstream dataset is private (e.g. CFD review artifacts) and therefore
+// cannot resolve on the public datasets-server.
+describe('release-backed capabilities', () => {
+  const releaseCap = () => ({
+    version: 1,
+    capabilities: [{
+      id: 'x-cfd', title: 'X', domain: 'digitalmodel', summary: 's',
+      hf_dataset: 'org/private-ds', provenance_url: 'https://example.com/p',
+      status: 'live', data_limits: 'limits', backing: 'release',
+      release: { hub_url: '/reports/x/', digest: 'a'.repeat(64), revision: 'b'.repeat(40) },
+    }],
+  });
+
+  test('a well-formed release-backed entry validates without tables', () => {
+    expect(validateRegistry(releaseCap())).toEqual([]);
+  });
+
+  test('rejects an unknown backing', () => {
+    const r = releaseCap(); r.capabilities[0].backing = 'magic';
+    expect(validateRegistry(r).some(e => /backing must be one of/.test(e))).toBe(true);
+  });
+
+  test('requires a release block', () => {
+    const r = releaseCap(); delete r.capabilities[0].release;
+    expect(validateRegistry(r).some(e => /requires a 'release' block/.test(e))).toBe(true);
+  });
+
+  test.each([
+    ['digest', 'digest', 'not-a-digest', /digest must be a 64-hex/],
+    ['revision', 'revision', 'nope', /revision must be a 40-hex/],
+    ['hub_url', 'hub_url', 'https://elsewhere.example/x', /hub_url must be a site-root path/],
+  ])('rejects a malformed %s', (_label, field, value, pattern) => {
+    const r = releaseCap(); r.capabilities[0].release[field] = value;
+    expect(validateRegistry(r).some(e => pattern.test(e))).toBe(true);
+  });
+
+  test('rejects declaring both release and tables', () => {
+    const r = releaseCap();
+    r.capabilities[0].tables = [{ config: 'c', label: 'l', viz: 'table', highlight_columns: ['a'] }];
+    expect(validateRegistry(r).some(e => /declare 'release', not 'tables'/.test(e))).toBe(true);
+  });
+
+  test('isDatasetBacked excludes release-backed and defaults to dataset', () => {
+    expect(isDatasetBacked(releaseCap().capabilities[0])).toBe(false);
+    expect(isDatasetBacked({ id: 'y' })).toBe(true);
+    expect(isDatasetBacked({ id: 'y', backing: 'dataset' })).toBe(true);
+  });
+
+  test('the committed sloshing entry is release-backed and pins the live release', () => {
+    const cap = loadRegistry(DEFAULT_REGISTRY).capabilities.find(c => c.id === 'tank-sloshing-cfd');
+    expect(cap).toBeDefined();
+    const pointer = JSON.parse(fs.readFileSync(path.join(repoRoot, 'config', 'sloshing-data-release.json'), 'utf8'));
+    expect(cap.release.digest).toBe(pointer.release.digest);
+    expect(cap.release.revision).toBe(pointer.source.revision);
+  });
+});
+
 // Every surfaced capability must be discoverable. Five live capability pages once served
 // 200 while being wholly absent from sitemap.xml, so search engines never saw them; this
 // ties the sitemap to the registry rather than to anyone remembering to edit both.
 describe('capability discoverability', () => {
   const sitemap = fs.readFileSync(path.join(repoRoot, 'sitemap.xml'), 'utf8');
   const surfaced = loadRegistry(DEFAULT_REGISTRY).capabilities.filter(c => c.status !== 'withheld');
+  const generated = surfaced.filter(c => c.backing !== 'release');
+  const released = surfaced.filter(c => c.backing === 'release');
 
   test('the capabilities index is in the sitemap', () => {
     expect(sitemap).toContain('<loc>https://www.aceengineer.com/capabilities/</loc>');
   });
 
-  test.each(surfaced.map(c => [c.id]))('capability %s has a sitemap entry', id => {
+  test.each(generated.map(c => [c.id]))('capability %s has a sitemap entry', id => {
     expect(sitemap).toContain(`<loc>https://www.aceengineer.com/capabilities/${id}.html</loc>`);
   });
 
-  test('no sitemap entry points at a capability that is withheld or absent from the registry', () => {
+  // Release-backed capabilities generate no detail page; their hub is the destination,
+  // so it is the hub that has to be discoverable.
+  test.each(released.map(c => [c.id, c.release.hub_url]))('release-backed %s has its hub %s in the sitemap', (id, hub) => {
+    expect(sitemap).toContain(`<loc>https://www.aceengineer.com${hub}</loc>`);
+  });
+
+  test('no sitemap entry points at a capability that is withheld, absent, or release-backed', () => {
     const listed = [...sitemap.matchAll(/capabilities\/([a-z0-9-]+)\.html/g)].map(m => m[1]);
-    const allowed = new Set(surfaced.map(c => c.id));
+    const allowed = new Set(generated.map(c => c.id));
     expect(listed.filter(id => !allowed.has(id))).toEqual([]);
   });
 });

--- a/tests/js/render-capabilities.test.js
+++ b/tests/js/render-capabilities.test.js
@@ -222,6 +222,68 @@ describe('capabilityDetailDocument', () => {
   });
 });
 
+describe('release-backed capability rendering', () => {
+  const cap = {
+    id: 'tank-sloshing-cfd', title: 'Tank Sloshing CFD', domain: 'digitalmodel',
+    summary: 'VOF sloshing analysis.', hf_dataset: 'aceengineer/digitalmodel-sloshing',
+    provenance_url: 'https://www.aceengineer.com/reports/sloshing/validation.html',
+    status: 'live', data_limits: 'Source-neutral geometry only.', backing: 'release',
+    release: {
+      hub_url: '/reports/sloshing/', digest: 'a'.repeat(64), revision: 'b'.repeat(40),
+      stats: [{ count: 24, label: 'accepted cases' }],
+    },
+  };
+  const html = renderCard(cap);
+
+  test('is not mistaken for pending data despite having no tables', () => {
+    expect(html).not.toContain('data pending publication');
+    expect(html).toContain('View capability →');
+  });
+
+  test('points at its hub, not a generated detail page', () => {
+    expect(html).toContain('href="/reports/sloshing/"');
+    expect(html).not.toContain('/capabilities/tank-sloshing-cfd.html');
+  });
+
+  test('cites the pinned digest instead of linking a private dataset', () => {
+    expect(html).toContain('Immutable release');
+    expect(html).toContain('a'.repeat(12));
+    expect(html).not.toContain('huggingface.co');
+  });
+
+  test('renders registry-declared stats', () => {
+    expect(html).toContain('24');
+    expect(html).toContain('accepted cases');
+  });
+});
+
+describe('snapshot stamp', () => {
+  const withSource = source => ({
+    id: 'x', title: 'X', domain: 'worldenergy', summary: 's', hf_dataset: 'a/b',
+    provenance_url: 'u', status: 'live', data_limits: 'd',
+    tables: [{ ...tableFixture(), data_source: source }],
+  });
+
+  test('states a live build fetch', () => {
+    expect(capabilityDetailDocument(withSource('live'), [], { renderedAt: '2026-07-26' }))
+      .toContain('Rendered from a live datasets-server fetch on 2026-07-26');
+  });
+
+  test('warns that a cached snapshot may have moved', () => {
+    expect(capabilityDetailDocument(withSource('snapshot'), [], { renderedAt: '2026-07-26' }))
+      .toContain('cached snapshot on 2026-07-26');
+  });
+
+  test('flags an unreachable dataset rather than implying fresh data', () => {
+    const doc = capabilityDetailDocument(withSource('unavailable'), [], { renderedAt: '2026-07-26' });
+    expect(doc).toContain('could not be reached at build time');
+  });
+
+  test('is omitted when no table declares a source', () => {
+    expect(capabilityDetailDocument(withSource(undefined))).not.toContain('<strong>Snapshot:</strong>');
+  });
+});
+
 describe('page wiring', () => {
   test('content/capabilities/index.html injects the capabilitiesCards local', () => {
     const src = fs.readFileSync(path.join(repoRoot, 'content', 'capabilities', 'index.html'), 'utf8');

--- a/tests/js/render-capabilities.test.js
+++ b/tests/js/render-capabilities.test.js
@@ -190,6 +190,36 @@ describe('capabilityDetailDocument', () => {
   test('detailFileName is <id>.html', () => {
     expect(detailFileName(cap)).toBe('field-explorer.html');
   });
+
+  // Cross-nav: siblings reachable without going back to the index, and exactly one
+  // "you are here" marker. Degrades to the plain back-link when no siblings are passed.
+  const siblings = [
+    cap,
+    { id: 'atlas-explorer', title: 'Atlas Explorer' },
+    { id: 'dc-days-qaqc', title: 'Field D&C Days QA/QC' },
+  ];
+  const navDoc = capabilityDetailDocument(cap, siblings);
+
+  test('reaches every sibling capability', () => {
+    for (const s of siblings) expect(navDoc).toContain(`href="/capabilities/${s.id}.html"`);
+    expect(navDoc).toContain('href="/capabilities/"');
+  });
+
+  test('marks exactly one page as current, and it is this page', () => {
+    expect(navDoc.match(/aria-current="page"/g)).toHaveLength(1);
+    expect(navDoc).toContain(`href="/capabilities/${cap.id}.html" aria-current="page"`);
+  });
+
+  test('escapes sibling titles rather than emitting raw markup', () => {
+    const hostile = capabilityDetailDocument(cap, [cap, { id: 'x', title: '<script>bad()</script>' }]);
+    expect(hostile).not.toContain('<script>bad()');
+    expect(hostile).toContain('&lt;script&gt;');
+  });
+
+  test('falls back to the back-link when no siblings are supplied', () => {
+    expect(doc).toContain('← All capabilities');
+    expect(doc).not.toContain('aria-current="page"');
+  });
 });
 
 describe('page wiring', () => {


### PR DESCRIPTION
Brings the capabilities surface up to the standard the tank sloshing report pages set in #73.

## Discoverability
Five capability pages were serving HTTP 200 while being wholly absent from `sitemap.xml` — search engines never saw them. Adds the index plus one entry per surfaced capability, and **couples them to the registry with tests**: a capability that reaches the site but not the sitemap now fails CI, as does a sitemap entry for a withheld or deleted capability. The gap existed because two files had to be edited by hand and one was forgotten.

## Navigation
A detail page previously offered only an "All capabilities" back-link, so sibling capabilities were reachable exclusively by going back to the index, and nothing marked which page you were on. Detail pages now carry a cross-nav over all surfaced capabilities with `aria-current` on the active one, matching the sloshing capability nav. `capabilityDetailBody/Document` take an optional siblings list and degrade to the old back-link without it, so existing callers are unaffected.

## Release-backed capabilities (new registry mode)
The registry gains a `backing` field. Default `dataset` is unchanged — live datasets-server configs, resolved by the online CI gate. The new `release` mode covers work pinned to an immutable, content-addressed release published by this site, for capabilities whose upstream dataset is private or whose evidence is not datasets-server shaped (CFD review artifacts).

**Tank Sloshing CFD** is registered this way. Its dataset returns 401 (private), so a `live` dataset-backed entry could resolve for neither CI nor a visitor. Instead the entry pins digest `a0da3df2` + revision `aa37e6d3`, the card links to the existing `/reports/sloshing/` hub, and no detail page is generated (the hub *is* the detail page — a thin extra URL would compete for the same content). A test asserts the registry digest/revision stay equal to the committed release pointer, so the card cannot drift from what the site serves.

Release-backed entries validate on `hub_url`/`digest`/`revision` shape instead of `tables`, are skipped by `verify-capabilities-online`, and are exempt from the detail-page sitemap rule — their hub carries discoverability instead.

## Provenance
Capability pages are baked at build time then optionally re-fetched client-side via "Refresh to latest", so a pinned digest like sloshing's would *misdescribe* them. They now carry a dated snapshot stamp naming the mode the build actually got — live fetch, cached snapshot, or unreachable — so a degraded render is visible rather than indistinguishable from a fresh one. No new build-time network call; this surfaces the `data_source` flag hydration already records.

## Verification
- tests 312 → 330, all green
- `validate:capabilities` PASS — 5 capabilities valid
- `validate:capabilities:online` PASS — 3 dataset-backed live entries resolve; sloshing correctly skipped
- build clean; verified each of the four generated pages marks itself and only itself as current

🤖 Generated with [Claude Code](https://claude.com/claude-code)