### PR TITLE
fix(seo,a11y): defects found by adversarial review of the #80 plans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # Full history so the generated sitemap's <lastmod> reflects when each page
+          # actually changed. On a shallow clone build.js omits lastmod entirely
+          # rather than emitting a misleading partial set (#85).
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -45,6 +50,11 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # Full history so the generated sitemap's <lastmod> reflects when each page
+          # actually changed. On a shallow clone build.js omits lastmod entirely
+          # rather than emitting a misleading partial set (#85).
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -45,6 +45,15 @@
   outline-offset: 2px;
 }
 
+/* --- contrast overrides on Bootstrap defaults (a11y, #87) -----------------
+   Bootswatch United ships .text-muted as #aea79f — 2.379:1 on white, well under
+   the 4.5:1 AA floor for body text, and it is used for real prose on the
+   calculator pages. Overridden to the palette's muted grey (5.53:1). Loaded after
+   bootstrap-united.css in the bundle, so this wins without !important. */
+.text-muted {
+  color: #5a6b76;
+}
+
 /* --- heading size utilities (a11y, #87) -----------------------------------
    The heading OUTLINE (h1..h6) must not skip levels — screen readers use it to
    navigate. Where a heading's level was corrected, these classes hold the visual

--- a/build.js
+++ b/build.js
@@ -238,12 +238,31 @@ function copyAssets() {
   }
 }
 
+// Can this checkout answer "when did this file last change?" — i.e. is it a git repo
+// with full history? On a shallow clone `git log -- <path>` only sees the commits in
+// the shallow window, so files touched by the tip get a date and everything else gets
+// nothing. That yields a sitemap where a handful of pages carry a lastmod and the rest
+// don't, which reads to a crawler as "only these changed" — worse than omitting the
+// field entirely. CI checks out with fetch-depth: 0; Vercel's clone depth is not ours
+// to control, so this is detected rather than assumed.
+function gitHistoryAvailable() {
+  try {
+    const { execFileSync } = require('child_process');
+    const run = args => execFileSync('git', args,
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    run(['rev-parse', '--git-dir']);
+    return run(['rev-parse', '--is-shallow-repository']) !== 'true';
+  } catch {
+    return false;
+  }
+}
+
 // Last commit date for a source file, as YYYY-MM-DD. Used for sitemap <lastmod> so the
 // date reflects when the page actually changed rather than when the site was rebuilt —
 // a build-time stamp would tell crawlers every page changed on every deploy. Returns
-// null outside a git checkout (shallow CI clones, tarball builds), in which case the
-// entry ships without a lastmod, which is valid and honest.
+// null when the file has no history reachable from this checkout.
 function gitLastModified(sourceFile) {
+  if (!sourceFile) return null;
   try {
     const { execFileSync } = require('child_process');
     const out = execFileSync('git', ['log', '-1', '--format=%cs', '--', sourceFile],
@@ -282,8 +301,15 @@ function sourceFileFor(relPath) {
 // from dist/ means a new page is listed the moment it builds.
 function writeSitemap(destDirArg = distDir) {
   const pages = builtPages(destDirArg).filter(p => !(p in SITEMAP_EXCLUDE));
+  // All-or-nothing on lastmod: a partial set is a misleading signal (see
+  // gitHistoryAvailable). <lastmod> is optional in the sitemap protocol, so omitting it
+  // everywhere is valid; emitting it for an arbitrary subset is not honest.
+  const datesAvailable = gitHistoryAvailable();
+  if (!datesAvailable) {
+    console.warn('sitemap: shallow or non-git checkout — omitting <lastmod> (all-or-nothing)');
+  }
   const entries = pages.map(p => {
-    const lastmod = gitLastModified(sourceFileFor(p));
+    const lastmod = datesAvailable ? gitLastModified(sourceFileFor(p)) : null;
     return [
       '  <url>',
       `    <loc>${canonicalUrlFor(p)}</loc>`,
@@ -301,7 +327,8 @@ function writeSitemap(destDirArg = distDir) {
   ].join('\n');
   fs.writeFileSync(path.join(destDirArg, 'sitemap.xml'), xml);
   const skipped = Object.keys(SITEMAP_EXCLUDE).length;
-  console.log(`Generated: sitemap.xml — ${pages.length} URLs (${skipped} excluded)`);
+  const dated = datesAvailable ? ' with lastmod' : ' without lastmod';
+  console.log(`Generated: sitemap.xml — ${pages.length} URLs (${skipped} excluded)${dated}`);
   return pages;
 }
 
@@ -463,4 +490,4 @@ if (require.main === module) {
     });
 }
 
-module.exports = { parseFrontMatter, getHtmlFiles, ensureDir, copyRobotsTxt, loadCopy, loadCapabilities, loadHydratedCapabilities, validateSloshingRelease, writeSitemap, builtPages, canonicalUrlFor, gitLastModified, SITE_ORIGIN, SITEMAP_EXCLUDE };
+module.exports = { parseFrontMatter, getHtmlFiles, ensureDir, copyRobotsTxt, loadCopy, loadCapabilities, loadHydratedCapabilities, validateSloshingRelease, writeSitemap, builtPages, canonicalUrlFor, gitLastModified, gitHistoryAvailable, SITE_ORIGIN, SITEMAP_EXCLUDE };

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -327,7 +327,8 @@ rootPath: "../"
                 <!-- Anti-abuse honeypot: Web3Forms drops submissions where this is filled. -->
                 <input type="checkbox" name="botcheck" class="hidden" style="display:none;" tabindex="-1" autocomplete="off" aria-hidden="true">
                 <div class="input-group">
-                    <input type="email" name="email" class="form-control" placeholder="Enter your email" required>
+                    <label class="sr-only" for="newsletter-email">Email address</label>
+                    <input type="email" id="newsletter-email" name="email" class="form-control" placeholder="Enter your email" required>
                     <span class="input-group-btn">
                         <button type="submit" class="btn btn-primary">Subscribe</button>
                     </span>

--- a/scripts/render-capabilities.js
+++ b/scripts/render-capabilities.js
@@ -461,7 +461,6 @@ function datasetJsonLd(cap) {
     description,
     url,
     isAccessibleForFree: true,
-    license: 'https://huggingface.co/datasets/' + cap.hf_dataset,
     creator: { '@id': `${SITE_ORIGIN}/#organization` },
     distribution: {
       '@type': 'DataDownload',

--- a/tests/js/a11y-baseline.test.js
+++ b/tests/js/a11y-baseline.test.js
@@ -12,6 +12,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { JSDOM } = require('jsdom');
 
 const DIST = path.join(__dirname, '..', '..', 'dist');
 
@@ -38,16 +39,19 @@ function walk(dir, out = []) {
   return out;
 }
 
-function stripNonContent(html) {
-  const at = html.indexOf('<body');
-  const body = at < 0 ? html : html.slice(at);
-  return body
-    .replace(/<script\b[\s\S]*?<\/script>/g, '')
-    .replace(/<style\b[\s\S]*?<\/style>/g, '');
+// One parse per page, reused by every assertion below. Real DOM, not regexes: the
+// script that repaired the heading outlines used regex detection, so a regex-based gate
+// would share its blind spots (raised in the codex review of #80).
+const domCache = new Map();
+function docFor(p) {
+  if (!domCache.has(p)) {
+    domCache.set(p, new JSDOM(fs.readFileSync(p, 'utf8')).window.document);
+  }
+  return domCache.get(p);
 }
 
-function headingLevels(html) {
-  return [...stripNonContent(html).matchAll(/<h([1-6])[\s>]/g)].map(m => Number(m[1]));
+function headingLevels(p) {
+  return [...docFor(p).querySelectorAll('h1,h2,h3,h4,h5,h6')].map(h => Number(h.tagName[1]));
 }
 
 const pages = fs.existsSync(DIST) ? walk(DIST) : [];
@@ -76,7 +80,7 @@ describe('a11y baseline (dist/)', () => {
 
   test('every page has exactly one <h1>', () => {
     const bad = chromePages
-      .map(p => [rel(p), headingLevels(read(p)).filter(l => l === 1).length])
+      .map(p => [rel(p), headingLevels(p).filter(l => l === 1).length])
       .filter(([, n]) => n !== 1);
     expect(bad).toEqual([]);
   });
@@ -84,7 +88,7 @@ describe('a11y baseline (dist/)', () => {
   test('no page skips a heading level', () => {
     const bad = [];
     for (const p of chromePages) {
-      const levels = headingLevels(read(p));
+      const levels = headingLevels(p);
       let prev = 0;
       const skips = [];
       for (const l of levels) {
@@ -97,24 +101,42 @@ describe('a11y baseline (dist/)', () => {
   });
 
   test('every page has a <main id="main"> landmark', () => {
-    const missing = chromePages.filter(p => !/<main\s+id="main"/.test(read(p))).map(rel);
+    const missing = chromePages.filter(p => !docFor(p).querySelector('main#main')).map(rel);
     expect(missing).toEqual([]);
   });
 
   test('every page has a skip link targeting #main', () => {
     const missing = chromePages
-      .filter(p => !/class="skip-link"[^>]*href="#main"|href="#main"[^>]*class="skip-link"/.test(read(p)))
+      .filter(p => !docFor(p).querySelector('a.skip-link[href="#main"]'))
       .map(rel);
     expect(missing).toEqual([]);
   });
 
-  test('the skip link is the first focusable element in the body', () => {
+  test('the skip link is the first focusable element, and targets a real element', () => {
     const bad = [];
     for (const p of chromePages) {
-      const body = stripNonContent(read(p));
-      const firstAnchor = body.search(/<a\b|<button\b|<input\b|<select\b|<textarea\b/);
-      if (firstAnchor < 0) continue;
-      if (!/^<a\b[^>]*class="skip-link"/.test(body.slice(firstAnchor))) bad.push(rel(p));
+      const doc = docFor(p);
+      const focusable = doc.querySelector('a[href], button, input:not([type="hidden"]), select, textarea');
+      if (focusable && !focusable.classList.contains('skip-link')) bad.push([rel(p), 'not first']);
+      // A skip link that points at nothing is worse than none — it silently does nothing.
+      if (!doc.getElementById('main')) bad.push([rel(p), '#main target missing']);
+    }
+    expect(bad).toEqual([]);
+  });
+
+  test('every form control has an accessible name', () => {
+    const bad = [];
+    for (const p of pages) {
+      const doc = docFor(p);
+      for (const el of doc.querySelectorAll('input:not([type="hidden"]), select, textarea')) {
+        if (el.type === 'checkbox' && el.getAttribute('aria-hidden') === 'true') continue;  // honeypot
+        const labelled = (el.id && doc.querySelector(`label[for="${el.id}"]`))
+          || el.closest('label')
+          || el.getAttribute('aria-label')
+          || el.getAttribute('aria-labelledby')
+          || el.getAttribute('title');
+        if (!labelled) bad.push([rel(p), el.tagName.toLowerCase(), el.name || el.type]);
+      }
     }
     expect(bad).toEqual([]);
   });
@@ -162,13 +184,10 @@ describe('a11y baseline (dist/)', () => {
     }
   });
 
-  test('<main> tags are balanced', () => {
+  test('there is exactly one <main> per page', () => {
     const bad = chromePages
-      .map(p => {
-        const html = read(p);
-        return [rel(p), (html.match(/<main\b/g) || []).length, (html.match(/<\/main>/g) || []).length];
-      })
-      .filter(([, o, c]) => o !== 1 || c !== 1);
+      .map(p => [rel(p), docFor(p).querySelectorAll('main').length])
+      .filter(([, n]) => n !== 1);
     expect(bad).toEqual([]);
   });
 });


### PR DESCRIPTION
Part of epic #80. Fixes defects in #91 and #92 (both already merged) found by an adversarial review of all nine plans.

## 1. `<lastmod>` was clone-depth dependent — the worst of the three

On a shallow checkout `git log -1 -- <path>` only sees commits in the shallow window: pages touched by the tip get a date, everything else gets nothing. A sitemap where 3 pages carry a `lastmod` and 108 don't tells a crawler *"only these three changed"* — strictly worse than omitting the field.

This was the real CI and Vercel behaviour, not an edge case: `actions/checkout` had no `fetch-depth`, so it defaults to 1. And the local clone is shallow too, which is exactly why the original "111 URLs with lastmod" output looked correct.

Fixed both ends:
- `fetch-depth: 0` on both CI checkout steps
- `gitHistoryAvailable()` detects a shallow or non-git checkout and `writeSitemap` then omits `lastmod` for **every** entry. All-or-nothing, and the build says which mode it used:

```
sitemap: shallow or non-git checkout — omitting <lastmod> (all-or-nothing)
Generated: sitemap.xml — 111 URLs (4 excluded) without lastmod
```

## 2. Fabricated `license` in the Dataset JSON-LD

I emitted `license: https://huggingface.co/datasets/<id>`. A dataset page is not a license, and the registry has no license field — so it was invented metadata on a page whose entire purpose is verifiable provenance. Removed; `distribution.contentUrl` already carries the dataset URL.

## 3. My #87 contrast finding was wrong

I reported "two real AA failures". I had only checked the colours in the custom palette, not Bootstrap's defaults. Bootswatch United's `.text-muted` is `#aea79f` — **2.379:1** on white, roughly half the AA floor — and it's used for real prose on `npv-field-development` (15 uses), `fatigue-sn-curve` (5) and `engineering` (2). Overridden to the palette's muted grey at 5.53:1.

The other default flagged, link orange `#e95420` at 3.650:1, is the Bootswatch United brand colour used for ordinary body links. Changing it is a brand decision, not a bug fix — filed as follow-up rather than decided here.

## 4. Unlabelled form control

The newsletter email input on `blog/index.html` had no accessible name.

## 5. The gate shared the fixer's blind spot

`a11y-baseline` was regex-based, and so was the script that repaired the heading outlines — a regex gate cannot catch what a regex fixer missed. The review measured 34 heading-skip pages at baseline where my script found 32.

The suite now parses with **jsdom**. An independent DOM pass over `dist/` confirms the #87 end state is genuinely clean:

```
heading-skip pages: 0, total jumps: 0
multiple h1: 0
zero h1 / no main / no skip link: 3  (the exempt noindex redirect stubs)
```

Two assertions added while converting:
- the skip link must target an element that **exists** — a skip link pointing at nothing silently does nothing, and a presence-only test would pass
- every form control must have an accessible name (this is what caught #4)

## Verification

350 JS tests (20 projects), 187 Python tests, `validate:capabilities` PASS, `verify_repo_structure.py` OK.

## Follow-ups filed, not fixed here

Link-colour contrast (brand decision), generated chart SVGs having no accessible name (renderer — #83), and a rendered-browser audit to catch what static analysis can't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)