### PR TITLE
fix(sloshing): correct CSV reading in the publication scripts

### DIFF
--- a/scripts/publish-sloshing-conduit-area.js
+++ b/scripts/publish-sloshing-conduit-area.js
@@ -18,29 +18,7 @@ const revision = (process.env.SLOSHING_SOURCE_REVISION || '').trim();
 if (!fs.existsSync(bundlePath)) throw new Error('reviewed conduit-area bundle is required');
 if (!/^[0-9a-f]{40}$/.test(revision)) throw new Error('SLOSHING_SOURCE_REVISION must be the 40-hex dataset revision holding the bundle');
 
-// RFC4180 reader: published summaries contain quoted commas, so a naive split
-// silently shreds those rows into extra columns and breaks the closed schema.
-function parseCsv(text) {
-  const rows = [];
-  let row = [], field = '', quoted = false;
-  for (let i = 0; i < text.length; i += 1) {
-    const ch = text[i];
-    if (quoted) {
-      if (ch !== '"') { field += ch; continue; }
-      if (text[i + 1] === '"') { field += '"'; i += 1; continue; }
-      quoted = false;
-    } else if (ch === '"' && field === '') { quoted = true; }
-    else if (ch === ',') { row.push(field); field = ''; }
-    else if (ch === '\n') { row.push(field); rows.push(row); row = []; field = ''; }
-    else if (ch !== '\r') { field += ch; }
-  }
-  if (field !== '' || row.length) { row.push(field); rows.push(row); }
-  const headers = rows.shift();
-  return rows.map(cells => {
-    if (cells.length !== headers.length) throw new Error(`malformed CSV row: ${cells[0]}`);
-    return Object.fromEntries(headers.map((header, index) => [header, cells[index]]));
-  });
-}
+const parseCsv = R.parseCsv;   // RFC4180: released summaries/labels contain quoted commas
 function upsert(base, rows, key) {
   const id = row => key.map(column => row[column]).join('\0');
   const result = new Map(base.map(row => [id(row), row]));

--- a/scripts/publish-sloshing-enrichment.js
+++ b/scripts/publish-sloshing-enrichment.js
@@ -4,16 +4,13 @@
 const fs = require('fs');
 const path = require('path');
 const R = require('./refresh-sloshing-data');
+const parseCsv = R.parseCsv;   // RFC4180: released summaries/labels contain quoted commas
 
 const REVISION = 'd9ff6967021755156c3daa35f93e6385f672b257';
 const repoRoot = path.resolve(__dirname, '..');
 const reviewRoot = process.env.SLOSHING_REVIEW_ROOT && path.resolve(process.env.SLOSHING_REVIEW_ROOT);
 if (!reviewRoot || !fs.existsSync(reviewRoot)) throw new Error('SLOSHING_REVIEW_ROOT must point to the reviewed dm1528 output directory');
 
-function parseCsv(text) {
-  const lines = text.trim().split(/\r?\n/); const headers = lines.shift().split(',');
-  return lines.map(line => Object.fromEntries(line.split(',').map((value, i) => [headers[i], value])));
-}
 function sourceEntry(localPath, remotePath) {
   const body = fs.readFileSync(localPath);
   return { path: remotePath, sha256: R.sha256(body), bytes: body.length };

--- a/scripts/publish-sloshing-evidence-extension.js
+++ b/scripts/publish-sloshing-evidence-extension.js
@@ -4,6 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 const R = require('./refresh-sloshing-data');
+const parseCsv = R.parseCsv;   // RFC4180: released summaries/labels contain quoted commas
 
 const repoRoot = path.resolve(__dirname, '..');
 const reviewRoot = path.resolve(process.env.SLOSHING_REVIEW_ROOT || '/home/undi/cfd_work/dm1528');
@@ -12,10 +13,6 @@ const mediaRoot = path.join(reviewRoot, 'review_output/evidence_extension/media'
 const mediaManifestPath = path.join(mediaRoot, 'media_manifest.json');
 if (!fs.existsSync(bundlePath) || !fs.existsSync(mediaManifestPath)) throw new Error('reviewed evidence-extension bundle and media manifest are required');
 
-function parseCsv(text) {
-  const lines = text.trim().split(/\r?\n/); const headers = lines.shift().split(',');
-  return lines.map(line => Object.fromEntries(line.split(',').map((value, index) => [headers[index], value])));
-}
 function upsert(base, rows, key) {
   const id = row => key.map(column => row[column]).join('\0');
   const result = new Map(base.map(row => [id(row), row]));

--- a/scripts/refresh-sloshing-data.js
+++ b/scripts/refresh-sloshing-data.js
@@ -331,7 +331,7 @@ function verifyRelease(release) {
   const previews = manifest.tables.find(t => t.name === 'previews');
   if ((manifest.assets || []).length && (!previews || previews.rows !== manifest.assets.length)) throw new Error('preview/asset count mismatch');
   if (previews) {
-    const rows = parseCsvSimple(release.files[previews.file]);
+    const rows = parseCsv(release.files[previews.file]);
     const byPath = new Map((manifest.assets || []).map(asset => [asset.file, asset]));
     for (const row of rows) {
       const asset = byPath.get(row.relative_path);
@@ -372,7 +372,7 @@ function publishRelease(release, options) {
       manifest: path.posix.join('assets/data/sloshing', release.digest, 'manifest.json'),
       tables: release.manifest.tables, counts: release.manifest.counts,
       assets: release.manifest.assets || [],
-      public_case_ids: parseCsvSimple(release.files['cases.csv']).map(r => r.case_id),
+      public_case_ids: parseCsv(release.files['cases.csv']).map(r => r.case_id),
     },
   };
   const tmp = `${pointerPath}.tmp-${process.pid}`;
@@ -389,10 +389,44 @@ function publishRelease(release, options) {
   return { digest: release.digest, directory: finalDir, pointer };
 }
 
-function parseCsvSimple(text) {
-  const lines = text.trim().split(/\r?\n/);
-  const headers = lines.shift().split(',');
-  return lines.map(line => Object.fromEntries(line.split(',').map((v, i) => [headers[i], v])));
+/**
+ * RFC4180 CSV reader for released tables.
+ *
+ * Published summaries and series labels contain commas, which tableCsv correctly quotes
+ * on write. A naive `line.split(',')` therefore shreds those rows on read: fields shift
+ * by one, the trailing value lands under an `undefined` key, and the closed-schema check
+ * in tableCsv then rejects the row outright. Any job that reads a committed release and
+ * writes it back must use this, not a split.
+ *
+ * Throws on a row whose field count disagrees with the header — for generated releases
+ * that is corruption, not input to tolerate.
+ */
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let field = '';
+  let quoted = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (quoted) {
+      if (ch !== '"') { field += ch; continue; }
+      if (text[i + 1] === '"') { field += '"'; i += 1; continue; }
+      quoted = false;
+    } else if (ch === '"' && field === '') { quoted = true; }
+    else if (ch === ',') { row.push(field); field = ''; }
+    else if (ch === '\n') { row.push(field); rows.push(row); row = []; field = ''; }
+    else if (ch !== '\r') { field += ch; }
+  }
+  if (field !== '' || row.length) { row.push(field); rows.push(row); }
+  const headers = rows.shift() || [];
+  // A blank line is not a row. An empty table serialises as "<header>\n" + "\n", so the
+  // trailing newline would otherwise read as a single empty field and trip the width check.
+  return rows.filter(cells => !(cells.length === 1 && cells[0] === '')).map(cells => {
+    if (cells.length !== headers.length) {
+      throw new Error(`malformed CSV row (${cells.length} fields, expected ${headers.length}): ${cells[0]}`);
+    }
+    return Object.fromEntries(headers.map((header, index) => [header, cells[index]]));
+  });
 }
 
 async function fetchPinnedFile({ dataset, revision, file, token, fetchImpl = fetch }) {
@@ -429,7 +463,7 @@ function validateCommittedRelease(repoRoot) {
 }
 
 module.exports = {
-  COLUMNS, SCHEMA_VERSION, TRANSFORMER_VERSION, sha256, stableJson,
+  COLUMNS, SCHEMA_VERSION, TRANSFORMER_VERSION, sha256, stableJson, parseCsv,
   fetchPinnedFile, transformReviewed, transformPressureArtifacts, transformPressureEvidence, mergePressureRelease, mergePressureEvidence, buildRelease, verifyRelease,
   publishRelease, validateCommittedRelease,
 };

--- a/tests/js/sloshing-refresh.test.js
+++ b/tests/js/sloshing-refresh.test.js
@@ -330,3 +330,78 @@ describe('committed report enrichment release', () => {
     expect(envelopes).toContain('forced-fine-co025-pressure-t24');
   });
 });
+
+// Released summaries and series labels contain commas, which the writer quotes. A naive
+// `line.split(',')` shreds exactly those rows — fields shift by one, the trailing value
+// lands under an `undefined` key, and the closed-schema check then rejects the row. Every
+// job that reads a committed release and writes it back depends on this reader.
+describe('parseCsv (RFC4180)', () => {
+  const { parseCsv } = refresh;
+
+  test('keeps a quoted comma inside one field', () => {
+    const rows = parseCsv('a,b,c\n1,"x, y",3\n');
+    expect(rows).toEqual([{ a: '1', b: 'x, y', c: '3' }]);
+  });
+
+  test('unescapes a doubled quote', () => {
+    expect(parseCsv('a\n"say ""hi"""\n')).toEqual([{ a: 'say "hi"' }]);
+  });
+
+  test('preserves empty trailing fields and tolerates CRLF', () => {
+    expect(parseCsv('a,b,c\r\n1,,\r\n')).toEqual([{ a: '1', b: '', c: '' }]);
+  });
+
+  test('never produces an undefined key on a comma-bearing row', () => {
+    const rows = parseCsv('id,label,tail\nx,"one, two",end\n');
+    expect(Object.keys(rows[0])).toEqual(['id', 'label', 'tail']);
+    expect(rows[0].tail).toBe('end');
+  });
+
+  test('throws on a row whose field count disagrees with the header', () => {
+    expect(() => parseCsv('a,b\n1,2,3\n')).toThrow(/malformed CSV row/);
+  });
+
+  test('every committed release table round-trips byte-exact through read and write', () => {
+    const repoRoot = path.resolve(__dirname, '..', '..');
+    const validated = refresh.validateCommittedRelease(repoRoot);
+    const dir = path.join(repoRoot, validated.pointer.release.directory);
+    const cell = value => {
+      const s = String(value == null ? '' : value);
+      return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+    };
+    for (const table of validated.manifest.tables) {
+      const original = fs.readFileSync(path.join(dir, table.file), 'utf8');
+      const columns = refresh.COLUMNS[table.name];
+      const rows = parseCsv(original);
+      const rebuilt = `${columns.join(',')}\n${rows.map(r => columns.map(c => cell(r[c])).join(',')).join('\n')}\n`;
+      expect(rebuilt).toBe(original);
+    }
+  });
+
+  test('the release really does contain comma-bearing rows this guards', () => {
+    const repoRoot = path.resolve(__dirname, '..', '..');
+    const validated = refresh.validateCommittedRelease(repoRoot);
+    const dir = path.join(repoRoot, validated.pointer.release.directory);
+    const withCommas = validated.manifest.tables.filter(t => {
+      const rows = parseCsv(fs.readFileSync(path.join(dir, t.file), 'utf8'));
+      return rows.some(r => Object.values(r).some(v => String(v).includes(',')));
+    });
+    expect(withCommas.map(t => t.name).sort()).toEqual(['case_catalog', 'series']);
+  });
+});
+
+describe('parseCsv edge cases the release writer actually emits', () => {
+  const { parseCsv } = refresh;
+
+  test('an empty table (header plus trailing blank line) reads as zero rows', () => {
+    expect(parseCsv('a,b,c\n\n')).toEqual([]);
+  });
+
+  test('a blank line between rows is skipped, not read as a short row', () => {
+    expect(parseCsv('a,b\n1,2\n\n3,4\n')).toEqual([{ a: '1', b: '2' }, { a: '3', b: '4' }]);
+  });
+
+  test('a quoted field containing a newline stays one field', () => {
+    expect(parseCsv('a,b\n"line1\nline2",x\n')).toEqual([{ a: 'line1\nline2', b: 'x' }]);
+  });
+});

--- a/tests/js/sloshing-reports.test.js
+++ b/tests/js/sloshing-reports.test.js
@@ -78,6 +78,25 @@ describe('data and rendering safety', () => {
     expect(() => R.parseCsv('a,b\n1\n')).toThrow(/column/i);
   });
 
+  // The published case_catalog and series tables contain quoted commas. The Node
+  // publication scripts once shredded exactly those rows; this asserts the browser path
+  // that actually renders them to visitors does not.
+  test('browser parser keeps quoted commas in the committed release intact', () => {
+    const repoRoot = path.resolve(__dirname, '..', '..');
+    const pointer = JSON.parse(fs.readFileSync(path.join(repoRoot, 'config', 'sloshing-data-release.json'), 'utf8'));
+    const dir = path.join(repoRoot, pointer.release.directory);
+    let withCommas = 0;
+    for (const table of pointer.release.tables) {
+      const rows = R.parseCsv(fs.readFileSync(path.join(dir, table.file), 'utf8'));
+      expect(rows).toHaveLength(table.rows);
+      for (const row of rows) {
+        expect(Object.keys(row)).toEqual(table.columns);
+        if (Object.values(row).some(v => String(v).includes(','))) withCommas += 1;
+      }
+    }
+    expect(withCommas).toBeGreaterThan(0);
+  });
+
   test('stale load cannot replace a newer committed release', async () => {
     const commits = [];
     const gate = R.createLoadGate(value => commits.push(value));


### PR DESCRIPTION
The publication scripts read committed release tables with `line.split(',')`. Released summaries and series labels contain commas, which the writer correctly quotes — so exactly those rows were shredded on read: fields shift by one, the trailing value lands under an `undefined` key, and `tableCsv`'s closed-schema check then rejects the row.

## This was not latent

Measured against the current release:

```
series:       3/47 rows shredded    label became "\"Exchange volume difference
case_catalog: 9/24 rows shredded    overflow into undefined: "/reports/sloshing/validation.html"
```

12 rows, so `publish-sloshing-enrichment.js` and `publish-sloshing-evidence-extension.js` **could not run at all** against the current release. It stayed invisible because each earlier job happened to rewrite every affected row from its own bundle; the narrower conduit-area publication in #73 hit it on the first run.

## Fix

One RFC4180 reader in `refresh-sloshing-data.js`, replacing all three copies plus the shared `parseCsvSimple` — which had survived only because the columns it reads sit before any comma-bearing field. `grep "split(',')" scripts/` now matches only the comment explaining the bug.

It throws on a row whose width disagrees with the header: for generated releases that is corruption, not input to tolerate.

**Edge case the stricter parser exposed:** an empty table serialises as `header\n` + `\n`, and the old `.trim()` silently swallowed that trailing blank line. Three existing tests failed until blank lines were treated as non-data.

## Verification

- release digest **unchanged**; `validateCommittedRelease` passes
- **all 14 tables round-trip byte-exact** through read then write — 10,442 rows, zero closed-schema violations
- simulated both older scripts' exact parse step: they can now round-trip the release
- build clean; tests 330 → 341

## Production was never affected

`assets/js/sloshing-reports.js` — the browser path that actually renders these tables to visitors — already had a correct RFC4180 parser (quotes, doubled quotes, CRLF, blank-line skip, unclosed-quote guard). The 12 rows have always rendered correctly on the live site; the defect was confined to the Node publication scripts. Added a test asserting the browser parser against the real release so that path stays covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)