### PR TITLE
chore(sloshing): lock the published schema document to the code it describes

### DIFF
--- a/config/sloshing-report-schema.json
+++ b/config/sloshing-report-schema.json
@@ -3,6 +3,7 @@
   "closed": true,
   "limits": {
     "max_public_rows": 10000,
+    "max_source_bytes": 12000000,
     "max_string_length": 160
   },
   "tables": {

--- a/tests/js/sloshing-refresh.test.js
+++ b/tests/js/sloshing-refresh.test.js
@@ -460,3 +460,49 @@ describe('parseCsv edge cases the release writer actually emits', () => {
     expect(parseCsv('a,b\n"line1\nline2",x\n')).toEqual([{ a: 'line1\nline2', b: 'x' }]);
   });
 });
+
+// config/sloshing-report-schema.json is the human-readable declaration of the release
+// contract. No code reads it, so nothing stopped it drifting from the constants it
+// describes — the same defect class as a declared-but-unenforced limit. It duplicates the
+// schema version, the limits, and the column list of all 14 tables; today they agree, and
+// these tests are what keep that true.
+describe('published schema document matches the code it describes', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const schema = JSON.parse(fs.readFileSync(path.join(repoRoot, 'config', 'sloshing-report-schema.json'), 'utf8'));
+
+  test('declares the same schema version', () => {
+    expect(schema.schema_version).toBe(refresh.SCHEMA_VERSION);
+  });
+
+  test('declares exactly the enforced limits, none missing or extra', () => {
+    expect(schema.limits).toEqual(refresh.LIMITS);
+  });
+
+  test('declares every table, and no table the code does not define', () => {
+    expect(Object.keys(schema.tables).sort()).toEqual(Object.keys(refresh.COLUMNS).sort());
+  });
+
+  test.each(Object.keys(refresh.COLUMNS))('table %s declares the code column list in order', name => {
+    expect(schema.tables[name].columns).toEqual(refresh.COLUMNS[name]);
+  });
+
+  // Key declarations vary by table on purpose: detail tables carry foreign_keys rather than
+  // a primary_key, and `dispositions` is a standalone rollup with neither. So presence is not
+  // asserted — only that whatever a table does declare names a column that really exists.
+  test('every declared key names a column that exists', () => {
+    for (const [name, table] of Object.entries(schema.tables)) {
+      const keys = [...(table.primary_key || []), ...Object.keys(table.foreign_keys || {})];
+      for (const key of keys) expect(refresh.COLUMNS[name]).toContain(key);
+    }
+  });
+
+  test('every foreign key points at a table and column that exist', () => {
+    for (const table of Object.values(schema.tables)) {
+      for (const target of Object.values(table.foreign_keys || {})) {
+        const [targetTable, targetColumn] = String(target).split('.');
+        expect(refresh.COLUMNS[targetTable]).toBeDefined();
+        expect(refresh.COLUMNS[targetTable]).toContain(targetColumn);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Follow-up to #95, which made the declared source-byte limit honest and enforced. That PR surfaced a second instance of the same defect class, deliberately left out of scope at the time.

## The problem

`config/sloshing-report-schema.json` is the human-readable declaration of the release contract — and **no code reads it**. Nothing stopped it drifting from the constants it describes. It duplicates:

- `schema_version` (vs `SCHEMA_VERSION`)
- `limits` (vs `LIMITS` — and it was missing `max_source_bytes` entirely)
- the **column list of all 14 tables** (vs `COLUMNS`)

They agreed today. That is exactly why a drift would have been silent: add a column to `COLUMNS` and the published contract quietly describes a different schema than the one being enforced.

## Fix

- adds the missing `max_source_bytes` to the limits block — one line, formatting otherwise untouched
- adds tests locking `schema_version`, `limits`, the table set, and **every table's column list in order** to the code constants
- checks that any declared primary or foreign key names a real column, and that foreign keys point at a table and column that exist

## A judgement call worth noting

Key declarations are **not** required to be present. Detail tables (`metrics`, `samples`, …) legitimately carry `foreign_keys` instead of a `primary_key`, and `dispositions` is a standalone rollup with neither. My first two attempts at this test asserted a `primary_key` on every table and then a key of *some* kind on every table — both were invented requirements that the schema correctly violated. Only what a table actually declares is now validated.

## Verification

- release digest unchanged at `a0da3df2d32f03e5dd7014dc81af6aeb6f332a8570738eecca4a3c62c6f9af97`
- `validateCommittedRelease` passes; `node build.js` clean
- tests **365 → 384**, 20 suites
- lock confirmed non-vacuous: simulated a column addition and a removed limit, both are caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)