### PR TITLE
A6 — asset delivery: PurgeCSS 0%→49%, three Plotly versions to one, cdn.plot.ly out of the CSP

### DIFF
--- a/build.js
+++ b/build.js
@@ -280,6 +280,51 @@ async function buildCapabilityDetailPages(registry) {
 // bundle".
 const CSS_NOT_COPIED = new Set([...BUNDLE_INPUTS, 'styles.min.css']);
 
+// Verify every vendored third-party blob that ships a `<file>.sha256` sidecar (#86).
+//
+// `assets/js/plotly-2.32.0.min.js` is 3.6MB of third-party code served from our own
+// origin, and its `.sha256` sidecar existed for months with nothing reading it —
+// integrity theatre. Now that the CSP no longer allows cdn.plot.ly, this copy is the
+// only Plotly the site can load, so a corrupted or swapped file breaks every chart on
+// 18 pages with no external fallback. Fail the build rather than ship it.
+//
+// Format is `sha256sum` output: "<hex>  <path>". Throws on mismatch, missing target,
+// or a malformed sidecar — a check that silently passes when it can't run is worse
+// than no check.
+function verifyVendoredAssets(assetsDir = './assets') {
+  if (!fs.existsSync(assetsDir)) return [];
+  const crypto = require('crypto');
+  const verified = [];
+
+  const walk = (dir) => {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) { walk(p); continue; }
+      if (!e.name.endsWith('.sha256')) continue;
+
+      const target = p.slice(0, -'.sha256'.length);
+      const rel = path.relative(assetsDir, target).split(path.sep).join('/');
+      if (!fs.existsSync(target)) {
+        throw new Error(`vendored-asset integrity: ${rel}.sha256 exists but ${rel} does not`);
+      }
+      const expected = (fs.readFileSync(p, 'utf8').trim().split(/\s+/)[0] || '').toLowerCase();
+      if (!/^[0-9a-f]{64}$/.test(expected)) {
+        throw new Error(`vendored-asset integrity: ${rel}.sha256 is not a sha256 digest`);
+      }
+      const actual = crypto.createHash('sha256').update(fs.readFileSync(target)).digest('hex');
+      if (actual !== expected) {
+        throw new Error(
+          `vendored-asset integrity: ${rel} does not match its .sha256\n` +
+          `  expected ${expected}\n  actual   ${actual}`);
+      }
+      verified.push(rel);
+    }
+  };
+
+  walk(assetsDir);
+  return verified;
+}
+
 function copyAssets() {
   const assetsDir = './assets';
   const destDir = path.join(distDir, 'assets');
@@ -463,7 +508,9 @@ async function build() {
     console.warn(`Drill-down skipped: ${err.message}`);
   }
 
-  // Copy assets
+  // Copy assets — integrity-check vendored blobs before they reach dist/
+  const verified = verifyVendoredAssets();
+  console.log(`Verified: ${verified.length} vendored asset(s) against .sha256 — ${verified.join(', ') || 'none'}`);
   copyAssets();
   writeSitemap();
   copyRobotsTxt();
@@ -545,4 +592,4 @@ if (require.main === module) {
     });
 }
 
-module.exports = { parseFrontMatter, getHtmlFiles, ensureDir, copyRobotsTxt, loadCopy, loadCapabilities, loadHydratedCapabilities, validateSloshingRelease, writeSitemap, builtPages, buildCSS, copyAssets, BUNDLE_INPUTS, CSS_NOT_COPIED, PURGE_SAFELIST, PURGE_REQUIRED, PURGE_MIN_REDUCTION, canonicalUrlFor, gitLastModified, gitHistoryAvailable, SITE_ORIGIN, SITEMAP_EXCLUDE };
+module.exports = { parseFrontMatter, getHtmlFiles, ensureDir, copyRobotsTxt, loadCopy, loadCapabilities, loadHydratedCapabilities, validateSloshingRelease, writeSitemap, builtPages, buildCSS, copyAssets, verifyVendoredAssets, BUNDLE_INPUTS, CSS_NOT_COPIED, PURGE_SAFELIST, PURGE_REQUIRED, PURGE_MIN_REDUCTION, canonicalUrlFor, gitLastModified, gitHistoryAvailable, SITE_ORIGIN, SITEMAP_EXCLUDE };

--- a/build.js
+++ b/build.js
@@ -28,6 +28,44 @@ const SITEMAP_EXCLUDE = {
   'reports/diffraction/orcawave-aqwa-comparison.html': 'noindex redirect stub -> comparison.html',
 };
 
+// Classes that only ever appear because JavaScript adds them at runtime, so PurgeCSS
+// cannot see them in the markup it scans. Derived from the actual `classList` calls in
+// assets/js — not guessed. Keep this list minimal: every entry is CSS that ships
+// whether or not it is needed.
+//
+//   navbar-toggle.js toggles: collapse, collapsing, in
+//   Bootstrap state classes applied by our own inline handlers: active, open, disabled
+//
+// The previous safelist matched essentially all of Bootstrap (/^nav/, /^btn/, /^col-/,
+// /^text-/, deep: /navbar/ …), which is why the step logged "0% reduction" on every
+// build while appearing to succeed (#86).
+const PURGE_SAFELIST = [
+  /^col-(xs|sm|md|lg)-\d+$/, /^col-(xs|sm|md|lg)-offset-\d+$/,
+  /^collapse$/, /^collapsing$/, /^in$/,
+  /^active$/, /^open$/, /^disabled$/,
+  /^has-(error|warning|success|feedback)$/,
+  /^sr-only(-focusable)?$/,
+];
+
+// Selectors the site cannot render without. A byte-size floor alone is not a
+// correctness check — a purge can strip something essential and still hit its
+// target — so the build asserts these survived.
+const PURGE_REQUIRED = [
+  '.container', '.row', '.navbar', '.navbar-toggle', '.collapse', '.btn',
+  '.form-control', '.table', '.col-md-6', '.sr-only',
+];
+
+// Minimum reduction we expect from purging Bootstrap. Below this, something has
+// re-broadened the safelist and dead CSS is shipping again.
+const PURGE_MIN_REDUCTION = 0.30;
+
+// CSS concatenated into styles.min.css, in cascade order. These are bundle INPUTS —
+// they are never copied to dist/ individually (see copyAssets).
+const BUNDLE_INPUTS = [
+  'fonts.css', 'bootstrap-united.css', 'responsive.css',
+  'marketing.css', 'components.css', 'theme.css',
+];
+
 // Turn a dist-relative path into the canonical absolute URL. Directory index pages
 // canonicalise to the directory ("/blog/", not "/blog/index.html") so the site has
 // one URL per page rather than two that serve identical bytes.
@@ -227,15 +265,39 @@ async function buildCapabilityDetailPages(registry) {
   return generated.length;
 }
 
-// Copy assets directory
+// Copy assets/ into dist/, minus the CSS that buildCSS() produces or consumes (#86).
+//
+// Skipped:
+//   - BUNDLE_INPUTS — they are concatenated into styles.min.css; shipping them too was
+//     ~124KB of dead weight no page references.
+//   - styles.min.css — a stale committed build artifact (predates theme.css). It was
+//     copied in and then overwritten by the bundle step, so the copy was pointless and
+//     the stale file could ship if the bundle ever failed. Untracking it belongs with
+//     the legacy-root cleanup (#88), which still needs it.
+//
+// Directly-referenced stylesheets (sloshing-browser.css, sloshing-reports.css) are NOT
+// bundle inputs and must keep shipping — hence a skip list rather than "copy only the
+// bundle".
+const CSS_NOT_COPIED = new Set([...BUNDLE_INPUTS, 'styles.min.css']);
+
 function copyAssets() {
   const assetsDir = './assets';
   const destDir = path.join(distDir, 'assets');
+  if (!fs.existsSync(assetsDir)) return;
 
-  if (fs.existsSync(assetsDir)) {
-    fs.cpSync(assetsDir, destDir, { recursive: true });
-    console.log('Copied: assets/');
-  }
+  let skipped = 0;
+  fs.cpSync(assetsDir, destDir, {
+    recursive: true,
+    filter: (src) => {
+      const rel = path.relative(assetsDir, src).split(path.sep).join('/');
+      if (rel.startsWith('css/') && CSS_NOT_COPIED.has(path.basename(src))) {
+        skipped++;
+        return false;
+      }
+      return true;
+    },
+  });
+  console.log(`Copied: assets/ (${skipped} bundled/stale CSS files not copied)`);
 }
 
 // Can this checkout answer "when did this file last change?" — i.e. is it a git repo
@@ -410,84 +472,77 @@ async function build() {
 }
 
 // PurgeCSS - strip unused Bootstrap CSS
-async function purgeBootstrapCSS() {
-  const cssSource = './assets/css/bootstrap-united.css';
-  if (!fs.existsSync(cssSource)) {
-    console.log('PurgeCSS: bootstrap-united.css not found, skipping.');
-    return;
+// Build dist/assets/css/styles.min.css: purge Bootstrap against the built HTML, then
+// concatenate and minify — all reading from ./assets/css (source), never from dist/.
+//
+// The previous order was copy → purge-in-place → bundle-from-dist, which meant the
+// bundle silently depended on the copy step having run and on files existing in dist/;
+// a missing input produced a smaller bundle and a successful exit.
+async function buildCSS() {
+  const srcCssDir = './assets/css';
+  const distCssDir = path.join(distDir, 'assets/css');
+  ensureDir(distCssDir);
+
+  console.log('\nBuilding CSS...');
+
+  const pieces = [];
+  let totalOriginal = 0;
+
+  for (const file of BUNDLE_INPUTS) {
+    const srcPath = path.join(srcCssDir, file);
+    if (!fs.existsSync(srcPath)) {
+      throw new Error(`CSS bundle input missing: ${srcPath}`);
+    }
+    let css = fs.readFileSync(srcPath, 'utf8');
+    totalOriginal += Buffer.byteLength(css, 'utf8');
+
+    if (file === 'bootstrap-united.css') {
+      const before = Buffer.byteLength(css, 'utf8');
+      const [result] = await new PurgeCSS().purge({
+        // Scan the built HTML plus the JS that ships with it — dist/assets/js is where
+        // runtime class names live.
+        content: [`${distDir}/**/*.html`, `${distDir}/assets/js/*.js`],
+        css: [{ raw: css, extension: 'css' }],
+        safelist: { standard: PURGE_SAFELIST },
+      });
+      css = result.css;
+      const after = Buffer.byteLength(css, 'utf8');
+      const reduction = 1 - after / before;
+      console.log(`  PurgeCSS: ${(before / 1024).toFixed(1)}KB → ${(after / 1024).toFixed(1)}KB (${(reduction * 100).toFixed(0)}% reduction)`);
+
+      if (reduction < PURGE_MIN_REDUCTION) {
+        throw new Error(
+          `PurgeCSS reduction ${(reduction * 100).toFixed(0)}% is below the ${(PURGE_MIN_REDUCTION * 100)}% floor — ` +
+          `the safelist has probably re-broadened and dead CSS is shipping again (#86).`
+        );
+      }
+      const stripped = PURGE_REQUIRED.filter(sel => !css.includes(sel));
+      if (stripped.length) {
+        throw new Error(`PurgeCSS stripped required selectors: ${stripped.join(', ')}`);
+      }
+    }
+
+    pieces.push(css);
   }
 
-  console.log('\nRunning PurgeCSS...');
-  const purgeCSSResults = await new PurgeCSS().purge({
-    content: ['./dist/**/*.html'],
-    css: [cssSource],
-    safelist: {
-      standard: [
-        /^navbar/, /^collapse/, /^collapsing/, /^nav/, /^in$/,
-        /^container/, /^row/, /^col-/, /^btn/, /^form/,
-        /^sr-only/, /^text-/, /^table/, /^input-group/,
-        /^well/, /^lead/, /^breadcrumb/, /^list-/,
-        /^page-header/, /^alert/, /^label/
-      ],
-      deep: [/navbar/, /collapse/]
-    }
-  });
-
-  if (purgeCSSResults.length > 0) {
-    const outputPath = path.join('./dist/assets/css/bootstrap-united.css');
-    fs.writeFileSync(outputPath, purgeCSSResults[0].css);
-    const originalSize = fs.statSync(cssSource).size;
-    const purgedSize = Buffer.byteLength(purgeCSSResults[0].css, 'utf8');
-    console.log(`PurgeCSS: ${(originalSize / 1024).toFixed(1)}KB → ${(purgedSize / 1024).toFixed(1)}KB (${((1 - purgedSize / originalSize) * 100).toFixed(0)}% reduction)`);
+  const output = new CleanCSS({ level: 2, compatibility: 'ie9' }).minify(pieces.join('\n'));
+  if (output.errors.length) {
+    throw new Error(`CSS minification failed: ${output.errors.join('; ')}`);
   }
-}
 
-// Concatenate and minify all CSS into a single file
-async function bundleCSS() {
-    console.log('\nBundling CSS...');
-    const distCssDir = path.join(distDir, 'assets/css');
-
-    // Read CSS files in correct order
-    const cssFiles = ['fonts.css', 'bootstrap-united.css', 'responsive.css', 'marketing.css', 'components.css', 'theme.css'];
-    let combined = '';
-    let totalOriginal = 0;
-
-    for (const file of cssFiles) {
-        const filePath = path.join(distCssDir, file);
-        if (fs.existsSync(filePath)) {
-            const content = fs.readFileSync(filePath, 'utf8');
-            combined += content + '\n';
-            totalOriginal += Buffer.byteLength(content, 'utf8');
-        }
-    }
-
-    // Minify
-    const output = new CleanCSS({
-        level: 2,
-        compatibility: 'ie9'
-    }).minify(combined);
-
-    if (output.errors.length > 0) {
-        console.error('CSS minification errors:', output.errors);
-        return;
-    }
-
-    const outputPath = path.join(distCssDir, 'styles.min.css');
-    fs.writeFileSync(outputPath, output.styles);
-
-    const minifiedSize = Buffer.byteLength(output.styles, 'utf8');
-    console.log(`CSS Bundle: ${(totalOriginal / 1024).toFixed(1)}KB → ${(minifiedSize / 1024).toFixed(1)}KB (${((1 - minifiedSize / totalOriginal) * 100).toFixed(0)}% reduction)`);
+  fs.writeFileSync(path.join(distCssDir, 'styles.min.css'), output.styles);
+  const minified = Buffer.byteLength(output.styles, 'utf8');
+  console.log(`  Bundle: ${(totalOriginal / 1024).toFixed(1)}KB → ${(minified / 1024).toFixed(1)}KB (${((1 - minified / totalOriginal) * 100).toFixed(0)}% reduction)`);
 }
 
 // Only run build when executed directly (not when required for testing)
 if (require.main === module) {
   build()
-    .then(() => purgeBootstrapCSS())
-    .then(() => bundleCSS())
+    .then(() => buildCSS())
     .catch(err => {
       console.error('Build failed:', err);
       process.exit(1);
     });
 }
 
-module.exports = { parseFrontMatter, getHtmlFiles, ensureDir, copyRobotsTxt, loadCopy, loadCapabilities, loadHydratedCapabilities, validateSloshingRelease, writeSitemap, builtPages, canonicalUrlFor, gitLastModified, gitHistoryAvailable, SITE_ORIGIN, SITEMAP_EXCLUDE };
+module.exports = { parseFrontMatter, getHtmlFiles, ensureDir, copyRobotsTxt, loadCopy, loadCapabilities, loadHydratedCapabilities, validateSloshingRelease, writeSitemap, builtPages, buildCSS, copyAssets, BUNDLE_INPUTS, CSS_NOT_COPIED, PURGE_SAFELIST, PURGE_REQUIRED, PURGE_MIN_REDUCTION, canonicalUrlFor, gitLastModified, gitHistoryAvailable, SITE_ORIGIN, SITEMAP_EXCLUDE };

--- a/content/calculators/decline-curve.html
+++ b/content/calculators/decline-curve.html
@@ -21,7 +21,7 @@ rootPath: "../"
     <include src="partials/head-common.html"></include>
 
     <!-- Plotly for interactive charts -->
-    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" integrity="sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="{{ rootPath }}assets/js/plotly-2.32.0.min.js"></script>
 
     <!-- JSON-LD Structured Data - WebApplication -->
     <script type="application/ld+json">

--- a/content/calculators/fatigue-sn-curve.html
+++ b/content/calculators/fatigue-sn-curve.html
@@ -19,7 +19,7 @@ rootPath: "../"
     <title>S-N Curve Fatigue Calculator - AceEngineer</title>
 
     <include src="partials/head-common.html"></include>
-    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" integrity="sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="{{ rootPath }}assets/js/plotly-2.32.0.min.js"></script>
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">

--- a/content/calculators/mooring-fatigue.html
+++ b/content/calculators/mooring-fatigue.html
@@ -21,7 +21,7 @@ rootPath: "../"
     <include src="partials/head-common.html"></include>
 
     <!-- Plotly for interactive charts -->
-    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" integrity="sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="{{ rootPath }}assets/js/plotly-2.32.0.min.js"></script>
 
     <!-- JSON-LD Structured Data - WebApplication -->
     <script type="application/ld+json">

--- a/content/calculators/npv-field-development.html
+++ b/content/calculators/npv-field-development.html
@@ -19,7 +19,7 @@ rootPath: "../"
     <title>NPV Field Development Calculator - AceEngineer</title>
 
     <include src="partials/head-common.html"></include>
-    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" integrity="sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="{{ rootPath }}assets/js/plotly-2.32.0.min.js"></script>
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">

--- a/content/calculators/on-bottom-stability.html
+++ b/content/calculators/on-bottom-stability.html
@@ -21,7 +21,7 @@ rootPath: "../"
     <include src="partials/head-common.html"></include>
 
     <!-- Plotly for interactive charts -->
-    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" integrity="sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="{{ rootPath }}assets/js/plotly-2.32.0.min.js"></script>
 
     <!-- JSON-LD Structured Data - WebApplication -->
     <script type="application/ld+json">

--- a/content/calculators/wall-thickness.html
+++ b/content/calculators/wall-thickness.html
@@ -21,7 +21,7 @@ rootPath: "../"
     <include src="partials/head-common.html"></include>
 
     <!-- Plotly for interactive charts -->
-    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" integrity="sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="{{ rootPath }}assets/js/plotly-2.32.0.min.js"></script>
 
     <!-- JSON-LD Structured Data - WebApplication -->
     <script type="application/ld+json">

--- a/content/reports/diffraction/analysis.html
+++ b/content/reports/diffraction/analysis.html
@@ -9,7 +9,7 @@ rootPath: "../../"
 <title>Diffraction Analysis — Live Dataset Report | AceEngineer</title>
 <meta name="description" content="Vessel motion RAOs from potential-flow diffraction analysis (AQWA / OrcaWave) — select program, vessel and damping ratio; results render live from the de-identified aceengineer/digitalmodel-diffraction-rao Hugging Face dataset.">
 <include src="partials/head-common.html"></include>
-<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+<script src="{{ rootPath }}assets/js/plotly-2.32.0.min.js"></script>
 <style>
   .rpt * { box-sizing: border-box; }
   .rpt { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;

--- a/content/reports/diffraction/comparison.html
+++ b/content/reports/diffraction/comparison.html
@@ -9,7 +9,7 @@ rootPath: "../../"
 <title>Diffraction Comparison — Any Two Series | AceEngineer</title>
 <meta name="description" content="Compare any two published diffraction RAO series (across solver, vessel or damping ratio) with overlay plots and interpolated delta statistics, rendered live from the de-identified aceengineer/digitalmodel-diffraction-rao Hugging Face dataset.">
 <include src="partials/head-common.html"></include>
-<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+<script src="{{ rootPath }}assets/js/plotly-2.32.0.min.js"></script>
 <style>
   .rpt * { box-sizing: border-box; }
   .rpt { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;

--- a/package.json
+++ b/package.json
@@ -92,6 +92,11 @@
         "testMatch": ["<rootDir>/tests/js/a11y-baseline.test.js"]
       },
       {
+        "displayName": "vendored-assets",
+        "testEnvironment": "node",
+        "testMatch": ["<rootDir>/tests/js/vendored-assets.test.js"]
+      },
+      {
         "displayName": "wall-thickness",
         "testEnvironment": "node",
         "testMatch": ["<rootDir>/tests/js/wall-thickness.test.js"]

--- a/stats.json
+++ b/stats.json
@@ -1,4 +1,4 @@
 {
   "standards": 17,
-  "last_updated": "2026-07-26"
+  "last_updated": "2026-07-27"
 }

--- a/tests/js/vendored-assets.test.js
+++ b/tests/js/vendored-assets.test.js
@@ -1,0 +1,127 @@
+/**
+ * vendored-assets.test.js — one Plotly, served by us, and it must be the file we vetted (#86).
+ *
+ * Before this, three Plotly versions shipped: 2.32.0 vendored (10 pages), 2.27.0 from
+ * cdn.plot.ly (6 calculator pages) and 2.35.2 from cdn.plot.ly (2 diffraction reports).
+ * Visitors paid for a 3.6MB local copy AND a third-party round trip, the CSP had to keep
+ * `https://cdn.plot.ly` in `script-src`, and nothing stopped a fourth version appearing.
+ *
+ * These are the assertions that make the consolidation hold. Each one corresponds to a
+ * way it can silently come undone.
+ *
+ * Runs against dist/, so `npm run build` must have run first.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const ROOT = path.join(__dirname, '..', '..');
+const DIST = path.join(ROOT, 'dist');
+
+// The single version the whole site is allowed to load.
+const PLOTLY = 'plotly-2.32.0.min.js';
+
+function walk(dir, ext, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, ext, out);
+    else if (e.name.endsWith(ext)) out.push(p);
+  }
+  return out;
+}
+
+const pages = walk(DIST, '.html');
+const rel = p => path.relative(DIST, p).split(path.sep).join('/');
+const read = p => fs.readFileSync(p, 'utf8');
+
+// `<script src="...">` only. Blog posts legitimately discuss plotly in prose and in
+// Python code samples (`import plotly.express as px`), and those must not trip this.
+const SCRIPT_SRC = /<script[^>]+src="([^"]+)"/g;
+function scriptSrcs(p) {
+  return [...read(p).matchAll(SCRIPT_SRC)].map(m => m[1]);
+}
+
+describe('vendored assets (dist/)', () => {
+  test('the build output exists — run `npm run build` first', () => {
+    expect(pages.length).toBeGreaterThan(50);
+  });
+
+  test('no page loads a script from cdn.plot.ly', () => {
+    const bad = pages
+      .map(p => [rel(p), scriptSrcs(p).filter(s => /cdn\.plot\.ly/.test(s))])
+      .filter(([, hits]) => hits.length);
+    expect(bad).toEqual([]);
+  });
+
+  test('every Plotly script tag points at the one vendored version', () => {
+    const bad = [];
+    for (const p of pages) {
+      for (const src of scriptSrcs(p)) {
+        if (!/plotly/i.test(src)) continue;
+        if (!src.endsWith(`assets/js/${PLOTLY}`)) bad.push([rel(p), src]);
+      }
+    }
+    expect(bad).toEqual([]);
+  });
+
+  test('exactly one Plotly build ships in dist/assets/js', () => {
+    const shipped = walk(path.join(DIST, 'assets', 'js'), '.js')
+      .map(p => path.basename(p))
+      .filter(n => /^plotly.*\.js$/.test(n));
+    expect(shipped).toEqual([PLOTLY]);
+  });
+
+  test('the vendored Plotly is actually referenced by at least one page', () => {
+    // A 3.6MB blob nobody loads is dead weight; this fails if the last reference goes.
+    const users = pages.filter(p => scriptSrcs(p).some(s => s.endsWith(`assets/js/${PLOTLY}`)));
+    expect(users.length).toBeGreaterThan(0);
+  });
+
+  test('the CSP no longer allows cdn.plot.ly', () => {
+    // The whole point of vendoring: script-src gets narrower. If a future change puts the
+    // CDN back without reverting the pages, this catches the widened policy.
+    const vercel = JSON.parse(read(path.join(ROOT, 'vercel.json')));
+    const csp = JSON.stringify(vercel).match(/script-src[^;"]*/);
+    expect(csp).not.toBeNull();
+    expect(csp[0]).not.toMatch(/cdn\.plot\.ly/);
+  });
+
+  test('every vendored blob matches its .sha256 sidecar', () => {
+    // The sidecar shipped for months with nothing reading it. build.js verifies it now;
+    // this asserts the sidecars still exist and still match, so the guard cannot rot
+    // back into decoration.
+    const sidecars = walk(path.join(ROOT, 'assets'), '.sha256');
+    expect(sidecars.length).toBeGreaterThan(0);
+
+    for (const sc of sidecars) {
+      const target = sc.slice(0, -'.sha256'.length);
+      expect(fs.existsSync(target)).toBe(true);
+      const expected = read(sc).trim().split(/\s+/)[0].toLowerCase();
+      expect(expected).toMatch(/^[0-9a-f]{64}$/);
+      const actual = crypto.createHash('sha256').update(fs.readFileSync(target)).digest('hex');
+      expect(`${path.basename(target)}: ${actual}`).toBe(`${path.basename(target)}: ${expected}`);
+    }
+  });
+
+  test('verifyVendoredAssets throws on a corrupted blob', () => {
+    // Proving the build gate fires, rather than trusting that it would.
+    const { verifyVendoredAssets } = require('../../build.js');
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'vendored-'));
+    try {
+      fs.writeFileSync(path.join(tmp, 'lib.js'), 'trustworthy');
+      fs.writeFileSync(path.join(tmp, 'lib.js.sha256'), `${'0'.repeat(64)}  lib.js\n`);
+      expect(() => verifyVendoredAssets(tmp)).toThrow(/does not match its \.sha256/);
+
+      const good = crypto.createHash('sha256').update('trustworthy').digest('hex');
+      fs.writeFileSync(path.join(tmp, 'lib.js.sha256'), `${good}  lib.js\n`);
+      expect(verifyVendoredAssets(tmp)).toEqual(['lib.js']);
+
+      fs.rmSync(path.join(tmp, 'lib.js'));
+      expect(() => verifyVendoredAssets(tmp)).toThrow(/exists but/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -55,7 +55,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.plot.ly https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.web3forms.com https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com https://datasets-server.huggingface.co https://huggingface.co; form-action 'self' https://api.web3forms.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.web3forms.com https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com https://datasets-server.huggingface.co https://huggingface.co; form-action 'self' https://api.web3forms.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; upgrade-insecure-requests"
         }
       ]
     }


### PR DESCRIPTION
Closes [#86](https://github.com/vamseeachanta/aceengineer-website/issues/86). Two halves: the CSS pipeline, then Plotly.

## 1 — The CSS pipeline was a no-op

PurgeCSS scanned and rewrote files in `dist/` that the copy step then overwrote. The reduction in the build log was real; it never reached a browser. `buildCSS()` now reads from `assets/css` (source) and replaces the old `purgeBootstrapCSS()` + `bundleCSS()` pair.

| | Before | After |
|---|---|---|
| PurgeCSS | 75.3 KB → 75.3 KB (**0%**) | 75.3 KB → 38.3 KB (**49%**) |
| Served bundle | 77.1 KB | **47.0 KB** |
| `dist/assets/css/` | ~200 KB, 8 files | **68 KB, 3 files** |

The three surviving files (`styles.min.css`, `sloshing-browser.css`, `sloshing-reports.css`) were each confirmed as referenced before the copy filter was allowed to drop the rest.

The safelist was derived by grepping actual `classList` calls in `assets/js`, not guessed — only `collapse`, `collapsing` and `in` are applied at runtime by our own code. The rest of the original safelist was Plotly/mapbox internals keeping 37 KB of Bootstrap alive for nothing. Measured alternatives: no safelist 33.2 KB, dynamic-only 35.5 KB, previous safelist 75.3 KB.

**Guardrails, because this failed silently once.** A percentage in a log is not a gate:

- `PURGE_MIN_REDUCTION = 0.30` — throws below a 30% reduction (what a re-broken pipeline looks like).
- `PURGE_REQUIRED` — throws if any of 10 structural selectors is stripped (what an over-aggressive purge looks like).

## 2 — Three Plotly versions, one of them served twice over

| Version | Source | Pages |
|---|---|---|
| 2.32.0 | vendored, 3.6 MB | 10 |
| 2.27.0 | `cdn.plot.ly` | 6 calculators |
| 2.35.2 | `cdn.plot.ly` | 2 diffraction reports |

Visitors paid for a large local copy **and** a third-party round trip, and `script-src` had to keep `https://cdn.plot.ly` open to allow it.

All 18 references now point at the vendored 2.32.0, and the CSP is narrower by one origin:

```diff
- script-src 'self' 'unsafe-inline' https://cdn.plot.ly https://www.googletagmanager.com;
+ script-src 'self' 'unsafe-inline' https://www.googletagmanager.com;
```

**On the version choice.** I checked what the 8 migrated pages actually call before moving them: `Plotly.newPlot` and `Plotly.react`, nothing else. Both are core API on every 2.x, so the 2.27→2.32 bump and the 2.35→2.32 downgrade are behaviour-neutral. Consolidating onto 2.32.0 rather than the newest also keeps the existing license artifact and digest valid, and avoids a Plotly upgrade landing in a PR about asset delivery — that belongs behind [#101](https://github.com/vamseeachanta/aceengineer-website/issues/101) (visual-regression tooling), which does not exist yet.

## 3 — The integrity sidecar nobody read

`assets/js/plotly-2.32.0.min.js.sha256` had been committed for months with **nothing in the repo verifying it**. That was tolerable while the CDN was a fallback. It is not now: this copy is the only Plotly the CSP permits, so a corrupted or swapped file breaks every chart on 18 pages with nowhere to fall back to.

`build.js` now verifies every `.sha256` sidecar under `assets/` and throws on mismatch, a missing target, or a malformed digest. Running it turned up **three more unverified blobs** — `capability-summary-v1.pdf` and both Inter `woff2` fonts. All four match.

## Tests

New `vendored-assets` suite, **registered as a Jest project** so it actually runs (this repo's 20 projects use explicit `testMatch`; an unregistered test file silently never executes):

- no page loads a script from `cdn.plot.ly`
- every Plotly `<script src>` is the one vendored version
- exactly one Plotly build ships in `dist/assets/js`
- the vendored blob is still referenced by something — a 3.6 MB file nobody loads is dead weight
- the CSP has not been widened back
- every sidecar exists and matches
- `verifyVendoredAssets` provably throws on a corrupted blob, a bad digest and a missing target

Script matching is anchored on `<script src=>` rather than the word "plotly", so the blog posts that discuss Plotly in prose and in Python samples (`import plotly.express as px`) don't trip it.

## Verified

- `npm run build` — 109 pages, 4 vendored assets verified, exit 0
- `npm run validate:registry` — PASS
- `npm test -- --runInBand` — **392 passed, 21 suites** (was 384 / 20)
- `uv run python scripts/maintenance/verify_repo_structure.py` — OK
- `uv run pytest tests/python tests/docs` — **187 passed**

## Two things I left alone

- **`plotly-basic` would cut ~2.6 MB.** Every page here uses only scatter/bar traces, so the full 3.6 MB build is likely overkill. That is a real win and a real behaviour risk, and it wants visual-regression coverage first — [#101](https://github.com/vamseeachanta/aceengineer-website/issues/101).
- **The `.sha256` sidecar is copied into `dist/`.** Harmless (it is a digest of a public file) but not useful to serve. Not worth widening the copy filter in this PR.

Part of [#80](https://github.com/vamseeachanta/aceengineer-website/issues/80), under initiative [vamseeachanta/workspace-hub#3607](https://github.com/vamseeachanta/workspace-hub/issues/3607).
