### PR TITLE
fix(security): finish #16 XSS-hardening — innerHTML→DOM, NPV NaN guards, navbar timer constant, dead code

### DIFF
--- a/assets/js/navbar-toggle.js
+++ b/assets/js/navbar-toggle.js
@@ -2,6 +2,8 @@
 (function() {
     'use strict';
 
+    var COLLAPSE_TRANSITION_MS = 350; // matches .collapsing transition-duration: 0.35s
+
     document.addEventListener('DOMContentLoaded', function() {
         var toggleBtn = document.querySelector('[data-toggle="collapse"]');
         if (!toggleBtn) return;
@@ -26,7 +28,7 @@
                     target.classList.add('collapse');
                     target.style.height = '';
                     toggleBtn.setAttribute('aria-expanded', 'false');
-                }, 350);
+                }, COLLAPSE_TRANSITION_MS);
             } else {
                 // Expand: animate height from 0 to scrollHeight
                 target.classList.remove('collapse');
@@ -40,7 +42,7 @@
                     target.classList.add('collapse', 'in');
                     target.style.height = '';
                     toggleBtn.setAttribute('aria-expanded', 'true');
-                }, 350);
+                }, COLLAPSE_TRANSITION_MS);
             }
         });
     });

--- a/content/calculators/npv-field-development.html
+++ b/content/calculators/npv-field-development.html
@@ -434,6 +434,20 @@ rootPath: "../"
             const taxRate = parseFloat(document.getElementById('tax_rate').value) / 100;
             const royaltyRate = parseFloat(document.getElementById('royalty_rate').value) / 100;
 
+            const inputs = [
+                initialRate, declineRate, projectYears, oilPrice, priceEscalation,
+                capex, opex, opexEscalation, discountRate, taxRate, royaltyRate
+            ];
+            if (!inputs.every(Number.isFinite) || projectYears < 1) {
+                const resultContent = document.getElementById('result-content');
+                const errorMessage = document.createElement('p');
+                errorMessage.className = 'danger-text';
+                errorMessage.textContent = 'Please enter a valid number in every field.';
+                resultContent.replaceChildren(errorMessage);
+                document.getElementById('results-card').style.display = 'block';
+                return;
+            }
+
             // Calculate year-by-year cashflows
             const years = [];
             const production = [];
@@ -556,36 +570,63 @@ rootPath: "../"
             const npvStatus = npv >= 0 ? 'VIABLE' : 'NOT VIABLE';
             const npvStatusClass = npv >= 0 ? 'success-text' : 'danger-text';
 
-            let resultHTML = `
-                <div class="result-value ${npvClass}">$${formatMoney(npv)} M</div>
-                <div class="result-label">Net Present Value (NPV)</div>
-                <div class="result-detail">
-                    <p><strong>Project Status:</strong> <span class="${npvStatusClass}">${npvStatus}</span></p>
-            `;
+            const resultContent = document.getElementById('result-content');
+            const resultValue = document.createElement('div');
+            resultValue.className = 'result-value ' + npvClass;
+            resultValue.textContent = '$' + formatMoney(npv) + ' M';
+
+            const resultLabel = document.createElement('div');
+            resultLabel.className = 'result-label';
+            resultLabel.textContent = 'Net Present Value (NPV)';
+
+            const resultDetail = document.createElement('div');
+            resultDetail.className = 'result-detail';
+
+            function addResultLine(label, value, valueClass) {
+                const paragraph = document.createElement('p');
+                const strong = document.createElement('strong');
+                strong.textContent = label;
+                paragraph.appendChild(strong);
+                paragraph.appendChild(document.createTextNode(' '));
+
+                if (valueClass) {
+                    const span = document.createElement('span');
+                    span.className = valueClass;
+                    span.textContent = value;
+                    paragraph.appendChild(span);
+                } else {
+                    paragraph.appendChild(document.createTextNode(value));
+                }
+
+                resultDetail.appendChild(paragraph);
+            }
+
+            addResultLine('Project Status:', npvStatus, npvStatusClass);
 
             if (irr !== null) {
                 const irrClass = irr > discountRate * 100 ? 'success-text' : 'danger-text';
-                resultHTML += `
-                    <p><strong>Internal Rate of Return:</strong> <span class="${irrClass}">${irr.toFixed(2)}%</span></p>
-                    <p><small>Discount rate: ${(discountRate * 100).toFixed(1)}% | IRR ${irr > discountRate * 100 ? '>' : '<'} discount rate</small></p>
-                `;
+                addResultLine('Internal Rate of Return:', irr.toFixed(2) + '%', irrClass);
+
+                const discountParagraph = document.createElement('p');
+                const discountDetail = document.createElement('small');
+                discountDetail.textContent = 'Discount rate: ' + (discountRate * 100).toFixed(1) +
+                    '% | IRR ' + (irr > discountRate * 100 ? '>' : '<') + ' discount rate';
+                discountParagraph.appendChild(discountDetail);
+                resultDetail.appendChild(discountParagraph);
             } else {
-                resultHTML += `<p><strong>Internal Rate of Return:</strong> <span class="danger-text">Not calculable</span></p>`;
+                addResultLine('Internal Rate of Return:', 'Not calculable', 'danger-text');
             }
 
             if (payback !== null) {
                 const paybackClass = payback < 10 ? 'success-text' : (payback < 15 ? 'warning-text' : 'danger-text');
-                resultHTML += `<p><strong>Payback Period:</strong> <span class="${paybackClass}">${payback.toFixed(1)} years</span></p>`;
+                addResultLine('Payback Period:', payback.toFixed(1) + ' years', paybackClass);
             } else {
-                resultHTML += `<p><strong>Payback Period:</strong> <span class="danger-text">No payback within project life</span></p>`;
+                addResultLine('Payback Period:', 'No payback within project life', 'danger-text');
             }
 
-            resultHTML += `
-                    <p><strong>Profit-to-Investment Ratio:</strong> ${profitRatio.toFixed(2)}x</p>
-                </div>
-            `;
+            addResultLine('Profit-to-Investment Ratio:', profitRatio.toFixed(2) + 'x');
 
-            document.getElementById('result-content').innerHTML = resultHTML;
+            resultContent.replaceChildren(resultValue, resultLabel, resultDetail);
             document.getElementById('results-card').style.display = 'block';
         }
 

--- a/demos/hse-risk-dashboard.html
+++ b/demos/hse-risk-dashboard.html
@@ -660,36 +660,52 @@
             ? (rows.reduce(function (s, r) { return s + r.composite_score; }, 0) / rows.length).toFixed(1)
             : '—';
 
-        strip.innerHTML =
-            '<div class="stat-card"><div class="stat-val">' + rows.length + '</div><div class="stat-lbl">Activity Rows</div></div>' +
-            '<div class="stat-card"><div class="stat-val">' + totalInc.toLocaleString() + '</div><div class="stat-lbl">Total Incidents</div></div>' +
-            '<div class="stat-card"><div class="stat-val">' + avgScore + '</div><div class="stat-lbl">Avg Composite</div></div>' +
-            '<div class="stat-card"><div class="stat-val val-critical">' + counts.CRITICAL + '</div><div class="stat-lbl">Critical</div></div>' +
-            '<div class="stat-card"><div class="stat-val val-high">' + counts.HIGH + '</div><div class="stat-lbl">High</div></div>' +
-            '<div class="stat-card"><div class="stat-val val-medium">' + counts.MEDIUM + '</div><div class="stat-lbl">Medium</div></div>' +
-            '<div class="stat-card"><div class="stat-val val-low">' + counts.LOW + '</div><div class="stat-lbl">Low</div></div>';
+        var stats = [
+            [rows.length, 'Activity Rows', 'stat-val'],
+            [totalInc.toLocaleString(), 'Total Incidents', 'stat-val'],
+            [avgScore, 'Avg Composite', 'stat-val'],
+            [counts.CRITICAL, 'Critical', 'stat-val val-critical'],
+            [counts.HIGH, 'High', 'stat-val val-high'],
+            [counts.MEDIUM, 'Medium', 'stat-val val-medium'],
+            [counts.LOW, 'Low', 'stat-val val-low'],
+        ];
+
+        strip.replaceChildren();
+        stats.forEach(function (stat) {
+            var card = document.createElement('div');
+            var value = document.createElement('div');
+            var label = document.createElement('div');
+            card.className = 'stat-card';
+            value.className = stat[2];
+            value.textContent = stat[0];
+            label.className = 'stat-lbl';
+            label.textContent = stat[1];
+            card.appendChild(value);
+            card.appendChild(label);
+            strip.appendChild(card);
+        });
     }
 
     // -------------------------------------------------------------------
     // Ranked table
     // -------------------------------------------------------------------
-    function colorForScore(score) {
-        var cat = data.getRiskCategory(score).toLowerCase();
-        return CATEGORY_COLORS[data.getRiskCategory(score)];
-    }
-
-    function badgeHtml(score) {
-        var cat = data.getRiskCategory(score);
-        var lower = cat.toLowerCase();
-        return '<span class="risk-badge badge-' + lower + '">' + cat + '</span>';
-    }
-
-    function scoreBarHtml(score, color) {
+    function scoreBarEl(score, color) {
         var pct = ((score - 1) / 9 * 100).toFixed(1);
-        return '<div class="score-bar-wrap">' +
-            '<span style="min-width:30px;font-weight:600;">' + score.toFixed(1) + '</span>' +
-            '<div class="score-bar-bg"><div class="score-bar-fill" style="width:' + pct + '%;background:' + color + '"></div></div>' +
-            '</div>';
+        var wrap = document.createElement('div');
+        var scoreText = document.createElement('span');
+        var barBackground = document.createElement('div');
+        var barFill = document.createElement('div');
+
+        wrap.className = 'score-bar-wrap';
+        scoreText.setAttribute('style', 'min-width:30px;font-weight:600;');
+        scoreText.textContent = score.toFixed(1);
+        barBackground.className = 'score-bar-bg';
+        barFill.className = 'score-bar-fill';
+        barFill.setAttribute('style', 'width:' + pct + '%;background:' + color);
+        barBackground.appendChild(barFill);
+        wrap.appendChild(scoreText);
+        wrap.appendChild(barBackground);
+        return wrap;
     }
 
     function updateTable(rows) {
@@ -697,22 +713,52 @@
         if (!tbody) return;
 
         var sorted = rows.slice().sort(function (a, b) { return b.composite_score - a.composite_score; });
-        tbody.innerHTML = sorted.map(function (r, i) {
+        tbody.replaceChildren();
+        sorted.forEach(function (r, i) {
             var cat   = data.getRiskCategory(r.composite_score);
             var color = CATEGORY_COLORS[cat];
             var confCls = 'conf-' + r.confidence;
-            return '<tr>' +
-                '<td>' + (i + 1) + '</td>' +
-                '<td>' + r.activity_name + '</td>' +
-                '<td>' + (DEPTH_LABELS[r.water_depth_band] || r.water_depth_band) + '</td>' +
-                '<td>' + scoreBarHtml(r.composite_score, color) + '</td>' +
-                '<td style="color:' + color + ';font-weight:600;">' + r.acute_score.toFixed(1) + '</td>' +
-                '<td style="color:' + color + ';font-weight:600;">' + r.chronic_score.toFixed(1) + '</td>' +
-                '<td style="color:' + color + ';font-weight:600;">' + r.compliance_score.toFixed(1) + '</td>' +
-                '<td>' + r.incident_count.toLocaleString() + '</td>' +
-                '<td class="' + confCls + '">' + r.confidence.charAt(0).toUpperCase() + r.confidence.slice(1) + '</td>' +
-                '</tr>';
-        }).join('');
+            var tr = document.createElement('tr');
+            var values = [
+                i + 1,
+                r.activity_name,
+                DEPTH_LABELS[r.water_depth_band] || r.water_depth_band,
+            ];
+
+            values.forEach(function (value) {
+                var td = document.createElement('td');
+                td.textContent = value;
+                tr.appendChild(td);
+            });
+
+            var scoreCell = document.createElement('td');
+            scoreCell.appendChild(scoreBarEl(r.composite_score, color));
+            tr.appendChild(scoreCell);
+
+            [r.acute_score, r.chronic_score, r.compliance_score].forEach(function (score) {
+                var td = document.createElement('td');
+                td.setAttribute('style', 'color:' + color + ';font-weight:600;');
+                td.textContent = score.toFixed(1);
+                tr.appendChild(td);
+            });
+
+            var incidentCell = document.createElement('td');
+            incidentCell.textContent = r.incident_count.toLocaleString();
+            tr.appendChild(incidentCell);
+
+            var confidenceCell = document.createElement('td');
+            confidenceCell.className = confCls;
+            confidenceCell.textContent = r.confidence.charAt(0).toUpperCase() + r.confidence.slice(1);
+            tr.appendChild(confidenceCell);
+            tbody.appendChild(tr);
+        });
+    }
+
+    function showEmptyState(el, message) {
+        var paragraph = document.createElement('p');
+        paragraph.setAttribute('style', 'color:#999;padding:20px;');
+        paragraph.textContent = message;
+        el.replaceChildren(paragraph);
     }
 
     // -------------------------------------------------------------------
@@ -721,7 +767,7 @@
     function renderHeatmap(rows) {
         var el = document.getElementById('chart-heatmap');
         if (!el || !rows.length) {
-            if (el) el.innerHTML = '<p style="color:#999;padding:20px;">No data for selected filters.</p>';
+            if (el) showEmptyState(el, 'No data for selected filters.');
             return;
         }
 
@@ -761,7 +807,7 @@
     function renderBar(rows) {
         var el = document.getElementById('chart-bar');
         if (!el || !rows.length) {
-            if (el) el.innerHTML = '<p style="color:#999;padding:20px;">No data for selected filters.</p>';
+            if (el) showEmptyState(el, 'No data for selected filters.');
             return;
         }
 
@@ -795,7 +841,7 @@
         if (!el) return;
 
         if (!trendRows.length) {
-            el.innerHTML = '<p style="color:#999;padding:20px;">No data for selected period.</p>';
+            showEmptyState(el, 'No data for selected period.');
             return;
         }
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,21 @@
         "testMatch": ["<rootDir>/tests/js/npv-calculator.test.js"]
       },
       {
+        "displayName": "npv-render",
+        "testEnvironment": "jsdom",
+        "testMatch": ["<rootDir>/tests/js/npv-render.test.js"]
+      },
+      {
+        "displayName": "hse-render",
+        "testEnvironment": "jsdom",
+        "testMatch": ["<rootDir>/tests/js/hse-render.test.js"]
+      },
+      {
+        "displayName": "html-sinks",
+        "testEnvironment": "node",
+        "testMatch": ["<rootDir>/tests/js/html-sinks.test.js"]
+      },
+      {
         "displayName": "obs-calculator",
         "testEnvironment": "node",
         "testMatch": ["<rootDir>/tests/js/obs-calculator.test.js"]

--- a/tests/js/hse-render.test.js
+++ b/tests/js/hse-render.test.js
@@ -1,0 +1,234 @@
+/**
+ * Render tests for the HSE risk dashboard's INLINE controller script
+ * (issue #16 — innerHTML → DOM APIs).
+ *
+ * tests/js/hse-risk-dashboard.test.js covers the data module. This file drives
+ * the real controller IIFE in jsdom and asserts on the DOM it produces, so the
+ * innerHTML → createElement refactor is provably render-identical and cannot
+ * silently regress.
+ *
+ * @jest-environment jsdom
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PAGE = path.join(__dirname, '..', '..', 'demos', 'hse-risk-dashboard.html');
+
+const dataModule = require('../../demos/hse-risk-dashboard-data');
+
+function controllerScript() {
+  const html = fs.readFileSync(PAGE, 'utf8');
+  const blocks = [
+    ...html.matchAll(/<script\b(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi),
+  ].map((m) => m[1]);
+  const src = blocks.find((b) => b.includes('function updateTable'));
+  if (!src) {
+    throw new Error('inline dashboard controller not found in ' + PAGE);
+  }
+  return src;
+}
+
+function boot() {
+  document.body.innerHTML = [
+    '<select id="filter-category"><option value="all">All</option></select>',
+    '<select id="filter-depth"><option value="all">All</option></select>',
+    '<select id="filter-period"><option value="all">All</option></select>',
+    '<button id="btn-reset">Reset</button>',
+    '<div class="stats-strip" id="stats-strip"></div>',
+    '<table><tbody id="risk-table-body"></tbody></table>',
+    '<div id="chart-heatmap"></div>',
+    '<div id="chart-bar"></div>',
+    '<div id="chart-trend"></div>',
+  ].join('');
+
+  window.HseRiskDashboardData = dataModule;
+  window.Plotly = { react: jest.fn() };
+
+  window.eval(controllerScript());
+}
+
+describe('HSE dashboard controller — no HTML sink', () => {
+  test('the inline controller contains no innerHTML assignment', () => {
+    expect(controllerScript()).not.toMatch(/innerHTML/);
+  });
+
+  test('the unused lower-cased category assignment in colorForScore is gone', () => {
+    expect(controllerScript()).not.toMatch(
+      /var cat = data\.getRiskCategory\(score\)\.toLowerCase\(\);/
+    );
+  });
+
+  // colorForScore and badgeHtml are declared but never called anywhere in the
+  // page (verified by grep on origin/main). The review's "unused var cat" is a
+  // symptom of a wholly dead function, so the whole dead pair goes.
+  test.each(['colorForScore', 'badgeHtml'])(
+    'the dead helper %s is removed, not merely tidied',
+    (name) => {
+      expect(controllerScript()).not.toMatch(new RegExp('function\\s+' + name));
+    }
+  );
+
+  test('the one live helper still builds the score bar', () => {
+    expect(controllerScript()).toMatch(/scoreBar/);
+  });
+});
+
+describe('HSE dashboard controller — stats strip', () => {
+  beforeEach(boot);
+
+  test('renders exactly seven stat cards', () => {
+    expect(document.querySelectorAll('#stats-strip .stat-card')).toHaveLength(7);
+  });
+
+  test('the first card reports the filtered row count', () => {
+    const rows = dataModule.filterByWaterDepth(
+      dataModule.filterByCategory(dataModule.RISK_DATA, 'all'),
+      'all'
+    );
+    const first = document.querySelector('#stats-strip .stat-card .stat-val');
+    expect(first.textContent).toBe(String(rows.length));
+  });
+
+  test('the stat labels are unchanged and in order', () => {
+    const labels = [...document.querySelectorAll('#stats-strip .stat-lbl')].map(
+      (el) => el.textContent
+    );
+    expect(labels).toEqual([
+      'Activity Rows',
+      'Total Incidents',
+      'Avg Composite',
+      'Critical',
+      'High',
+      'Medium',
+      'Low',
+    ]);
+  });
+
+  test('the severity cards keep their value classes', () => {
+    const classes = [...document.querySelectorAll('#stats-strip .stat-val')].map(
+      (el) => el.className
+    );
+    expect(classes).toEqual([
+      'stat-val',
+      'stat-val',
+      'stat-val',
+      'stat-val val-critical',
+      'stat-val val-high',
+      'stat-val val-medium',
+      'stat-val val-low',
+    ]);
+  });
+
+  test('re-rendering replaces the strip rather than appending to it', () => {
+    document.getElementById('btn-reset').dispatchEvent(new Event('click'));
+    expect(document.querySelectorAll('#stats-strip .stat-card')).toHaveLength(7);
+  });
+});
+
+describe('HSE dashboard controller — ranked table', () => {
+  beforeEach(boot);
+
+  test('renders one row per filtered activity', () => {
+    const rows = dataModule.filterByWaterDepth(
+      dataModule.filterByCategory(dataModule.RISK_DATA, 'all'),
+      'all'
+    );
+    expect(document.querySelectorAll('#risk-table-body tr')).toHaveLength(
+      rows.length
+    );
+  });
+
+  test('each row has nine cells', () => {
+    const first = document.querySelector('#risk-table-body tr');
+    expect(first.querySelectorAll('td')).toHaveLength(9);
+  });
+
+  test('rows are ordered by descending composite score', () => {
+    const bars = [...document.querySelectorAll('#risk-table-body .score-bar-wrap span')].map(
+      (el) => parseFloat(el.textContent)
+    );
+    const sorted = [...bars].sort((a, b) => b - a);
+    expect(bars).toEqual(sorted);
+  });
+
+  test('the top row carries the highest-scoring activity name as text', () => {
+    const rows = dataModule.filterByWaterDepth(
+      dataModule.filterByCategory(dataModule.RISK_DATA, 'all'),
+      'all'
+    );
+    const top = rows
+      .slice()
+      .sort((a, b) => b.composite_score - a.composite_score)[0];
+    const firstRowCells = document.querySelectorAll('#risk-table-body tr td');
+    expect(firstRowCells[0].textContent).toBe('1');
+    expect(firstRowCells[1].textContent).toBe(top.activity_name);
+  });
+
+  test('the ranked table carries no risk badges (it never did)', () => {
+    // Frozen behaviour: badgeHtml was dead code. The badge legend lives in
+    // static page markup, not in the generated rows.
+    expect(document.querySelectorAll('#risk-table-body .risk-badge')).toHaveLength(0);
+  });
+
+  test('every row renders a score bar with a percentage width and colour', () => {
+    const fills = [...document.querySelectorAll('#risk-table-body .score-bar-fill')];
+    expect(fills.length).toBe(
+      document.querySelectorAll('#risk-table-body tr').length
+    );
+    fills.forEach((f) => {
+      expect(f.style.width).toMatch(/^\d+(\.\d+)?%$/);
+      expect(f.style.background).not.toBe('');
+    });
+  });
+
+  test('confidence cells keep their conf- class and Capitalised label', () => {
+    const cells = [...document.querySelectorAll('#risk-table-body tr')].map(
+      (tr) => tr.querySelectorAll('td')[8]
+    );
+    cells.forEach((td) => {
+      expect(td.className).toMatch(/^conf-\w+$/);
+      expect(td.textContent).toMatch(/^[A-Z][a-z]+$/);
+    });
+  });
+
+  test('activity names are rendered as text, so markup in data cannot become nodes', () => {
+    const nameCells = [...document.querySelectorAll('#risk-table-body tr')].map(
+      (tr) => tr.querySelectorAll('td')[1]
+    );
+    nameCells.forEach((td) => {
+      expect(td.children).toHaveLength(0);
+    });
+  });
+
+  test('re-rendering replaces the table body rather than appending to it', () => {
+    const before = document.querySelectorAll('#risk-table-body tr').length;
+    document.getElementById('btn-reset').dispatchEvent(new Event('click'));
+    expect(document.querySelectorAll('#risk-table-body tr')).toHaveLength(before);
+  });
+});
+
+describe('HSE dashboard controller — empty states', () => {
+  test('an empty filter result renders the placeholder as text', () => {
+    boot();
+    const select = document.getElementById('filter-category');
+    select.innerHTML = '<option value="__none__">None</option>';
+    select.value = '__none__';
+    select.dispatchEvent(new Event('change'));
+
+    const heatmap = document.getElementById('chart-heatmap');
+    expect(heatmap.textContent).toMatch(/No data for selected filters\./);
+    expect(document.getElementById('chart-bar').textContent).toMatch(
+      /No data for selected filters\./
+    );
+  });
+
+  test('the empty-state placeholder replaces prior content', () => {
+    boot();
+    const select = document.getElementById('filter-category');
+    select.innerHTML = '<option value="__none__">None</option>';
+    select.value = '__none__';
+    select.dispatchEvent(new Event('change'));
+    expect(document.querySelectorAll('#chart-heatmap p')).toHaveLength(1);
+  });
+});

--- a/tests/js/html-sinks.test.js
+++ b/tests/js/html-sinks.test.js
@@ -1,0 +1,94 @@
+/**
+ * Source-level regression guards for issue #16 (and epic #107's
+ * "a test asserts this so it cannot regress" requirement).
+ *
+ * These are deliberately static assertions over the shipped source. The
+ * behavioural coverage lives in npv-render.test.js and hse-render.test.js;
+ * this file is the ratchet that stops the sinks coming back.
+ *
+ * Scope note: #16 covers the two pages the 2026-05-23 review named. The wider
+ * innerHTML sweep across content/** is epic #107's remaining work, so
+ * HARDENED_FILES is an explicit opt-in list rather than a whole-tree scan.
+ *
+ * @jest-environment node
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+
+const HARDENED_FILES = [
+  path.join('content', 'calculators', 'npv-field-development.html'),
+  path.join('demos', 'hse-risk-dashboard.html'),
+];
+
+function read(rel) {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+describe('hardened pages carry no innerHTML sink', () => {
+  test.each(HARDENED_FILES)('%s assigns no innerHTML', (rel) => {
+    const lines = read(rel).split('\n');
+    const offenders = lines
+      .map((line, i) => ({ line, n: i + 1 }))
+      .filter(({ line }) => /\binnerHTML\s*=/.test(line))
+      .map(({ line, n }) => `${rel}:${n}: ${line.trim()}`);
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('navbar collapse timing is a named constant', () => {
+  const rel = path.join('assets', 'js', 'navbar-toggle.js');
+
+  test('no bare 350 ms timeout literal remains', () => {
+    const src = read(rel);
+    expect(src).not.toMatch(/setTimeout\([\s\S]*?,\s*350\s*\)/);
+    expect(src).not.toMatch(/\}\s*,\s*350\s*\)/);
+  });
+
+  test('a single named constant carries the value and cites the CSS source', () => {
+    const src = read(rel);
+    const decl = src.match(
+      /var\s+COLLAPSE_TRANSITION_MS\s*=\s*(\d+)\s*;([^\n]*)/
+    );
+    expect(decl).not.toBeNull();
+    expect(Number(decl[1])).toBe(350);
+    // The constant must explain itself — it is coupled to the stylesheet.
+    expect(decl[2]).toMatch(/0\.35s|collapsing/i);
+  });
+
+  test('both timeouts use the constant', () => {
+    const src = read(rel);
+    const uses = src.match(/COLLAPSE_TRANSITION_MS/g) || [];
+    // one declaration + two call sites
+    expect(uses).toHaveLength(3);
+  });
+});
+
+describe('external links in the served tree cannot leak window.opener', () => {
+  function htmlFilesUnder(dir) {
+    const out = [];
+    (function walk(d) {
+      for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+        const full = path.join(d, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.name.endsWith('.html')) out.push(full);
+      }
+    })(dir);
+    return out;
+  }
+
+  test('every target="_blank" under content/ carries rel="noopener"', () => {
+    const offenders = [];
+    for (const file of htmlFilesUnder(path.join(ROOT, 'content'))) {
+      const lines = fs.readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        if (!line.includes('target="_blank"')) return;
+        if (/rel="[^"]*noopener/.test(line)) return;
+        offenders.push(`${path.relative(ROOT, file)}:${i + 1}: ${line.trim()}`);
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/js/npv-render.test.js
+++ b/tests/js/npv-render.test.js
@@ -1,0 +1,226 @@
+/**
+ * Hardening + frozen-behaviour tests for the NPV field-development
+ * calculator's INLINE page script (issue #16).
+ *
+ * Why a separate file: the page carries its own copy of calculateNPV /
+ * displayResults / formatMoney and does NOT import
+ * assets/js/npv-calculator-engine.js. tests/js/npv-calculator.test.js covers
+ * the module; the inline page logic that actually ships was uncovered.
+ *
+ * These tests verify:
+ *   - every parsed input is guarded, so no NaN can reach the DOM
+ *   - results are built with DOM APIs / textContent, never innerHTML
+ *   - the valid-input render is structurally unchanged (frozen behaviour)
+ *
+ * @jest-environment jsdom
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PAGE = path.join(
+  __dirname,
+  '..',
+  '..',
+  'content',
+  'calculators',
+  'npv-field-development.html'
+);
+
+// Default values mirror the `value="…"` attributes on the live inputs.
+const FIELDS = {
+  initial_rate: '5000',
+  decline_rate: '15',
+  project_years: '20',
+  oil_price: '70',
+  price_escalation: '2',
+  capex: '500',
+  opex: '50',
+  opex_escalation: '3',
+  discount_rate: '10',
+  tax_rate: '21',
+  royalty_rate: '18.75',
+};
+
+function calculatorScript() {
+  const html = fs.readFileSync(PAGE, 'utf8');
+  const blocks = [
+    ...html.matchAll(/<script\b(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi),
+  ].map((m) => m[1]);
+  const src = blocks.find((b) => b.includes('function calculateNPV'));
+  if (!src) {
+    throw new Error('inline calculator script not found in ' + PAGE);
+  }
+  return src;
+}
+
+function boot(overrides) {
+  const values = Object.assign({}, FIELDS, overrides || {});
+  document.body.innerHTML =
+    Object.keys(values)
+      .map((id) => '<input type="number" id="' + id + '" value="' + values[id] + '">')
+      .join('') +
+    '<div id="results-card" style="display: none;"><div id="result-content"></div></div>' +
+    '<div id="cashflow-chart"></div>';
+
+  window.gtag = function () {};
+  window.Plotly = { newPlot: function () {} };
+
+  // Indirect eval → the script's function declarations land on `window`.
+  window.eval(calculatorScript());
+  window.calculateNPV();
+
+  return document.getElementById('result-content');
+}
+
+describe('NPV inline calculator — input guards', () => {
+  test('a blank required field renders a validation message, not NaN', () => {
+    const out = boot({ capex: '' });
+    expect(out.textContent).not.toMatch(/NaN/);
+    expect(out.textContent).toMatch(/valid number/i);
+  });
+
+  test.each(Object.keys(FIELDS))(
+    'blanking %s produces no NaN in the results container',
+    (field) => {
+      const out = boot({ [field]: '' });
+      expect(out.textContent).not.toMatch(/NaN/);
+    }
+  );
+
+  test.each(Object.keys(FIELDS))(
+    'non-numeric %s produces no NaN in the results container',
+    (field) => {
+      const out = boot({ [field]: 'abc' });
+      expect(out.textContent).not.toMatch(/NaN/);
+    }
+  );
+
+  test('a zero project life is rejected rather than producing an empty run', () => {
+    const out = boot({ project_years: '0' });
+    expect(out.textContent).not.toMatch(/NaN/);
+    expect(out.textContent).toMatch(/valid number/i);
+  });
+
+  test('invalid input still reveals the results card so the user sees the message', () => {
+    boot({ capex: '' });
+    expect(document.getElementById('results-card').style.display).toBe('block');
+  });
+
+  test('invalid input does not draw the chart', () => {
+    const spy = jest.fn();
+    const values = Object.assign({}, FIELDS, { capex: '' });
+    document.body.innerHTML =
+      Object.keys(values)
+        .map((id) => '<input type="number" id="' + id + '" value="' + values[id] + '">')
+        .join('') +
+      '<div id="results-card" style="display: none;"><div id="result-content"></div></div>' +
+      '<div id="cashflow-chart"></div>';
+    window.gtag = function () {};
+    window.Plotly = { newPlot: spy };
+    window.eval(calculatorScript());
+    window.calculateNPV();
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('NPV inline calculator — DOM construction (no HTML sink)', () => {
+  test('the inline script contains no innerHTML assignment', () => {
+    expect(calculatorScript()).not.toMatch(/innerHTML/);
+  });
+
+  test('results are built as element nodes, not parsed markup', () => {
+    const out = boot();
+    // Every child is a real element created by the page, and the container
+    // was cleared before the render (single result-value node).
+    expect(out.querySelectorAll('.result-value')).toHaveLength(1);
+    expect(out.children.length).toBeGreaterThan(0);
+  });
+
+  test('re-running the calculation replaces rather than appends results', () => {
+    const out = boot();
+    window.calculateNPV();
+    expect(out.querySelectorAll('.result-value')).toHaveLength(1);
+    expect(out.querySelectorAll('.result-label')).toHaveLength(1);
+  });
+});
+
+describe('NPV inline calculator — frozen valid-input behaviour', () => {
+  test('renders the NPV headline with the money format and unit', () => {
+    const out = boot();
+    const headline = out.querySelector('.result-value');
+    expect(headline).not.toBeNull();
+    expect(headline.textContent).toMatch(/^\$-?[\d.]+B? M$/);
+  });
+
+  test('the NPV label text is unchanged', () => {
+    const out = boot();
+    expect(out.querySelector('.result-label').textContent).toBe(
+      'Net Present Value (NPV)'
+    );
+  });
+
+  test('a profitable case is classed positive and reported VIABLE', () => {
+    const out = boot();
+    const headline = out.querySelector('.result-value');
+    expect(headline.classList.contains('positive')).toBe(true);
+    expect(out.textContent).toMatch(/VIABLE/);
+    expect(out.querySelector('.success-text')).not.toBeNull();
+  });
+
+  // CHARACTERISATION, NOT ENDORSEMENT.
+  //
+  // The shipped inline maths mixes units: annual revenue is computed in
+  // DOLLARS (rate * price * 365) while capex/opex are entered in $M, so the
+  // headline is ~6 orders of magnitude too large and the IRR bisection never
+  // converges (hence "Not calculable" on every run). That is a correctness
+  // defect in its own right and is explicitly OUT OF SCOPE for #16, which is a
+  // security/hardening issue.
+  //
+  // These tests pin the CURRENT numbers precisely so the innerHTML -> DOM
+  // refactor is provably behaviour-preserving. When the units defect is fixed
+  // under its own issue, these expectations must be updated deliberately.
+  test('the default-input headline value is unchanged by the refactor', () => {
+    const out = boot();
+    expect(out.querySelector('.result-value').textContent).toBe('$348915.5B M');
+  });
+
+  test('the default-input profit ratio is unchanged by the refactor', () => {
+    const out = boot();
+    expect(out.textContent).toMatch(/Profit-to-Investment Ratio: 1162054\.01x/);
+  });
+
+  test('IRR and payback lines are both present', () => {
+    const out = boot();
+    expect(out.textContent).toMatch(/Internal Rate of Return:/);
+    expect(out.textContent).toMatch(/Payback Period: 1\.0 years/);
+  });
+
+  test('the non-converging IRR is reported as Not calculable, in the danger style', () => {
+    const out = boot();
+    expect(out.textContent).toMatch(/Not calculable/);
+    const danger = [...out.querySelectorAll('.danger-text')].map((el) => el.textContent);
+    expect(danger).toContain('Not calculable');
+  });
+
+  test('the results card is revealed on a successful calculation', () => {
+    boot();
+    expect(document.getElementById('results-card').style.display).toBe('block');
+  });
+
+  test('the chart is drawn for valid input', () => {
+    const spy = jest.fn();
+    const values = Object.assign({}, FIELDS);
+    document.body.innerHTML =
+      Object.keys(values)
+        .map((id) => '<input type="number" id="' + id + '" value="' + values[id] + '">')
+        .join('') +
+      '<div id="results-card" style="display: none;"><div id="result-content"></div></div>' +
+      '<div id="cashflow-chart"></div>';
+    window.gtag = function () {};
+    window.Plotly = { newPlot: spy };
+    window.eval(calculatorScript());
+    window.calculateNPV();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #16.

Finishes the leftover **Medium/Low** remediation from the 2026-05-23 review. The **High** items (CSP header, form honeypots, Plotly pinning) and most Medium items already shipped — see the mapping table below; they were re-verified against `origin/main` @ `c1e41c9`, not re-implemented.

## Honest framing — defence-in-depth, not a live exploit

Neither `innerHTML` site was an injection vector today:

- In `npv-field-development.html`, every interpolated value was a computed **number** (`.toFixed()` / `formatMoney()`) or a fixed CSS class literal. No string reached the markup.
- In `hse-risk-dashboard.html`, the interpolated strings (`activity_name`, `confidence`) come from a **static committed data file**, not user input.

So this is code quality plus CSP-friendliness — it removes reliance on `'unsafe-inline'`-guarded HTML sinks. The review's own wording was "fragile XSS posture *without CSP backup*", and the CSP backup now exists. This is also a strict prerequisite for epic #107's "no HTML sinks behind the CSP" clause; this PR deliberately does **not** touch `vercel.json`, so #107's CSP-tightening half stays unclaimed.

## What changed

**`content/calculators/npv-field-development.html`** (served)
- All 11 parsed inputs (10 `parseFloat` + 1 `parseInt`) are now validated with `Number.isFinite`, plus `projectYears >= 1`. Invalid input renders an inline message, reveals the results card, and returns **before** any arithmetic — so no chart is drawn and no `calculator_use` analytics event fires. Previously a single blank field produced `$NaN M`.
- `displayResults()` builds output with `createElement` / `textContent` / `classList` and `replaceChildren()`. No `innerHTML`.

**`demos/hse-risk-dashboard.html`** (root-only; see deploy note)
- Stat strip, ranked table and all three empty-state placeholders rebuilt with DOM APIs.
- `scoreBarHtml()` now returns a DOM element rather than an HTML string.
- Deleted two **dead** functions: `colorForScore()` and `badgeHtml()`. Both were declared and never called anywhere in the page. The review's "unused `var cat`" lived inside `colorForScore` — removing only the variable would have left two dead functions behind. The `var cat` in `updateTable()` **is** used and is retained.

**`assets/js/navbar-toggle.js`** (served)
- Two `350` literals replaced by `COLLAPSE_TRANSITION_MS`, commented as matching `.collapsing transition-duration: 0.35s`. Value unchanged, so `tests/js/navbar-toggle.test.js` passes untouched.

## Tests — written first, RED before GREEN

Three new jest projects (`npv-render`, `hse-render`, `html-sinks`), 65 tests, committed RED at `86d894c` before any implementation.

- **`npv-render`** (38) — drives the real inline calculator in jsdom. Every one of the 11 inputs is asserted blank-and-non-numeric to produce no `NaN`; chart suppression on the invalid path; exact valid-input render.
- **`hse-render`** (21) — drives the real controller IIFE in jsdom. Asserts stat-card count, label order, `stat-val` class list, 9-cell rows, descending sort, score-bar width/colour, `conf-` classes, and that activity-name cells contain **no child elements** (so markup in data can never become nodes).
- **`html-sinks`** (6) — static ratchet: no `innerHTML` assignment on either hardened page, the navbar constant contract, and every `target="_blank"` under `content/**` carries `rel="noopener"`. This is the regression guard epic #107 asks for.

## Frozen behaviour, and a defect found but NOT fixed here

`npv-render` pins the current output exactly — `$348915.5B M` and `Profit-to-Investment Ratio: 1162054.01x` for default inputs.

Those numbers are **wrong**, and deliberately left wrong. The inline maths mixes units: annual revenue is computed in **dollars** (`rate × price × 365`) while CAPEX/OPEX are entered in **$M**, so the headline is ~6 orders of magnitude too large, and the IRR bisection never converges against values of that magnitude — the page reports "Not calculable" on **every** run. That is a correctness defect with a live user-visible impact, it is **out of scope for a security issue**, and fixing it inside this PR would have made the refactor unverifiable. Pinning it proves this change is structurally pure. Filed separately.

## Review findings → disposition

| Finding | Severity | State |
|---|---|---|
| CSP header absent | High | Already shipped in `vercel.json` (verified) |
| Web3Forms abuse channel | High | Already shipped — `botcheck` honeypot on both forms (verified) |
| Plotly unpinned / no SRI / dead 3.5 MB bundle | High | Already resolved, and better than the plan assumed: the served tree self-hosts a **single** `plotly-2.32.0.min.js` with a `.sha256` sidecar and no longer references `cdn.plot.ly` at all |
| `innerHTML` string-concat | Medium | **Fixed here** |
| `parseFrontMatter` CRLF | Medium | Already shipped (verified) |
| Google Fonts direct pulls | Medium | Already shipped — `content/**` self-hosts (verified) |
| `parseFloat` NaN guards | Low | **Fixed here** |
| `target="_blank"` without `rel` | Low | `content/**` was already 100% clean — now **pinned by a test**. The ~60 remaining are all in the un-deployed legacy root tree; out of scope |
| Hardcoded 350 ms navbar timer | Low | **Fixed here** |
| Unused `var cat` | Low | **Fixed here**, by deleting the two dead functions it lived in |

## Deploy-model note

`demos/hse-risk-dashboard.html` sits **outside** the `content/` build tree, so Vercel does not serve it. It is edited in place because it is the single source of truth for that page and the target of `tests/js/hse-risk-dashboard.test.js`. Migrating it into `content/demos/` or retiring it is a separate decision, not this PR's.

## Verification

- `npx jest` → **471 passed / 471 total, 25 suites**. Baseline before this branch was 406/406 across 22 suites. Node-ID level diff: **0 removed, 0 status-changed, 65 added (all passing)** — no existing assertion was weakened, skipped or edited.
- `npm run build` → completes; built `dist/calculators/npv-field-development.html` contains zero `innerHTML` and carries the guard.
- `npm run lint:copy` → PASS.
- `git grep innerHTML` over both hardened files → nothing.
- No new inline `<script>`, no new external host, no `eval` — net CSP effect neutral-to-positive.

**Pre-existing flake, not introduced here:** on a *cold* tree with no `dist/`, 8 tests fail and 28 never run, because several suites assert on build output without an ordered build. Run `npm run build` first, or run jest twice. Worth its own issue.
