### PR TITLE
fix(npv): $M unit coherence, honest IRR reporting, and cited defaults (#124)

### DIFF
--- a/assets/js/npv-calculator-engine.js
+++ b/assets/js/npv-calculator-engine.js
@@ -35,8 +35,8 @@ const IRR_BRACKET_HIGH = 2.0;
  *
  * The page renders IRR as toFixed(2) on a percentage, so 0.01 percentage
  * points -- 1e-4 as a rate fraction -- is everything it can display. This
- * bound is 1e-6, two orders finer than that, and is reached in 22 bisections
- * of a 2.5-wide bracket, comfortably inside the iteration budget.
+ * bound is 1e-6, two orders finer than that. Roots arrive already bracketed to
+ * IRR_SCAN_STEP, so about 7 bisections reach it, well inside the budget.
  *
  * It is stated in RATE units and therefore carries no cashflow magnitude,
  * which is the whole point: a bound on |NPV| is scale-dependent, too loose on
@@ -143,11 +143,15 @@ function calcIRR(capex, cashflows) {
  * of the bracket while being positive in between. An endpoint test calls that
  * "no root" even when two exist.
  *
- * Where several roots exist the IRR is genuinely ambiguous. The rate reported
- * is the one above which NPV stays negative -- the downward crossing, which is
- * what a decision-maker compares against a cost of capital. For a conventional
+ * Only a DOWNWARD crossing -- NPV positive below the rate, negative above it --
+ * is an IRR you can compare against a cost of capital. A cashflow can have a
+ * root that goes the other way, and reporting one as "the IRR" puts a green
+ * "IRR > discount rate" next to a NOT VIABLE headline. Where no downward
+ * crossing exists the status is 'no-decision-rate' and irr is null, with the
+ * roots still returned so the shape stays inspectable. For a conventional
  * cashflow there is exactly one crossing and this reduces to the usual IRR.
- * All roots found are returned so the ambiguity stays inspectable.
+ *
+ * Statuses: 'ok', 'no-root', 'no-decision-rate', 'not-converged', 'invalid'.
  *
  * @param {number}   capex      Initial CAPEX (positive, same unit as cashflows)
  * @param {number[]} cashflows  Annual net cashflows
@@ -168,46 +172,75 @@ function calcIRRResult(capex, cashflows, options) {
   const npvAtLow = calcNPV(capex, cashflows, IRR_BRACKET_LOW);
   const npvAtHigh = calcNPV(capex, cashflows, IRR_BRACKET_HIGH);
 
-  const refuse = (status) => ({
+  const result = (status, irr, roots) => ({
     status: status,
-    irr: null,
-    roots: [],
-    multipleRoots: false,
+    irr: irr,
+    roots: roots || [],
+    multipleRoots: (roots || []).length > 1,
     npvAtLow: npvAtLow,
     npvAtHigh: npvAtHigh,
   });
 
-  // Locate every sub-interval in which NPV changes sign.
-  const brackets = [];
+  // Non-finite input cannot be reasoned about: Math.sign(NaN) !== Math.sign(NaN)
+  // is true, so every scan step would look like a sign change and the bisection
+  // would return a confident number for nonsense.
+  const finite = (x) => typeof x === 'number' && isFinite(x);
+  if (!finite(capex) || !Array.isArray(cashflows) || !cashflows.every(finite)) {
+    return result('invalid', null, []);
+  }
+  if (!finite(npvAtLow) || !finite(npvAtHigh)) {
+    return result('invalid', null, []);
+  }
+
+  // Scan the bracket for sign changes. Testing only the two ENDS is unsound
+  // here: production declines while OPEX escalates, so late-year cashflows turn
+  // negative, the cashflow changes sign more than once, and NPV can be negative
+  // at both ends while positive in between.
+  const crossings = [];
+  const steps = Math.ceil((IRR_BRACKET_HIGH - IRR_BRACKET_LOW) / IRR_SCAN_STEP);
   let prevRate = IRR_BRACKET_LOW;
   let prevNpv = npvAtLow;
-  const steps = Math.ceil((IRR_BRACKET_HIGH - IRR_BRACKET_LOW) / IRR_SCAN_STEP);
+  let anyNonZero = npvAtLow !== 0;
+
+  // A root sitting exactly on the low endpoint would otherwise be stepped over.
+  if (npvAtLow === 0) {
+    crossings.push({ low: IRR_BRACKET_LOW, high: IRR_BRACKET_LOW, loSign: 0 });
+  }
 
   for (let i = 1; i <= steps; i++) {
-    const rate = Math.min(
-      IRR_BRACKET_LOW + i * IRR_SCAN_STEP,
-      IRR_BRACKET_HIGH
-    );
+    const rate = Math.min(IRR_BRACKET_LOW + i * IRR_SCAN_STEP, IRR_BRACKET_HIGH);
     const npv = calcNPV(capex, cashflows, rate);
+    if (!finite(npv)) {
+      return result('invalid', null, []);
+    }
+    if (npv !== 0) {
+      anyNonZero = true;
+    }
     if (npv === 0) {
-      brackets.push([rate, rate]);
+      if (prevNpv !== 0) {
+        crossings.push({ low: rate, high: rate, loSign: Math.sign(prevNpv) });
+      }
     } else if (prevNpv !== 0 && Math.sign(npv) !== Math.sign(prevNpv)) {
-      brackets.push([prevRate, rate]);
+      crossings.push({ low: prevRate, high: rate, loSign: Math.sign(prevNpv) });
     }
     prevRate = rate;
     prevNpv = npv;
   }
 
-  if (brackets.length === 0) {
-    return refuse('no-root');
+  // NPV identically zero across the whole bracket: every rate solves it, which
+  // is a degenerate cashflow, not an IRR.
+  if (!anyNonZero || crossings.length === 0) {
+    return result('no-root', null, []);
   }
 
-  // Bisect each bracketed root down to the rate tolerance.
+  // Bisect each bracketed root. The direction is known from the bracket's own
+  // endpoint sign, so no probe offset outside the bracket is needed.
   const roots = [];
-  for (let b = 0; b < brackets.length; b++) {
-    let low = brackets[b][0];
-    let high = brackets[b][1];
-    const npvLowSign = Math.sign(calcNPV(capex, cashflows, low));
+  const downward = [];
+  for (let c = 0; c < crossings.length; c++) {
+    let low = crossings[c].low;
+    let high = crossings[c].high;
+    const loSign = crossings[c].loSign;
     let converged = high - low <= rateTolerance;
 
     for (let i = 0; i < maxIterations && !converged; i++) {
@@ -216,7 +249,7 @@ function calcIRRResult(capex, cashflows, options) {
       if (npvMid === 0) {
         low = mid;
         high = mid;
-      } else if (Math.sign(npvMid) === npvLowSign) {
+      } else if (Math.sign(npvMid) === loSign) {
         low = mid;
       } else {
         high = mid;
@@ -225,33 +258,30 @@ function calcIRRResult(capex, cashflows, options) {
     }
 
     if (!converged) {
-      return refuse('not-converged');
+      return result('not-converged', null, []);
     }
-    roots.push((low + high) / 2);
+
+    const root = (low + high) / 2;
+    // Skip a duplicate of the previous root (adjacent degenerate zeros).
+    if (roots.length && Math.abs(root - roots[roots.length - 1]) <= rateTolerance) {
+      continue;
+    }
+    roots.push(root);
+    // Positive below, negative above: the only orientation you can compare to
+    // a cost of capital.
+    if (loSign > 0) {
+      downward.push(root);
+    }
   }
 
-  // The downward crossing: NPV positive below it, negative above.
-  let reported = null;
-  for (let i = roots.length - 1; i >= 0; i--) {
-    const below = calcNPV(capex, cashflows, roots[i] - rateTolerance * 10);
-    const above = calcNPV(capex, cashflows, roots[i] + rateTolerance * 10);
-    if (below > 0 && above < 0) {
-      reported = roots[i];
-      break;
-    }
-  }
-  if (reported === null) {
-    reported = roots[roots.length - 1];
+  if (downward.length === 0) {
+    // Roots exist, but NPV never falls through zero. There is no rate here
+    // that behaves like an IRR, and reporting one would print a green
+    // "IRR > discount rate" beside a NOT VIABLE headline.
+    return result('no-decision-rate', null, roots);
   }
 
-  return {
-    status: 'ok',
-    irr: reported * 100,
-    roots: roots,
-    multipleRoots: roots.length > 1,
-    npvAtLow: npvAtLow,
-    npvAtHigh: npvAtHigh,
-  };
+  return result('ok', downward[downward.length - 1] * 100, roots);
 }
 
 /**

--- a/assets/js/npv-calculator-engine.js
+++ b/assets/js/npv-calculator-engine.js
@@ -13,6 +13,40 @@
 'use strict';
 
 /**
+ * Dollars per million dollars. This is the definition of the unit, not a
+ * tuned constant. The engine computes in DOLLARS; the calculator page's form
+ * is denominated in $M, so exactly one conversion sits between them.
+ */
+const DOLLARS_PER_MILLION = 1e6;
+
+/** IRR search bracket: -50% to +200%. */
+const IRR_BRACKET_LOW = -0.5;
+const IRR_BRACKET_HIGH = 2.0;
+
+/**
+ * Convergence bound, expressed as the WIDTH OF THE RATE BRACKET.
+ *
+ * The page renders IRR as toFixed(2) on a percentage, so 0.01 percentage
+ * points -- 1e-4 as a rate fraction -- is everything it can display. This
+ * bound is 1e-6, two orders finer than that, and is reached in 22 bisections
+ * of a 2.5-wide bracket, comfortably inside the iteration budget.
+ *
+ * It is stated in RATE units and therefore carries no cashflow magnitude,
+ * which is the whole point: a bound on |NPV| is scale-dependent, too loose on
+ * small cashflows and unreachable on large ones.
+ */
+const IRR_RATE_TOLERANCE = 1e-6;
+
+/**
+ * Resolution of the sign-change scan across the bracket, in rate units.
+ * Set to the page's display resolution (0.01pp = 1e-4) so that no root the
+ * page could distinguish on screen can be stepped over.
+ */
+const IRR_SCAN_STEP = 1e-4;
+
+const IRR_MAX_ITERATIONS = 100;
+
+/**
  * Exponential decline production for a given year.
  * Q(t) = Q0 * (1 - declineRate)^(year - 1)
  *
@@ -85,36 +119,132 @@ function calcNPV(capex, cashflows, rate) {
  * @returns {number|null} IRR as a percentage, or null
  */
 function calcIRR(capex, cashflows) {
-  const tolerance = 0.0001;
-  const maxIterations = 100;
+  return calcIRRResult(capex, cashflows).irr;
+}
 
-  let low = -0.5;
-  let high = 2.0;
+/**
+ * Internal Rate of Return, reported with the REASON when none is available.
+ *
+ * "No IRR exists for this project" and "the search failed to pin one down"
+ * are different facts, and a bare null conflates them. This returns which
+ * happened.
+ *
+ * Roots are located by scanning the bracket for sign changes rather than by
+ * testing only the sign at its two ends. A field whose production declines
+ * while its OPEX escalates has negative cashflows in its late years, so the
+ * cashflow changes sign more than once and NPV can be negative at BOTH ends
+ * of the bracket while being positive in between. An endpoint test calls that
+ * "no root" even when two exist.
+ *
+ * Where several roots exist the IRR is genuinely ambiguous. The rate reported
+ * is the one above which NPV stays negative -- the downward crossing, which is
+ * what a decision-maker compares against a cost of capital. For a conventional
+ * cashflow there is exactly one crossing and this reduces to the usual IRR.
+ * All roots found are returned so the ambiguity stays inspectable.
+ *
+ * @param {number}   capex      Initial CAPEX (positive, same unit as cashflows)
+ * @param {number[]} cashflows  Annual net cashflows
+ * @param {object}   [options]
+ * @param {number}   [options.rateTolerance]  Bracket width to converge to
+ * @param {number}   [options.maxIterations]  Bisection budget per root
+ * @returns {{status: string, irr: number|null, roots: number[],
+ *           multipleRoots: boolean, npvAtLow: number, npvAtHigh: number}}
+ *          status is 'ok', 'no-root' or 'not-converged'
+ */
+function calcIRRResult(capex, cashflows, options) {
+  const opts = options || {};
+  const rateTolerance =
+    opts.rateTolerance === undefined ? IRR_RATE_TOLERANCE : opts.rateTolerance;
+  const maxIterations =
+    opts.maxIterations === undefined ? IRR_MAX_ITERATIONS : opts.maxIterations;
 
-  const npvAtLow = calcNPV(capex, cashflows, low);
-  const npvAtHigh = calcNPV(capex, cashflows, high);
+  const npvAtLow = calcNPV(capex, cashflows, IRR_BRACKET_LOW);
+  const npvAtHigh = calcNPV(capex, cashflows, IRR_BRACKET_HIGH);
 
-  // IRR requires NPV to change sign across the search range
-  if (npvAtLow * npvAtHigh > 0) {
-    return null;
+  const refuse = (status) => ({
+    status: status,
+    irr: null,
+    roots: [],
+    multipleRoots: false,
+    npvAtLow: npvAtLow,
+    npvAtHigh: npvAtHigh,
+  });
+
+  // Locate every sub-interval in which NPV changes sign.
+  const brackets = [];
+  let prevRate = IRR_BRACKET_LOW;
+  let prevNpv = npvAtLow;
+  const steps = Math.ceil((IRR_BRACKET_HIGH - IRR_BRACKET_LOW) / IRR_SCAN_STEP);
+
+  for (let i = 1; i <= steps; i++) {
+    const rate = Math.min(
+      IRR_BRACKET_LOW + i * IRR_SCAN_STEP,
+      IRR_BRACKET_HIGH
+    );
+    const npv = calcNPV(capex, cashflows, rate);
+    if (npv === 0) {
+      brackets.push([rate, rate]);
+    } else if (prevNpv !== 0 && Math.sign(npv) !== Math.sign(prevNpv)) {
+      brackets.push([prevRate, rate]);
+    }
+    prevRate = rate;
+    prevNpv = npv;
   }
 
-  for (let i = 0; i < maxIterations; i++) {
-    const mid = (low + high) / 2;
-    const npvMid = calcNPV(capex, cashflows, mid);
-
-    if (Math.abs(npvMid) < tolerance) {
-      return mid * 100;
-    }
-
-    if (npvMid > 0) {
-      low = mid;
-    } else {
-      high = mid;
-    }
+  if (brackets.length === 0) {
+    return refuse('no-root');
   }
 
-  return ((low + high) / 2) * 100;
+  // Bisect each bracketed root down to the rate tolerance.
+  const roots = [];
+  for (let b = 0; b < brackets.length; b++) {
+    let low = brackets[b][0];
+    let high = brackets[b][1];
+    const npvLowSign = Math.sign(calcNPV(capex, cashflows, low));
+    let converged = high - low <= rateTolerance;
+
+    for (let i = 0; i < maxIterations && !converged; i++) {
+      const mid = (low + high) / 2;
+      const npvMid = calcNPV(capex, cashflows, mid);
+      if (npvMid === 0) {
+        low = mid;
+        high = mid;
+      } else if (Math.sign(npvMid) === npvLowSign) {
+        low = mid;
+      } else {
+        high = mid;
+      }
+      converged = high - low <= rateTolerance;
+    }
+
+    if (!converged) {
+      return refuse('not-converged');
+    }
+    roots.push((low + high) / 2);
+  }
+
+  // The downward crossing: NPV positive below it, negative above.
+  let reported = null;
+  for (let i = roots.length - 1; i >= 0; i--) {
+    const below = calcNPV(capex, cashflows, roots[i] - rateTolerance * 10);
+    const above = calcNPV(capex, cashflows, roots[i] + rateTolerance * 10);
+    if (below > 0 && above < 0) {
+      reported = roots[i];
+      break;
+    }
+  }
+  if (reported === null) {
+    reported = roots[roots.length - 1];
+  }
+
+  return {
+    status: 'ok',
+    irr: reported * 100,
+    roots: roots,
+    multipleRoots: roots.length > 1,
+    npvAtLow: npvAtLow,
+    npvAtHigh: npvAtHigh,
+  };
 }
 
 /**
@@ -217,6 +347,13 @@ function formatMoney(value) {
  * @param {number} params.opexEscalation    Annual OPEX escalation fraction
  * @param {number} params.taxRate           Income tax fraction
  * @param {number} params.royaltyRate       Royalty fraction
+ * @param {number} [params.initialCumulative=0]
+ *        Where the cumulative cashflow series STARTS. Defaults to 0, i.e. the
+ *        series counts operating cashflow only. Pass -capex to make it a
+ *        project-level series that begins in the hole, which is what a payback
+ *        period is normally measured against. Stated explicitly because the
+ *        calculator page and this module previously disagreed about it in
+ *        silence, and the two meanings of "payback" are not interchangeable.
  * @returns {object} { years, revenue, costs, netCashflow, cumulativeCashflow }
  */
 function buildYearlyCashflows(params) {
@@ -230,6 +367,7 @@ function buildYearlyCashflows(params) {
     opexEscalation,
     taxRate,
     royaltyRate,
+    initialCumulative,
   } = params;
 
   const years = [];
@@ -238,7 +376,7 @@ function buildYearlyCashflows(params) {
   const netCashflow = [];
   const cumulativeCashflow = [];
 
-  let cumulative = 0;
+  let cumulative = initialCumulative === undefined ? 0 : initialCumulative;
 
   for (let year = 1; year <= projectYears; year++) {
     const prod = calcDeclineProduction(initialRate, declineRate, year);
@@ -263,14 +401,20 @@ function buildYearlyCashflows(params) {
   return { years, revenue, costs, netCashflow, cumulativeCashflow };
 }
 
-// CommonJS export for Node.js/Jest; also exposed as browser globals
+// CommonJS export for Node.js/Jest. In the browser this file is loaded as a
+// classic <script>, so the declarations above are already globals.
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
+    DOLLARS_PER_MILLION,
+    IRR_BRACKET_LOW,
+    IRR_BRACKET_HIGH,
+    IRR_RATE_TOLERANCE,
     calcDeclineProduction,
     calcAnnualRevenue,
     calcAnnualOpex,
     calcNPV,
     calcIRR,
+    calcIRRResult,
     calcMIRR,
     calcPayback,
     formatMoney,

--- a/assets/js/npv-calculator-engine.js
+++ b/assets/js/npv-calculator-engine.js
@@ -6,8 +6,15 @@
  *
  * Exports:
  *   calcDeclineProduction, calcAnnualRevenue, calcAnnualOpex,
- *   calcNPV, calcIRR, calcMIRR, calcPayback, formatMoney,
- *   buildYearlyCashflows
+ *   calcNPV, calcIRR, calcIRRResult, calcMIRR, calcPayback, formatMoney,
+ *   buildYearlyCashflows,
+ *   DOLLARS_PER_MILLION, IRR_BRACKET_LOW, IRR_BRACKET_HIGH,
+ *   IRR_RATE_TOLERANCE
+ *
+ * UNITS: this module computes in DOLLARS throughout. The calculator page's
+ * form is denominated in $M, so exactly one conversion sits between them —
+ * see DOLLARS_PER_MILLION. The one exception is formatMoney, which takes $M
+ * because it is a presentation helper; that contract is asserted by test.
  */
 
 'use strict';

--- a/content/calculators/npv-field-development.html
+++ b/content/calculators/npv-field-development.html
@@ -528,6 +528,12 @@ rootPath: "../"
             if (irrResult.status === 'no-root') {
                 return 'No IRR in the -50% to 200% range';
             }
+            if (irrResult.status === 'no-decision-rate') {
+                return 'No IRR (NPV never falls through zero)';
+            }
+            if (irrResult.status === 'invalid') {
+                return 'Not calculable (invalid input)';
+            }
             return 'Not calculable (did not converge)';
         }
 

--- a/content/calculators/npv-field-development.html
+++ b/content/calculators/npv-field-development.html
@@ -20,6 +20,7 @@ rootPath: "../"
 
     <include src="partials/head-common.html"></include>
     <script src="{{ rootPath }}assets/js/plotly-2.32.0.min.js"></script>
+    <script src="{{ rootPath }}assets/js/npv-calculator-engine.js"></script>
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
@@ -220,7 +221,7 @@ rootPath: "../"
 
                         <div class="form-group">
                             <label for="decline_rate">Annual Decline Rate (%/year)</label>
-                            <input type="number" id="decline_rate" class="form-control" value="15" min="0" max="50" step="1">
+                            <input type="number" id="decline_rate" class="form-control" value="12.5" min="0" max="50" step="0.5">
                             <small class="text-muted">Typical range: 10% - 25% for offshore fields</small>
                         </div>
 
@@ -254,7 +255,7 @@ rootPath: "../"
 
                         <div class="form-group">
                             <label for="opex">Annual OPEX ($M)</label>
-                            <input type="number" id="opex" class="form-control" value="50" min="1" max="1000" step="1">
+                            <input type="number" id="opex" class="form-control" value="16" min="1" max="1000" step="1">
                             <small class="text-muted">Annual operating expenditure</small>
                         </div>
 
@@ -448,124 +449,90 @@ rootPath: "../"
                 return;
             }
 
-            // Calculate year-by-year cashflows
+            // EVERYTHING BELOW THIS LINE IS IN $M.
+            //
+            // The form is denominated in $M (CAPEX and OPEX are labelled so)
+            // and the headline appends ' M', so $M is the unit this page
+            // speaks. The engine computes revenue in DOLLARS, because that is
+            // what bbl/day x $/bbl x 365 gives you. Exactly one conversion
+            // sits between the two, at the point revenue is produced.
             const years = [];
             const production = [];
             const revenue = [];
             const costs = [];
             const netCashflow = [];
             const cumulativeCashflow = [];
-            const discountedCashflow = [];
 
             let cumulative = -capex; // Year 0 CAPEX
-            let npv = -capex; // Start with negative CAPEX
 
             for (let year = 1; year <= projectYears; year++) {
-                // Production decline: Q(t) = Q0 * (1 - decline)^t
-                const prod = initialRate * Math.pow(1 - declineRate, year - 1);
+                const prod = calcDeclineProduction(initialRate, declineRate, year);
 
-                // Revenue with price escalation
-                const price = oilPrice * Math.pow(1 + priceEscalation, year - 1);
-                const annualRevenue = prod * price * 365 * (1 - royaltyRate);
+                // ---- THE SINGLE UNIT CONVERSION IN THIS PAGE ----
+                const annualRevenue = calcAnnualRevenue(
+                    prod, oilPrice, priceEscalation, royaltyRate, year
+                ) / DOLLARS_PER_MILLION;
+                // ------------------------------------------------
 
-                // OPEX with escalation
-                const annualOpex = opex * Math.pow(1 + opexEscalation, year - 1);
+                // OPEX is entered in $M, so it needs no conversion.
+                const annualOpex = calcAnnualOpex(opex, opexEscalation, year);
 
-                // Net cashflow before tax
                 const beforeTax = annualRevenue - annualOpex;
                 const tax = beforeTax > 0 ? beforeTax * taxRate : 0;
                 const afterTax = beforeTax - tax;
 
-                // Discounted cashflow
-                const discountFactor = Math.pow(1 + discountRate, year);
-                const dcf = afterTax / discountFactor;
-
-                // Cumulative cashflow
                 cumulative += afterTax;
-                npv += dcf;
 
-                // Store values
                 years.push(year);
                 production.push(prod);
                 revenue.push(annualRevenue);
                 costs.push(annualOpex);
                 netCashflow.push(afterTax);
                 cumulativeCashflow.push(cumulative);
-                discountedCashflow.push(dcf);
             }
 
-            // Calculate IRR using bisection method
-            const irr = calculateIRR(capex, netCashflow);
+            const npv = calcNPV(capex, netCashflow, discountRate);
 
-            // Calculate payback period
-            const payback = calculatePayback(cumulativeCashflow, years);
+            // Reports WHY there is no IRR when there is none, rather than
+            // collapsing every outcome into a bare null.
+            const irrResult = calcIRRResult(capex, netCashflow);
 
-            // Calculate profit-to-investment ratio
+            const payback = calcPayback(cumulativeCashflow, years);
+
             const totalProfit = cumulativeCashflow[cumulativeCashflow.length - 1];
             const profitRatio = totalProfit / capex;
 
-            // Display results
-            displayResults(npv, irr, payback, profitRatio, discountRate);
+            displayResults(npv, irrResult, payback, profitRatio, discountRate);
 
-            // Plot cashflow chart
             plotCashflow(years, revenue, costs, netCashflow, cumulativeCashflow);
 
-            // Track calculation
             gtag('event', 'calculator_use', {
                 'event_category': 'calculator',
                 'event_label': 'npv_calculation',
                 'value': Math.round(npv)
             });
+
+            return {
+                npv: npv,
+                irr: irrResult.irr,
+                irrStatus: irrResult.status,
+                payback: payback,
+                profitRatio: profitRatio
+            };
         }
 
-        // Calculate IRR using bisection method
-        function calculateIRR(capex, cashflows) {
-            let low = -0.5;
-            let high = 2.0;
-            const tolerance = 0.0001;
-            const maxIterations = 100;
-
-            for (let i = 0; i < maxIterations; i++) {
-                const mid = (low + high) / 2;
-                let npvAtMid = -capex;
-
-                for (let year = 0; year < cashflows.length; year++) {
-                    npvAtMid += cashflows[year] / Math.pow(1 + mid, year + 1);
-                }
-
-                if (Math.abs(npvAtMid) < tolerance) {
-                    return mid * 100; // Return as percentage
-                }
-
-                if (npvAtMid > 0) {
-                    low = mid;
-                } else {
-                    high = mid;
-                }
+        // Why there is no IRR. "No root in the search range" and "the search
+        // did not converge" are different facts about a project and must not
+        // reach the visitor as the same sentence.
+        function irrMessage(irrResult) {
+            if (irrResult.status === 'no-root') {
+                return 'No IRR in the -50% to 200% range';
             }
-
-            return null; // IRR not found
-        }
-
-        // Calculate payback period
-        function calculatePayback(cumulative, years) {
-            for (let i = 0; i < cumulative.length; i++) {
-                if (cumulative[i] > 0) {
-                    // Linear interpolation for fractional year
-                    if (i === 0) {
-                        return years[i];
-                    }
-                    const prevYear = i === 0 ? 0 : years[i - 1];
-                    const prevCum = i === 0 ? 0 : cumulative[i - 1];
-                    const fraction = -prevCum / (cumulative[i] - prevCum);
-                    return prevYear + fraction;
-                }
-            }
-            return null; // No payback within project life
+            return 'Not calculable (did not converge)';
         }
 
         // Display results
-        function displayResults(npv, irr, payback, profitRatio, discountRate) {
+        function displayResults(npv, irrResult, payback, profitRatio, discountRate) {
             const npvClass = npv >= 0 ? 'positive' : 'negative';
             const npvStatus = npv >= 0 ? 'VIABLE' : 'NOT VIABLE';
             const npvStatusClass = npv >= 0 ? 'success-text' : 'danger-text';
@@ -603,7 +570,8 @@ rootPath: "../"
 
             addResultLine('Project Status:', npvStatus, npvStatusClass);
 
-            if (irr !== null) {
+            if (irrResult.status === 'ok') {
+                const irr = irrResult.irr;
                 const irrClass = irr > discountRate * 100 ? 'success-text' : 'danger-text';
                 addResultLine('Internal Rate of Return:', irr.toFixed(2) + '%', irrClass);
 
@@ -613,8 +581,19 @@ rootPath: "../"
                     '% | IRR ' + (irr > discountRate * 100 ? '>' : '<') + ' discount rate';
                 discountParagraph.appendChild(discountDetail);
                 resultDetail.appendChild(discountParagraph);
+
+                if (irrResult.multipleRoots) {
+                    const ambiguityParagraph = document.createElement('p');
+                    const ambiguityDetail = document.createElement('small');
+                    ambiguityDetail.className = 'warning-text';
+                    ambiguityDetail.textContent = 'Cashflow changes sign more than once, so ' +
+                        irrResult.roots.length + ' rates solve NPV = 0. Shown: the rate above ' +
+                        'which NPV stays negative.';
+                    ambiguityParagraph.appendChild(ambiguityDetail);
+                    resultDetail.appendChild(ambiguityParagraph);
+                }
             } else {
-                addResultLine('Internal Rate of Return:', 'Not calculable', 'danger-text');
+                addResultLine('Internal Rate of Return:', irrMessage(irrResult), 'danger-text');
             }
 
             if (payback !== null) {
@@ -635,21 +614,21 @@ rootPath: "../"
             const traces = [
                 {
                     x: years,
-                    y: revenue.map(v => v / 1e6),
+                    y: revenue,
                     name: 'Revenue',
                     type: 'bar',
                     marker: { color: '#5cb85c' }
                 },
                 {
                     x: years,
-                    y: costs.map(v => v / 1e6),
+                    y: costs,
                     name: 'OPEX',
                     type: 'bar',
                     marker: { color: '#d9534f' }
                 },
                 {
                     x: years,
-                    y: netCashflow.map(v => v / 1e6),
+                    y: netCashflow,
                     name: 'Net Cashflow',
                     type: 'scatter',
                     mode: 'lines+markers',
@@ -658,7 +637,7 @@ rootPath: "../"
                 },
                 {
                     x: years,
-                    y: cumulative.map(v => v / 1e6),
+                    y: cumulative,
                     name: 'Cumulative Cashflow',
                     type: 'scatter',
                     mode: 'lines',
@@ -701,15 +680,6 @@ rootPath: "../"
             };
 
             Plotly.newPlot('cashflow-chart', traces, layout, config);
-        }
-
-        // Helper function to format money
-        function formatMoney(value) {
-            const absValue = Math.abs(value);
-            if (absValue >= 1000) {
-                return (value / 1000).toFixed(1) + 'B';
-            }
-            return value.toFixed(1);
         }
     </script>
 

--- a/docs/plans/2026-08-04-issue-124-npv-units-and-irr.md
+++ b/docs/plans/2026-08-04-issue-124-npv-units-and-irr.md
@@ -1,0 +1,377 @@
+# Plan for #124: make the NPV field-development calculator arithmetically honest
+
+> **Status:** plan-review (awaiting owner approval — never self-approved)
+> **Complexity:** T2
+> **Date:** 2026-08-04
+> **Issue:** https://github.com/vamseeachanta/aceengineer-website/issues/124
+> **Client:** N/A
+> **Branch:** `plan/124-npv-units` (worktree off `origin/main` @ `10190ff`)
+> **Review artifacts:** r1 Claude — inline, main session (see Adversarial Review Summary)
+
+---
+
+## Premise verification (2026-08-04, against `origin/main` @ `10190ff`)
+
+`origin/main` is exactly [PR #123](https://github.com/vamseeachanta/aceengineer-website/pull/123) (the [#16](https://github.com/vamseeachanta/aceengineer-website/issues/16) XSS hardening), so the tree is as that PR left it.
+
+Every claim in the issue and every repo trap named in the briefing was re-checked.
+**Two were refuted.**
+
+| Claim | Verdict | Evidence |
+|---|---|---|
+| Page renders `$348915.5B M`, IRR `Not calculable`, payback `1.0 years`, ratio `1162054.01x` for its own defaults | **CONFIRMED — all four reproduced exactly** | Transcribed the inline logic (`content/calculators/npv-field-development.html:455-548`) with the form defaults (`:217-283`) and executed it. Output matched to the last digit |
+| Revenue is in dollars, CAPEX/OPEX in `$M` | **CONFIRMED** | `:469` `prod * price * 365 * (1 - royaltyRate)` against `:251` `capex` `($M)` = 500 and `:257` `opex` `($M)` = 50 |
+| IRR never renders — the page has never shown one | **CONFIRMED as an observation** | `:547` returns `null` after the loop; `:617` renders `Not calculable` |
+| **…because the absolute `0.0001` tolerance is unreachable on cashflows of order 1e11** | **REFUTED — this is the wrong cause** | Measured: with the shipped (broken-unit) defaults, NPV at rate `−0.5` is `1.35e13` and at rate `2.0` is `3.84e7` — **both positive**. There is no root in the search bracket at all, because the 1e6 revenue inflation pushes the true IRR far above 200 %. Bisection walks `low` up to `2.0` and never crosses zero. An infinitely tight tolerance would not help. Separately measured: the absolute tolerance **is** reachable at 1e8 magnitude and only starts failing at **≥1e10** — so it is a real latent defect, but it is **not** why the page shows `Not calculable`. Fixing only the tolerance would leave the symptom exactly as it is |
+| `assets/js/npv-calculator-engine.js` is a separately-tested parallel implementation the page does not import | **CONFIRMED** | No `npv-calculator-engine` reference anywhere in the page; engine exports via CommonJS + globals (`:207-220` of the export block) |
+| PR #123's tests pin the wrong values, marked characterisation-not-endorsement | **CONFIRMED** | `tests/js/npv-render.test.js:171-182` carries the explicit `CHARACTERISATION, NOT ENDORSEMENT` block |
+| Homepage source is `content/index.html`; root `index.html` is stale and unserved | **CONFIRMED** | `content/index.html` 6,210 bytes; root `index.html` 32,206 bytes with 4 occurrences of `AI-Native` |
+| **The brand rule forbids the literal string "AI" in user-facing copy** | **REFUTED** | `brand/copy.yaml:84-86` states in terms: *"'AI' itself is permitted (the theme.css comment banning it was deleted; this file's firm_lede says 'AI-native' and is asserted on About). What #21 actually rules out is the breathless register."* The canonical `firm_lede` **contains** "AI-native" and `lint:copy` fails when it is *absent* from `content/about.html`. The forbidden list is `consultancy`, `consulting practice`, `Open Deck`, `t.me/`, `custom work is currently unavailable`, `revolutionary`, `cutting-edge AI`. Writing to the stated rule would have broken the copy lint |
+| `theme.css` stays last in `build.js` `cssFiles`, outside the bootstrap purge | **CONFIRMED** | `build.js:66` — last entry of the bundle input list; the purge at `:546-548` targets `bootstrap-united.css` only |
+| Jest suite is cold-state dependent | **CONFIRMED structurally; [#125](https://github.com/vamseeachanta/aceengineer-website/issues/125)'s numbers are stale** | Measured today in this worktree — **cold: 8 failed / 458 passed / 466 total, 5 suites failed. Warm: 494 passed / 494 total, 26 suites.** [#125](https://github.com/vamseeachanta/aceengineer-website/issues/125) records 370/8/378 cold and 406/406 warm. The **28-test cold shortfall is exactly preserved** (494 − 466 = 28), so the structural claim holds while every absolute count in that issue is now wrong |
+| The engine may have correct unit handling; adopting it may be the real fix | **PARTLY — and it carries its own seam** | See below |
+
+### The engine is dollars-coherent, but has a unit seam at its own presentation boundary
+
+`buildYearlyCashflows` documents `opex` as **dollars** (`:216`), `calcAnnualRevenue`
+returns **dollars** (`:42`), and `tests/js/npv-calculator.test.js:89` feeds
+`calcAnnualOpex(50e6, ...)`. So the engine's **arithmetic is internally consistent
+in dollars** — it does not have the page's defect.
+
+But two seams exist and both must be closed deliberately, or adopting the engine
+reproduces this same bug class one layer over:
+
+1. **`formatMoney` documents its input as "Dollar amount in millions"** (`:196`) and
+   divides by 1000 to append `B`. The engine therefore computes in dollars and
+   formats in millions. Nothing in the module converts between them.
+2. **`buildYearlyCashflows` starts `cumulative` at `0`, not `-capex`** (`:241`),
+   while the page starts at `-capex` (`:460`). Payback semantics differ between
+   the two implementations; swapping one for the other silently changes what
+   "payback" means.
+
+`calcIRR` is genuinely more robust than the page's copy: it has a sign-change
+bracket guard (`:97-100`) returning `null` when no root exists, and a defined
+post-loop return (`:116`). The page has neither.
+
+### The finding that reshapes this issue: correcting units makes the default project non-viable
+
+Running the corrected arithmetic on the page's own defaults:
+
+| quantity, corrected to `$M` | value |
+|---|---|
+| Year-1 revenue after royalty | **$103.8 M** |
+| Undiscounted total profit over 20 years | **−$1,135.9 M** (against $500 M CAPEX) |
+| NPV @ 10% | **−$603.9 M** |
+| NPV at the IRR bracket ends (−0.5 and 2.0) | −1.6e8 and −481.6 — **same sign** |
+
+The cause is structural, not a residual bug: production declines 15 %/yr while
+OPEX escalates 3 %/yr from a $50 M base, so OPEX overtakes revenue partway
+through the project and the field never repays its CAPEX.
+
+Three consequences, all of which change the acceptance criteria:
+
+1. **No IRR exists for the default inputs** — NPV is negative across the whole
+   search bracket, so there is no root to find. This is `null` for a *correct*
+   reason, where today it is `null` for a wrong one.
+2. **An acceptance criterion of the form "IRR renders a number for the default
+   inputs" is unsatisfiable** without also changing the defaults. The issue's
+   "Done when" list is worded loosely enough to invite exactly that criterion.
+3. **The "NOT VIABLE" branch becomes reachable by default** — which the issue
+   wanted, but it means the live page would greet every visitor with a
+   NOT VIABLE verdict on load. That is a product decision, not a maths one, and
+   it belongs to the owner (D4).
+
+---
+
+## Deliverable
+
+A calculator whose headline is dimensionally coherent, whose IRR is reported when
+one exists and refused when one does not — with the two reported for different
+and distinguishable reasons — and a default input set the owner has consciously
+chosen.
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repo code
+
+- `content/calculators/npv-field-development.html` — the served page. Inline
+  `calculateNPV:423-518`, `calculateIRR:522-548`, `calculatePayback:551-566`,
+  `displayResults:569+`, `formatMoney:707-713`. IRR rendered at `:608` as
+  `irr.toFixed(2) + '%'`; the refusal branch at `:617`.
+- `assets/js/npv-calculator-engine.js` — tested, unimported. `calcAnnualRevenue:40-43`,
+  `calcIRR:87-117` (bracket guard `:97-100`, fallback return `:116`),
+  `formatMoney:199-205`, `buildYearlyCashflows:222-264`.
+- `tests/js/npv-calculator.test.js` — engine unit tests, dollars convention.
+- `tests/js/npv-render.test.js` — the characterisation suite from PR #123.
+- `brand/copy.yaml:72-88` — `forbidden_phrases`; `scripts/lint-copy.js:100-108`
+  enforces them.
+- `build.js:65-66` — CSS bundle inputs, `theme.css` last.
+
+### Gaps identified
+
+No shared unit convention between the page and the engine, and no test anywhere
+asserts that the page and the engine agree. The two implementations have drifted
+without any signal.
+
+### Evidence
+
+**Issue states** (2026-08-04): `#124` OPEN (`priority:high`) · `#125` OPEN ·
+`#16` referenced by merged PR #123.
+
+**Environment**: `npm ci` → 380 packages, clean. `npm run build` rc=0. Cold and
+warm suites measured as tabulated above.
+
+---
+
+## Design decisions
+
+**D1 — `$M` is the canonical unit, and the conversion happens exactly once.**
+The form labels CAPEX and OPEX in `$M` (`:250`, `:256`) and the headline appends
+`' M'` (`:576`), so `$M` is what the page already claims to speak. Revenue is
+converted from dollars to `$M` at the single point where it is produced. One
+conversion, named, with a test asserting there is only one.
+
+**D2 — Delete the inline duplicate; the page consumes the engine.**
+The issue floats this and it is right, but only after the two seams above are
+closed. Keeping two implementations is what allowed this drift to persist
+untested. The engine stays in **dollars** internally (converting it wholesale
+would churn its ~40 passing unit tests for no correctness gain); the page applies
+one dollars→`$M` conversion at the presentation boundary, and `formatMoney`'s
+documented `$M` contract becomes an asserted one rather than a comment.
+`buildYearlyCashflows`'s `cumulative` origin is made explicit so payback means
+the same thing on both sides.
+
+**D3 — IRR has two independent defects, and the issue names only the secondary one.**
+Measurement (premise table) shows the observed `Not calculable` comes from **no
+root in the `[-0.5, 2.0]` bracket**, not from the tolerance. Both are real and
+both are fixed, but they must not be confused — a PR that fixed only the
+tolerance would close this issue with the symptom untouched.
+
+- *(a) **Primary** — the bracket.* The unit bug pushes the true IRR above 200 %,
+  outside the search range. **Fixing the units (D1) fixes this**, and no IRR-side
+  change is needed for it. What *is* needed is a **sign-change guard** so "no
+  root in range" is returned as a distinct outcome rather than falling through
+  100 pointless iterations to a bare `null`.
+- *(b) **Secondary, latent** — terminate on bracket width, not `|NPV|`.* `|NPV|`
+  scales with the cashflows; the bracket width is in **rate** units and does not.
+  Measured: the current absolute bound survives to 1e8 magnitude and fails at
+  ≥1e10. It is not biting today, and it would bite on a large field.
+- *(c) Define the post-loop return.* The page discards a converged answer at
+  `:547`; the engine already returns the midpoint at `:116`.
+
+Adopting the engine (D2) delivers the (a) guard and (c) for free. Only (b) is new
+work.
+
+**D4 — The default inputs are an owner decision this plan surfaces, not one it
+resolves.** With units fixed the defaults describe a field that loses $1.1 bn.
+Ranked options:
+
+1. **Re-pick the defaults from a cited public source** (recommended) — e.g. a
+   published decline rate and OPEX profile for a conventional development. The
+   page then opens on a viable project *because the cited field is viable*, not
+   because anyone tuned it.
+2. **Keep the defaults and let the page open on NOT VIABLE** — honest, exercises
+   the branch, and defensible for an engineering audience; a poor first
+   impression on a public marketing site.
+3. **Open with no result until the visitor presses Calculate** — sidesteps the
+   question; loses the at-a-glance demo.
+
+**Whichever is chosen, no default may be adjusted until the NPV turns positive.**
+That is fitting a constant to a desired output, and it is forbidden by an
+acceptance criterion below. If option 1's cited source yields a non-viable field,
+the answer is option 2, not a nudged parameter.
+
+**D5 — Every threshold derives from a named input.**
+- The IRR convergence bound derives from the page's **own display precision**:
+  IRR renders as `toFixed(2)` on a percentage (`:608`), i.e. 0.01 percentage
+  points = `1e-4` in rate-fraction terms. The bracket bound is `1e-6` — two
+  orders finer than what is displayed, reached in ~22 bisections of the
+  `[-0.5, 2.0]` bracket, comfortably inside the existing 100-iteration budget.
+  It is derived from the rendering contract, contains no cashflow magnitude, and
+  is therefore scale-free by construction.
+- The dollars→`$M` divisor is `1e6` by definition of the unit.
+- **No number in this PR is taken from an observed output.**
+
+**D6 — The characterisation tests are rewritten, not deleted — and six are
+affected, not the two the issue names.**
+PR #123 named `$348915.5B M` and `1162054.01x`. Enumerating
+`tests/js/npv-render.test.js`, the corrected behaviour also flips:
+
+| line | test | why it changes |
+|---|---|---|
+| `:163` | `a profitable case is classed positive and reported VIABLE` | NPV goes negative → `negative` class, `NOT VIABLE`, `.danger-text` |
+| `:183` | `the default-input headline value is unchanged by the refactor` | `$348915.5B M` → a `$X M` value |
+| `:188` | `the default-input profit ratio is unchanged by the refactor` | `1162054.01x` → a plausible ratio |
+| `:193` | `IRR and payback lines are both present` | asserts `Payback Period: 1.0 years`; there is no payback after the fix |
+| `:199` | `the non-converging IRR is reported as Not calculable` | still `Not calculable`, but for the **opposite reason** — must be re-pointed at the no-root case, or it passes for the wrong cause |
+| `:149` | `renders the NPV headline with the money format and unit` | verify — may survive if it asserts shape rather than value |
+
+`:199` is the subtle one: it stays green through the fix while its meaning
+inverts. A test that passes for a changed reason is worse than one that fails.
+
+**D7 — Repo traps.** Edit `content/calculators/...`, never `dist/`. The homepage
+is `content/index.html`; root `index.html` is stale and out of scope. `theme.css`
+stays last in `build.js:66`. Capability card links stay absolute. "AI" is
+**permitted** (premise refuted) — do not scrub it, and do not touch
+`brand/copy.yaml`'s `firm_lede`.
+
+**D8 — Any criterion citing a test count states cold or warm and is re-measured.**
+[#125](https://github.com/vamseeachanta/aceengineer-website/issues/125)'s counts are already stale by 88 tests. Criteria below use **warm** counts,
+measured at the branch point, and compare **node IDs**, not totals.
+
+---
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Modify | `content/calculators/npv-field-development.html` | D1/D2: delete the inline duplicate, load and call the engine, one dollars→`$M` conversion, wire the IRR refusal branch |
+| Modify | `assets/js/npv-calculator-engine.js` | D3(a) bracket-width termination; D2 seams — assert `formatMoney`'s `$M` contract, make `buildYearlyCashflows`'s `cumulative` origin explicit |
+| Modify | `tests/js/npv-render.test.js` | D6: rewrite the six affected tests with new values justified in the commit body |
+| Modify | `tests/js/npv-calculator.test.js` | D3(a) tests: known-IRR cashflow at two very different scales |
+| Create | `tests/js/npv-parity.test.js` | the missing signal — page and engine must agree on the same inputs |
+| Modify | `content/calculators/npv-field-development.html` (defaults `:217-283`) | **only if the owner picks D4 option 1**, with the source cited in the commit body |
+
+**Not touched:** root `index.html`, `brand/copy.yaml`, `build.js`, `dist/`,
+anything under `content/` other than the calculator.
+
+---
+
+## TDD Test List
+
+Every row states the expected value and why it is red on `origin/main` @ `10190ff`.
+
+| Test | Input | Expected | Red today because |
+|---|---|---|---|
+| `test_headline_unit_is_coherent` | page defaults | headline matches `/^\$-?\d+\.\d M$/` — **no `B M`** | today `$348915.5B M` |
+| `test_revenue_is_in_millions` | 5000 bopd, $70, no royalty | year-1 revenue ≈ `127.75` (`$M`), not `1.2775e8` | engine returns dollars and the page never converts |
+| `test_irr_of_known_cashflow_small_scale` | capex `100`, 10 flows of `16.2745` | IRR `10.00 % ± 0.01` | passes today — **characterisation, marked as such**. Measured green at scales 1, 1e6 and 1e8, so it is honestly not evidence of the fix |
+| `test_irr_of_known_cashflow_at_1e10` | the same cashflow × **`1e10`** | IRR `10.00 % ± 0.01` — **identical to the row above** | **measured red**: the absolute `1e-4` bound on `\|NPV\|` first fails at 1e10 (green at 1e8, so an earlier draft's 1e8 row was **vacuous**). Same IRR, 1e10× the magnitude — the scale-invariance the fix must deliver |
+| `test_irr_returns_no_root_when_true_irr_exceeds_bracket` | the page's **shipped, broken-unit** default cashflows | a distinct **no-root** outcome, and the reason recorded is "NPV positive at both bracket ends" — NPV at `−0.5` is `1.35e13`, at `2.0` is `3.84e7` | **this is the actual live defect**; today it falls through 100 iterations to a bare `null` indistinguishable from a convergence failure |
+| `test_irr_returns_no_root_when_npv_never_crosses_zero` | all-negative cashflows | a distinct **no-root** outcome, not a converge-failure | page has no bracket guard; `:547` returns bare `null` for every reason |
+| `test_irr_no_root_and_convergence_failure_are_distinguishable` | one of each | the two produce different internal outcomes even if both render `Not calculable` | today there is exactly one `null` and one reason for it |
+| `test_default_inputs_have_no_irr` | page defaults, corrected units | no-root — because NPV @ −0.5 and @ 2.0 are both negative | **pins the D4 finding**; asserts the *reason*, so it cannot be satisfied by the current accidental `null` |
+| `test_not_viable_branch_is_reachable` | any loss-making input | `NOT VIABLE`, `negative` class, `.danger-text` present | the issue reports this branch as dead code today |
+| `test_no_payback_branch_is_reachable` | never-positive cumulative | renders the no-payback message | today payback is always `1.0` |
+| `test_page_and_engine_agree` | 5 input sets incl. defaults **and** one loss-making | NPV, IRR, payback, ratio equal within `1e-9` | the page does not import the engine; **nothing asserts agreement** |
+| `test_conversion_happens_exactly_once` | source scan | exactly one `1e6` conversion site in the calculator | the seam is unguarded; two conversions is the natural regression |
+| `test_no_default_yields_a_tuned_positive_npv` | defaults | if the owner picks D4 option 1, the defaults match the cited source **verbatim** | guards D5; no such assertion exists |
+
+**Not included, deliberately:** no test pinning an IRR value for the page's
+default inputs (D4 — none exists, and a test demanding one would force a fitted
+default); no test asserting the absence of "AI" (premise refuted — it would fail
+the copy lint).
+
+---
+
+## Acceptance Criteria
+
+- [ ] **Every test above fails on `origin/main` @ `10190ff` and passes after**, except the two rows explicitly marked characterisation. The failure list is captured against a clean `origin/main` worktree and recorded in the PR body.
+- [ ] **Warm** suite (`npm run build` first, then `npx jest`) compared **node-ID by node-ID** against a warm baseline captured in the same worktree at the branch point. Baseline measured 2026-08-04: **494 passed / 494 total / 26 suites**. No new failure node IDs. Raw totals are not the criterion — the node-ID diff is.
+- [ ] **Cold** behaviour is unchanged relative to its own baseline (8 failed / 458 passed / 466 total). This plan does **not** fix [#125](https://github.com/vamseeachanta/aceengineer-website/issues/125), and must not make cold worse.
+- [ ] The headline for the page's default inputs matches `/^\$-?\d+\.\d M$/` — **the string `B M` appears nowhere in any rendered result**.
+- [ ] **The same cashflow scaled by `1e10` yields the same IRR to two decimals.** This is the scale-invariance criterion, and it cannot be satisfied by any absolute tolerance. `1e10` is the **measured** first-failing scale — `1e8` is green today and a criterion citing it would be vacuous.
+- [ ] **The page's shipped broken-unit defaults are refused with "no root in bracket", not "failed to converge".** This pins the *actual* live cause, which the issue mis-attributes to the tolerance.
+- [ ] "No IRR exists" and "IRR failed to converge" are **distinguishable outcomes** in the code, even where both render the same string to the visitor.
+- [ ] `NOT VIABLE` and the no-payback branch are each reached by at least one test with a **named input set** — not by mocking the branch condition.
+- [ ] The page and the engine agree to `1e-9` on five input sets, at least one of which is loss-making.
+- [ ] **No numeric default or threshold in this PR was chosen by observing its output.** The IRR bound traces to the page's `toFixed(2)` render precision; any changed default traces to a source cited in the commit body. Reviewer instruction: for each changed number, ask *"what named input produces this?"* — if the answer is "it made the result look right", reject.
+- [ ] `npx jest tests/js/copy-lint.test.js` passes **warm** — confirms nothing touched the brand copy, including the permitted "AI".
+- [ ] `dist/` contains no hand-edited file; the page is rebuilt from `content/`.
+- [ ] r1 review artifact recorded.
+
+---
+
+## Out of scope
+
+- **[#125](https://github.com/vamseeachanta/aceengineer-website/issues/125), the cold-state test dependency.** Real, separately filed, and fixing it inside a behaviour change would make the behaviour change unverifiable — the same reasoning that correctly kept this issue out of PR #123.
+- **Root `index.html`.** Stale, unserved, 4× "AI-Native". Its staleness deserves its own issue; deleting or refreshing it here would blur this PR's diff.
+- **The other calculators.** `decline-curve`, `wall-thickness`, `mooring-fatigue`, `obs-calculator` may share the inline-duplicate pattern. **This plan does not audit them**, and finding the same defect elsewhere should become its own issue rather than widening this one.
+- **`calcMIRR`.** Present in the engine, unused by the page, untouched.
+- **Visual/layout changes.** None.
+
+---
+
+## Adversarial Review Summary
+
+| Round | Provider | Verdict |
+|---|---|---|
+| r1 | Claude — inline, main session | **MAJOR** — 7 findings, all folded in |
+
+1. **An early draft carried the briefing's "brand rule forbids the literal string
+   AI" and proposed scrubbing it.** `brand/copy.yaml:84-86` says the opposite in
+   terms, and the canonical `firm_lede` *contains* "AI-native". Acting on it
+   would have **broken `lint:copy`** — the very check that is already red on a
+   cold tree, so the breakage would have looked like the known [#125](https://github.com/vamseeachanta/aceengineer-website/issues/125) flake.
+   → premise table; D7; a TDD exclusion.
+2. **"Fix the units and IRR renders" is false.** Correcting units leaves the
+   default project with no IRR at all, because NPV is negative across the entire
+   search bracket. A criterion of the form "IRR renders a number for the default
+   inputs" — which the issue's "Done when" invites — is **unsatisfiable without
+   fitting the defaults**. → D3(b), D4, `test_default_inputs_have_no_irr`.
+3. **The draft accepted the issue's "make the tolerance relative".** Relative to
+   *what* is the question, and every scale-bearing answer reintroduces the
+   problem. Terminating on **bracket width** removes cashflow magnitude from the
+   criterion entirely, and the bound then derives from the page's own render
+   precision. → D5.
+4. **The blast radius was under-counted at two tests.** Enumeration found six,
+   and `:199` is the dangerous one — it stays green while its meaning inverts.
+   → D6.
+5. **The draft asserted the engine "has the same defect".** Checking the engine's
+   tests (`npv-calculator.test.js:89` feeds `50e6`) showed its arithmetic is
+   dollars-coherent; the seam is between its arithmetic and its `formatMoney`,
+   which documents `$M`. Shipping the wrong diagnosis would have produced the
+   wrong fix. → the engine section; D2.
+
+6. **The issue's IRR root cause is wrong, and the draft repeated it.** The issue
+   attributes `Not calculable` to the absolute `0.0001` tolerance being
+   unreachable at 1e11. Measured: with the shipped defaults NPV is **positive at
+   both ends** of `[-0.5, 2.0]` (1.35e13 and 3.84e7) — there is no root to find,
+   and tolerance is irrelevant. Fixing only the tolerance would have closed this
+   issue with the visible symptom unchanged. → premise table, D3, and a new TDD
+   row pinning the real cause.
+7. **The draft's own scale-invariance test was vacuous.** It used `1e8`, which
+   measurement shows is **green today** — the absolute bound survives to 1e8 and
+   first fails at 1e10. A red-before/green-after claim on that row would have
+   been false. → the row now uses `1e10`, the measured failure point. This is the
+   same defect class as finding 6: a plausible number asserted rather than run.
+
+One criterion was **withdrawn as vacuous**: "the NOT VIABLE branch is covered by
+a test" — satisfiable by forcing the branch condition directly, which proves
+nothing about reachability from real inputs. Replaced with reachability from a
+**named input set**.
+
+**Verdict: ready for owner review.** One decision required (D4).
+
+---
+
+## Risks and Open Questions
+
+- **DECISION REQUIRED (D4) — the defaults.** With units fixed, the page's own
+  defaults describe a field losing $1.1 bn. Recommended: option 1, re-pick from a
+  cited public source. This plan will not choose the numbers, because choosing
+  them to produce a positive NPV is exactly the fitted-constant failure D5
+  forbids.
+- **Risk — this is live on `www.aceengineer.com`.** Every visitor currently sees
+  `$348915.5B M`. That argues for landing the unit fix quickly; it argues against
+  bundling it with a defaults debate. If D4 stalls, **split**: ship units + IRR
+  under this issue and move defaults to a follow-on. The plan is written so that
+  split is clean — only the last Files-to-Change row is conditional on D4.
+- **Risk — deleting the inline duplicate changes the page's loading contract.**
+  It gains a script dependency it did not have. The engine must be in the built
+  output and referenced with an absolute path, per the repo's link rule. If that
+  proves awkward, the fallback is to fix the inline maths in place and add the
+  parity test anyway — worse, but not blocked.
+- **Unverified — how the live page is deployed from `dist/`.** This plan assumes
+  the standard build path. It does not touch deployment, but "the fix is live" is
+  not something these criteria can prove.
+
+---
+
+## Complexity: T2
+
+One page, one module, three test files. No new dependency, no build change, no
+cross-repo coordination. Not T1: the defaults question is a genuine product
+decision and the characterisation rewrite has a six-test blast radius.

--- a/package.json
+++ b/package.json
@@ -90,6 +90,11 @@
         "testMatch": ["<rootDir>/tests/js/npv-render.test.js"]
       },
       {
+        "displayName": "npv-parity",
+        "testEnvironment": "jsdom",
+        "testMatch": ["<rootDir>/tests/js/npv-parity.test.js"]
+      },
+      {
         "displayName": "hse-render",
         "testEnvironment": "jsdom",
         "testMatch": ["<rootDir>/tests/js/hse-render.test.js"]

--- a/package.json
+++ b/package.json
@@ -95,6 +95,11 @@
         "testMatch": ["<rootDir>/tests/js/npv-parity.test.js"]
       },
       {
+        "displayName": "npv-browser",
+        "testEnvironment": "node",
+        "testMatch": ["<rootDir>/tests/js/npv-browser.test.js"]
+      },
+      {
         "displayName": "hse-render",
         "testEnvironment": "jsdom",
         "testMatch": ["<rootDir>/tests/js/hse-render.test.js"]

--- a/tests/js/npv-browser.test.js
+++ b/tests/js/npv-browser.test.js
@@ -1,0 +1,154 @@
+/**
+ * Executes the calculator page with REAL classic-script semantics (#124).
+ *
+ * Why this exists, and why the other suites are not enough:
+ *
+ * tests/js/npv-render.test.js and npv-parity.test.js reconstruct the browser
+ * environment with `Object.assign(window, engine)` followed by
+ * `window.eval(inlineScript)`. That is more permissive than a browser in two
+ * ways that matter:
+ *
+ *   1. The engine's top-level `const DOLLARS_PER_MILLION` becomes a global
+ *      LEXICAL binding in a browser, NOT a property of window. Assigning it to
+ *      window makes `window.DOLLARS_PER_MILLION` work in the test when it is
+ *      undefined on the real page.
+ *   2. A top-level `const`/`var` redeclaration in the page's inline script
+ *      would be a SyntaxError in a browser -- killing the whole calculator --
+ *      but is legal inside `window.eval`, because eval gets its own scope.
+ *
+ * So this suite loads the page as a document, lets jsdom fetch and run the
+ * engine as a separate <script src> in document order, and clicks the actual
+ * button. It reads from content/ and assets/, never dist/, so it does not
+ * depend on a build having run.
+ *
+ * @jest-environment node
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { JSDOM, ResourceLoader, VirtualConsole } = require('jsdom');
+
+const ROOT = path.join(__dirname, '..', '..');
+const PAGE = path.join(ROOT, 'content', 'calculators', 'npv-field-development.html');
+
+// Only the engine is served. Plotly is 3MB of third-party code irrelevant to
+// the arithmetic, and the analytics tags are external.
+function load(overrides) {
+  let html = fs.readFileSync(PAGE, 'utf8');
+  html = html.replace(/\{\{ rootPath \}\}/g, '');
+
+  if (overrides) {
+    Object.keys(overrides).forEach((id) => {
+      const re = new RegExp('(<input[^>]*id="' + id + '"[^>]*value=")[^"]*(")');
+      html = html.replace(re, '$1' + overrides[id] + '$2');
+    });
+  }
+
+  const served = [];
+  class EngineOnly extends ResourceLoader {
+    fetch(url) {
+      if (url.indexOf('npv-calculator-engine.js') !== -1) {
+        const p = decodeURIComponent(url.replace('file://', '').split('?')[0]);
+        served.push(path.basename(p));
+        return Promise.resolve(fs.readFileSync(p));
+      }
+      return Promise.resolve(Buffer.from(''));
+    }
+  }
+
+  const virtualConsole = new VirtualConsole();
+  const errors = [];
+  virtualConsole.on('jsdomError', (e) => errors.push(e.message));
+
+  const dom = new JSDOM(html, {
+    url: 'file://' + ROOT + '/',
+    runScripts: 'dangerously',
+    resources: new EngineOnly(),
+    virtualConsole: virtualConsole,
+    // The analytics and Plotly tags are deliberately not served, so stand in
+    // for them before any page script runs. Anything else reaching `errors`
+    // is a genuine defect in the page.
+    beforeParse: function (w) {
+      w.gtag = function () {};
+      w.Plotly = { newPlot: function () {} };
+    },
+  });
+
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({ window: dom.window, errors: errors, served: served });
+    }, 150);
+  });
+}
+
+function calculate(ctx) {
+  const w = ctx.window;
+  const button = w.document.querySelector('button.btn-calculate');
+  button.dispatchEvent(new w.Event('click', { bubbles: true }));
+  return w.document.getElementById('result-content');
+}
+
+describe('the page runs as a real document, not a reconstructed scope', () => {
+  test('the engine is fetched and executed as a separate script', async () => {
+    const ctx = await load();
+    expect(ctx.served).toContain('npv-calculator-engine.js');
+  });
+
+  test('the engine contributes its functions as globals the page can call', async () => {
+    const ctx = await load();
+    expect(ctx.window.eval('typeof calcIRRResult')).toBe('function');
+    expect(ctx.window.eval('typeof calcNPV')).toBe('function');
+  });
+
+  test('the unit constant resolves lexically, as a browser provides it', async () => {
+    const ctx = await load();
+    // Resolves by identifier lookup...
+    expect(ctx.window.eval('DOLLARS_PER_MILLION')).toBe(1e6);
+    // ...but is NOT a window property. Pinning this stops anyone "fixing" the
+    // page by reaching for window.DOLLARS_PER_MILLION, which is undefined.
+    expect(ctx.window.DOLLARS_PER_MILLION).toBeUndefined();
+  });
+
+  test('the page script parses without a redeclaration error', async () => {
+    const ctx = await load();
+    // A duplicate top-level const/var between the two scripts is a SyntaxError
+    // in a browser and would leave calculateNPV undefined.
+    expect(ctx.window.eval('typeof calculateNPV')).toBe('function');
+    expect(ctx.errors).toEqual([]);
+  });
+});
+
+describe('clicking Calculate on the real document', () => {
+  test('renders the corrected headline for the shipped defaults', async () => {
+    const out = calculate(await load());
+    expect(out.querySelector('.result-value').textContent).toBe('$-245.2 M');
+  });
+
+  test('reports the defaults as NOT VIABLE', async () => {
+    const out = calculate(await load());
+    expect(out.querySelector('.result-value').className).toContain('negative');
+    expect(out.textContent).toContain('NOT VIABLE');
+  });
+
+  test('refuses the IRR with the no-root reason', async () => {
+    const out = calculate(await load());
+    expect(out.textContent).toContain('No IRR in the -50% to 200% range');
+  });
+
+  test('reports no payback for the defaults', async () => {
+    const out = calculate(await load());
+    expect(out.textContent).toContain('No payback within project life');
+  });
+
+  test('renders a real IRR for a profitable field', async () => {
+    const out = calculate(
+      await load({ initial_rate: '40000', capex: '2000', opex: '120' })
+    );
+    expect(out.textContent).toContain('Internal Rate of Return: 11.76%');
+  });
+
+  test('never emits the incoherent B M unit', async () => {
+    const out = calculate(await load());
+    expect(out.textContent).not.toMatch(/B M/);
+  });
+});

--- a/tests/js/npv-calculator.test.js
+++ b/tests/js/npv-calculator.test.js
@@ -317,3 +317,185 @@ describe('buildYearlyCashflows', () => {
     result.revenue.forEach(r => expect(r).toBe(0));
   });
 });
+
+// ===================================================================
+// #124 — IRR reporting, scale-freedom, and the unit contract.
+//
+// Every threshold below derives from a NAMED input, never from an
+// observed output:
+//   - IRR agreement is asserted to 2 decimals because the page renders
+//     IRR as toFixed(2) on a percentage (npv-field-development.html).
+//   - The dollars->$M divisor is 1e6 by definition of the unit.
+// ===================================================================
+
+const {
+  calcIRRResult,
+  DOLLARS_PER_MILLION,
+} = require('../../assets/js/npv-calculator-engine');
+
+// A conventional annuity with a known IRR: capex 100 against 10 equal
+// receipts. 16.2745 is the annuity factor for 10% over 10 years, so the
+// IRR is 10.00% when rendered at the page's two-decimal precision.
+const KNOWN_IRR_CAPEX = 100;
+const KNOWN_IRR_FLOW = 16.2745;
+const KNOWN_IRR_YEARS = 10;
+const knownIrrCashflows = (scale) =>
+  Array(KNOWN_IRR_YEARS).fill(KNOWN_IRR_FLOW * scale);
+
+describe('calcIRRResult — "no IRR exists" and "IRR not computed" are different facts', () => {
+  test('a conventional cashflow with a root reports status ok and the rate', () => {
+    const r = calcIRRResult(KNOWN_IRR_CAPEX, knownIrrCashflows(1));
+    expect(r.status).toBe('ok');
+    expect(r.irr).toBeCloseTo(10, 2);
+  });
+
+  test('a cashflow whose NPV never crosses zero reports status no-root', () => {
+    // Every flow negative: NPV is negative at every rate, so no root exists.
+    const r = calcIRRResult(100, [-10, -10, -10, -10, -10]);
+    expect(r.status).toBe('no-root');
+    expect(r.irr).toBeNull();
+  });
+
+  test('exhausting the iteration budget reports not-converged, not no-root', () => {
+    // A root DOES exist here; only the budget is too small to isolate it.
+    // This is the outcome that must stay distinguishable from no-root.
+    const r = calcIRRResult(KNOWN_IRR_CAPEX, knownIrrCashflows(1), {
+      maxIterations: 1,
+    });
+    expect(r.status).toBe('not-converged');
+    expect(r.irr).toBeNull();
+  });
+
+  test('no-root and not-converged are distinct status values', () => {
+    const noRoot = calcIRRResult(100, [-10, -10, -10, -10, -10]).status;
+    const notConverged = calcIRRResult(KNOWN_IRR_CAPEX, knownIrrCashflows(1), {
+      maxIterations: 1,
+    }).status;
+    expect(noRoot).not.toBe(notConverged);
+  });
+});
+
+describe('calcIRRResult — the page’s shipped broken-unit defaults', () => {
+  // Transcribed from content/calculators/npv-field-development.html as it
+  // ships today: revenue in DOLLARS, capex/opex in $M. The issue attributes
+  // the live "Not calculable" to the convergence tolerance. It is not that:
+  // NPV is POSITIVE at both ends of [-0.5, 2.0], so no root exists at all.
+  const shippedBrokenUnitCashflows = () => {
+    const flows = [];
+    for (let year = 1; year <= 20; year++) {
+      const prod = 5000 * Math.pow(1 - 0.15, year - 1);
+      const price = 70 * Math.pow(1 + 0.02, year - 1);
+      const revenueDollars = prod * price * 365 * (1 - 0.1875);
+      const opexMillions = 50 * Math.pow(1 + 0.03, year - 1);
+      const beforeTax = revenueDollars - opexMillions;
+      flows.push(beforeTax - (beforeTax > 0 ? beforeTax * 0.21 : 0));
+    }
+    return flows;
+  };
+
+  test('are refused as no-root, because NPV is positive at both bracket ends', () => {
+    const r = calcIRRResult(500, shippedBrokenUnitCashflows());
+    expect(r.status).toBe('no-root');
+    expect(Math.sign(r.npvAtLow)).toBe(1);
+    expect(Math.sign(r.npvAtHigh)).toBe(1);
+  });
+});
+
+describe('calcIRR is scale-free', () => {
+  // An absolute bound on |NPV| is a scale-DEPENDENT convergence test: too
+  // loose when the cashflows are small, unreachable when they are large.
+  // Terminating on bracket width removes cashflow magnitude from the
+  // criterion entirely. The same cashflow scaled by 1e14 must give the
+  // same IRR to the precision the page displays.
+  test.each([
+    ['1e-4', 1e-4],
+    ['1', 1],
+    ['1e10', 1e10],
+  ])('the known 10%% cashflow at scale %s yields the same IRR', (_label, scale) => {
+    const r = calcIRRResult(KNOWN_IRR_CAPEX * scale, knownIrrCashflows(scale));
+    expect(r.status).toBe('ok');
+    expect(r.irr).toBeCloseTo(10, 2);
+  });
+});
+
+describe('calcIRRResult — non-conventional cashflows', () => {
+  // Production declines while OPEX escalates, so late-year cashflows turn
+  // negative and the cashflow changes sign twice. Testing only the SIGN AT
+  // THE BRACKET ENDS reports "no root" for such a project even when roots
+  // exist inside the bracket - a false refusal, not a safe one.
+  // Flows: three receipts then two abandonment-cost years, against capex
+  // 1000. NPV is negative at BOTH bracket ends yet positive in between, so
+  // roots exist at -23.1383% and +32.5237%. calcIRR returns null today.
+  const TWO_SIGN_CHANGE_CAPEX = 1000;
+  const twoSignChanges = [700, 700, 700, -400, -400];
+
+  test('a cashflow with two sign changes still reports an IRR', () => {
+    const r = calcIRRResult(TWO_SIGN_CHANGE_CAPEX, twoSignChanges);
+    expect(r.status).toBe('ok');
+  });
+
+  test('multiple roots are disclosed rather than silently collapsed', () => {
+    const r = calcIRRResult(TWO_SIGN_CHANGE_CAPEX, twoSignChanges);
+    expect(r.multipleRoots).toBe(true);
+  });
+
+  test('the reported rate is the one above which NPV stays negative', () => {
+    // The downward crossing is the rate a decision-maker compares to WACC.
+    // For a conventional (single-root) cashflow this reduces to the usual IRR.
+    const r = calcIRRResult(TWO_SIGN_CHANGE_CAPEX, twoSignChanges);
+    expect(r.irr).toBeCloseTo(32.5237, 2);
+  });
+
+  test('the lower root is reported too, so the ambiguity is inspectable', () => {
+    const r = calcIRRResult(TWO_SIGN_CHANGE_CAPEX, twoSignChanges);
+    expect(r.roots.map((x) => Number((x * 100).toFixed(4)))).toEqual([
+      -23.1383, 32.5237,
+    ]);
+  });
+});
+
+describe('the dollars<->$M unit contract', () => {
+  test('DOLLARS_PER_MILLION is the definition of the unit', () => {
+    expect(DOLLARS_PER_MILLION).toBe(1e6);
+  });
+
+  test('formatMoney treats its argument as $M, so 1000 renders as 1.0B', () => {
+    // 1000 million dollars IS one billion dollars. This pins the documented
+    // contract that the page had drifted from.
+    expect(formatMoney(1000)).toBe('1.0B');
+  });
+
+  test('formatMoney renders a sub-billion $M value with no B suffix', () => {
+    expect(formatMoney(-245.16619612295744)).toBe('-245.2');
+  });
+});
+
+describe('buildYearlyCashflows — the cumulative origin is explicit', () => {
+  const params = {
+    initialRate: 5000,
+    declineRate: 0.125,
+    projectYears: 3,
+    oilPrice: 70,
+    priceEscalation: 0.02,
+    opex: 16e6,
+    opexEscalation: 0.03,
+    taxRate: 0.21,
+    royaltyRate: 0.1875,
+  };
+
+  test('defaults to a zero origin, so the first cumulative equals the first cashflow', () => {
+    const cf = buildYearlyCashflows(params);
+    expect(cf.cumulativeCashflow[0]).toBeCloseTo(cf.netCashflow[0], 6);
+  });
+
+  test('an explicit initialCumulative offsets every cumulative entry', () => {
+    const capexDollars = 500e6;
+    const cf = buildYearlyCashflows(
+      Object.assign({}, params, { initialCumulative: -capexDollars })
+    );
+    expect(cf.cumulativeCashflow[0]).toBeCloseTo(
+      cf.netCashflow[0] - capexDollars,
+      6
+    );
+  });
+});

--- a/tests/js/npv-calculator.test.js
+++ b/tests/js/npv-calculator.test.js
@@ -499,3 +499,80 @@ describe('buildYearlyCashflows — the cumulative origin is explicit', () => {
     );
   });
 });
+
+// ===================================================================
+// #124 adversarial-review findings. Each of these produced a
+// confidently WRONG number before the fix, not a refusal.
+// ===================================================================
+
+describe('calcIRRResult — only a downward crossing is an IRR', () => {
+  // Reported by review against page-legal inputs: initial_rate 36530,
+  // decline 50%, 5 years, $150/bbl, capex 10, opex 1000. NPV rises through
+  // zero rather than falling through it, so there is a root but no rate that
+  // behaves like an IRR. Reporting it printed a green "IRR 34.40% > discount
+  // rate" beside a NOT VIABLE headline.
+  const upwardOnlyCapex = 10;
+  const upwardOnly = [1000.0, -30.0, -560.9, -842.7, -1000.5];
+
+  test('an upward-only crossing is refused as no-decision-rate', () => {
+    const r = calcIRRResult(upwardOnlyCapex, upwardOnly);
+    expect(r.status).toBe('no-decision-rate');
+  });
+
+  test('no rate is reported when none can be compared to a cost of capital', () => {
+    expect(calcIRRResult(upwardOnlyCapex, upwardOnly).irr).toBeNull();
+  });
+
+  test('the root is still returned so the shape stays inspectable', () => {
+    const r = calcIRRResult(upwardOnlyCapex, upwardOnly);
+    expect(r.roots.map((x) => Number((x * 100).toFixed(2)))).toEqual([34.4]);
+  });
+
+  test('no-decision-rate is distinct from no-root and from ok', () => {
+    const statuses = [
+      calcIRRResult(upwardOnlyCapex, upwardOnly).status,
+      calcIRRResult(100, [-10, -10, -10]).status,
+      calcIRRResult(100, [40, 40, 40]).status,
+    ];
+    expect(new Set(statuses).size).toBe(3);
+  });
+});
+
+describe('calcIRRResult — degenerate and non-finite input is refused, not answered', () => {
+  test('NaN capex is refused rather than yielding a rate', () => {
+    // Math.sign(NaN) !== Math.sign(NaN) is true, so every scan step looked
+    // like a sign change and bisection returned a confident 199.99%.
+    const r = calcIRRResult(NaN, [10, 10, 10]);
+    expect(r.status).toBe('invalid');
+    expect(r.irr).toBeNull();
+  });
+
+  test('a non-finite cashflow is refused', () => {
+    expect(calcIRRResult(100, [10, Infinity, 10]).status).toBe('invalid');
+  });
+
+  test('an all-zero cashflow against zero capex is refused, not certified 200%', () => {
+    // NPV is identically zero, so every rate "solves" it. That is a degenerate
+    // cashflow, not an internal rate of return.
+    const r = calcIRRResult(0, [0, 0, 0]);
+    expect(r.status).toBe('no-root');
+    expect(r.irr).toBeNull();
+  });
+
+  test('an empty cashflow against zero capex is refused', () => {
+    expect(calcIRRResult(0, []).status).toBe('no-root');
+  });
+});
+
+describe('calcIRRResult — the bracket endpoints are treated symmetrically', () => {
+  test('a root exactly at the low endpoint is found', () => {
+    // capex 1 against a single flow of 0.5 has an IRR of exactly -50%.
+    const r = calcIRRResult(1, [0.5]);
+    expect(r.roots.map((x) => Number(x.toFixed(6)))).toEqual([-0.5]);
+  });
+
+  test('a root exactly at the high endpoint is found', () => {
+    // capex 1 against a single flow of 3 has an IRR of exactly 200%.
+    expect(calcIRRResult(1, [3]).roots.map((x) => Number(x.toFixed(6)))).toEqual([2]);
+  });
+});

--- a/tests/js/npv-parity.test.js
+++ b/tests/js/npv-parity.test.js
@@ -240,6 +240,23 @@ describe('the page loads the tested engine rather than duplicating it', () => {
     );
   });
 
+  test('the engine is loaded BEFORE the inline script that calls it', () => {
+    // The page's inline script resolves calcIRRResult and DOLLARS_PER_MILLION
+    // as globals contributed by a separate classic <script>. If that tag ever
+    // moves below the inline block, the page throws on the first click.
+    //
+    // Verified against the built artifact with real classic-script semantics:
+    // the engine's top-level `const` lands in the global LEXICAL environment,
+    // not on window. It resolves by identifier lookup, which is why this
+    // ordering — not window assignment — is what the page actually depends on.
+    const src = fs.readFileSync(PAGE, 'utf8');
+    const enginePos = src.indexOf('npv-calculator-engine.js');
+    const inlinePos = src.indexOf('function calculateNPV');
+    expect(enginePos).toBeGreaterThan(-1);
+    expect(inlinePos).toBeGreaterThan(-1);
+    expect(enginePos).toBeLessThan(inlinePos);
+  });
+
   test('the page no longer defines its own IRR routine', () => {
     expect(calculatorScript()).not.toMatch(/function\s+calculateIRR\b/);
   });

--- a/tests/js/npv-parity.test.js
+++ b/tests/js/npv-parity.test.js
@@ -205,19 +205,29 @@ describe('the page and the engine agree', () => {
 });
 
 describe('the unit conversion happens in exactly one place', () => {
-  test('the inline script converts dollars to $M exactly once', () => {
+  test('the inline script divides by the named constant exactly once', () => {
     const src = calculatorScript();
-    // The named constant is the single conversion site. Any second literal
-    // 1e6 / 1000000 in the page is a second, unguarded conversion - which is
-    // how the chart and the headline drifted apart in the first place.
-    const literals = src.match(/\b(1e6|1000000)\b/g) || [];
-    expect(literals).toHaveLength(1);
+    const conversions = src.match(/\/\s*DOLLARS_PER_MILLION/g) || [];
+    expect(conversions).toHaveLength(1);
   });
 
-  test('the single conversion site is a named constant', () => {
-    expect(calculatorScript()).toMatch(
-      /const\s+DOLLARS_PER_MILLION\s*=\s*1e6\s*;/
+  test('the inline script contains no bare magnitude literal', () => {
+    // The chart used to carry four separate `/ 1e6` conversions while the
+    // headline carried none, which is how the two drifted apart. The unit is
+    // defined once, in the engine, and the page names it.
+    const literals = calculatorScript().match(/\b(1e6|1000000)\b/g) || [];
+    expect(literals).toHaveLength(0);
+  });
+
+  test('the constant is defined once, in the engine', () => {
+    const engineSrc = fs.readFileSync(
+      path.join(__dirname, '..', '..', 'assets', 'js', 'npv-calculator-engine.js'),
+      'utf8'
     );
+    const definitions =
+      engineSrc.match(/const\s+DOLLARS_PER_MILLION\s*=\s*1e6\s*;/g) || [];
+    expect(definitions).toHaveLength(1);
+    expect(engine.DOLLARS_PER_MILLION).toBe(1e6);
   });
 });
 

--- a/tests/js/npv-parity.test.js
+++ b/tests/js/npv-parity.test.js
@@ -1,0 +1,244 @@
+/**
+ * Parity between the SHIPPED page and the TESTED engine (issue #124).
+ *
+ * Why this file exists: `content/calculators/npv-field-development.html`
+ * carried its own copy of the economics and `assets/js/npv-calculator-engine.js`
+ * carried another. Nothing anywhere asserted that the two agreed, so they
+ * drifted — the page mixed dollars and $M for six orders of magnitude while
+ * the engine stayed dollars-coherent, and no test noticed.
+ *
+ * The page now computes in $M via the engine's primitives. This suite checks
+ * that against the engine's INDEPENDENT composite path (`buildYearlyCashflows`,
+ * which works in dollars), converted at the unit boundary. Two different routes
+ * through the engine must land on the same number.
+ *
+ * @jest-environment jsdom
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const engine = require('../../assets/js/npv-calculator-engine');
+
+const PAGE = path.join(
+  __dirname,
+  '..',
+  '..',
+  'content',
+  'calculators',
+  'npv-field-development.html'
+);
+
+// The unit boundary. 1e6 is the definition of "million", not a tuned constant.
+const DOLLARS_PER_MILLION = 1e6;
+
+// Agreement threshold. The two paths differ only by floating-point ordering,
+// so this is far tighter than anything the page can display (toFixed(1) on $M).
+const PARITY_TOLERANCE = 1e-9;
+
+function calculatorScript() {
+  const html = fs.readFileSync(PAGE, 'utf8');
+  const blocks = [
+    ...html.matchAll(/<script\b(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi),
+  ].map((m) => m[1]);
+  const src = blocks.find((b) => b.includes('function calculateNPV'));
+  if (!src) {
+    throw new Error('inline calculator script not found in ' + PAGE);
+  }
+  return src;
+}
+
+const FIELD_IDS = [
+  'initial_rate',
+  'decline_rate',
+  'project_years',
+  'oil_price',
+  'price_escalation',
+  'capex',
+  'opex',
+  'opex_escalation',
+  'discount_rate',
+  'tax_rate',
+  'royalty_rate',
+];
+
+/**
+ * Run the page exactly as a browser would: engine globals in scope, then the
+ * page's own inline script, then a click on Calculate.
+ */
+function runPage(inputs) {
+  document.body.innerHTML =
+    FIELD_IDS.map(
+      (id) => '<input type="number" id="' + id + '" value="' + inputs[id] + '">'
+    ).join('') +
+    '<div id="results-card" style="display: none;"><div id="result-content"></div></div>' +
+    '<div id="cashflow-chart"></div>';
+
+  window.gtag = function () {};
+  window.Plotly = { newPlot: function () {} };
+  // A classic <script src> exposes the engine's declarations as globals.
+  Object.assign(window, engine);
+  window.eval(calculatorScript());
+  return window.calculateNPV();
+}
+
+/**
+ * The engine's own composite route, in dollars, reduced to $M for comparison.
+ */
+function runEngine(inputs) {
+  const capexM = parseFloat(inputs.capex);
+  const capexDollars = capexM * DOLLARS_PER_MILLION;
+
+  const cf = engine.buildYearlyCashflows({
+    initialRate: parseFloat(inputs.initial_rate),
+    declineRate: parseFloat(inputs.decline_rate) / 100,
+    projectYears: parseInt(inputs.project_years, 10),
+    oilPrice: parseFloat(inputs.oil_price),
+    priceEscalation: parseFloat(inputs.price_escalation) / 100,
+    opex: parseFloat(inputs.opex) * DOLLARS_PER_MILLION,
+    opexEscalation: parseFloat(inputs.opex_escalation) / 100,
+    taxRate: parseFloat(inputs.tax_rate) / 100,
+    royaltyRate: parseFloat(inputs.royalty_rate) / 100,
+    initialCumulative: -capexDollars,
+  });
+
+  const npvDollars = engine.calcNPV(
+    capexDollars,
+    cf.netCashflow,
+    parseFloat(inputs.discount_rate) / 100
+  );
+  const irrResult = engine.calcIRRResult(capexDollars, cf.netCashflow);
+  const totalProfit = cf.cumulativeCashflow[cf.cumulativeCashflow.length - 1];
+
+  return {
+    npv: npvDollars / DOLLARS_PER_MILLION,
+    irr: irrResult.irr,
+    irrStatus: irrResult.status,
+    payback: engine.calcPayback(cf.cumulativeCashflow, cf.years),
+    profitRatio: totalProfit / capexDollars,
+  };
+}
+
+// Five named input sets. The defaults, plus sets chosen to reach the branches
+// the issue reports as dead: NOT VIABLE, no-payback, and a viable project with
+// a real IRR. None of these are page defaults; they are test inputs.
+const CITED_DEFAULTS = {
+  initial_rate: '5000',
+  decline_rate: '12.5',
+  project_years: '20',
+  oil_price: '70',
+  price_escalation: '2',
+  capex: '500',
+  opex: '16',
+  opex_escalation: '3',
+  discount_rate: '10',
+  tax_rate: '21',
+  royalty_rate: '18.75',
+};
+
+const INPUT_SETS = [
+  ['the page defaults', CITED_DEFAULTS],
+  [
+    'a viable project',
+    Object.assign({}, CITED_DEFAULTS, {
+      initial_rate: '40000',
+      capex: '2000',
+      opex: '120',
+    }),
+  ],
+  [
+    'a loss-making project',
+    Object.assign({}, CITED_DEFAULTS, { oil_price: '25', opex: '120' }),
+  ],
+  [
+    'no royalty and no tax',
+    Object.assign({}, CITED_DEFAULTS, { royalty_rate: '0', tax_rate: '0' }),
+  ],
+  [
+    'a short-life, high-rate project',
+    Object.assign({}, CITED_DEFAULTS, {
+      initial_rate: '25000',
+      project_years: '8',
+      capex: '900',
+      opex: '60',
+    }),
+  ],
+];
+
+describe('the page and the engine agree', () => {
+  test.each(INPUT_SETS)('NPV agrees for %s', (_label, inputs) => {
+    const page = runPage(inputs);
+    const expected = runEngine(inputs);
+    expect(Math.abs(page.npv - expected.npv)).toBeLessThan(PARITY_TOLERANCE);
+  });
+
+  test.each(INPUT_SETS)('the profit ratio agrees for %s', (_label, inputs) => {
+    const page = runPage(inputs);
+    const expected = runEngine(inputs);
+    expect(Math.abs(page.profitRatio - expected.profitRatio)).toBeLessThan(
+      PARITY_TOLERANCE
+    );
+  });
+
+  test.each(INPUT_SETS)('the IRR outcome agrees for %s', (_label, inputs) => {
+    const page = runPage(inputs);
+    const expected = runEngine(inputs);
+    expect(page.irrStatus).toBe(expected.irrStatus);
+    if (expected.irr === null) {
+      expect(page.irr).toBeNull();
+    } else {
+      expect(Math.abs(page.irr - expected.irr)).toBeLessThan(PARITY_TOLERANCE);
+    }
+  });
+
+  test.each(INPUT_SETS)('payback agrees for %s', (_label, inputs) => {
+    const page = runPage(inputs);
+    const expected = runEngine(inputs);
+    if (expected.payback === null) {
+      expect(page.payback).toBeNull();
+    } else {
+      expect(Math.abs(page.payback - expected.payback)).toBeLessThan(
+        PARITY_TOLERANCE
+      );
+    }
+  });
+});
+
+describe('the unit conversion happens in exactly one place', () => {
+  test('the inline script converts dollars to $M exactly once', () => {
+    const src = calculatorScript();
+    // The named constant is the single conversion site. Any second literal
+    // 1e6 / 1000000 in the page is a second, unguarded conversion - which is
+    // how the chart and the headline drifted apart in the first place.
+    const literals = src.match(/\b(1e6|1000000)\b/g) || [];
+    expect(literals).toHaveLength(1);
+  });
+
+  test('the single conversion site is a named constant', () => {
+    expect(calculatorScript()).toMatch(
+      /const\s+DOLLARS_PER_MILLION\s*=\s*1e6\s*;/
+    );
+  });
+});
+
+describe('the page loads the tested engine rather than duplicating it', () => {
+  const html = () => fs.readFileSync(PAGE, 'utf8');
+
+  test('the engine is referenced as a script dependency', () => {
+    expect(html()).toMatch(
+      /<script src="\{\{ rootPath \}\}assets\/js\/npv-calculator-engine\.js"><\/script>/
+    );
+  });
+
+  test('the page no longer defines its own IRR routine', () => {
+    expect(calculatorScript()).not.toMatch(/function\s+calculateIRR\b/);
+  });
+
+  test('the page no longer defines its own payback routine', () => {
+    expect(calculatorScript()).not.toMatch(/function\s+calculatePayback\b/);
+  });
+
+  test('the page no longer defines its own formatMoney', () => {
+    expect(calculatorScript()).not.toMatch(/function\s+formatMoney\b/);
+  });
+});

--- a/tests/js/npv-render.test.js
+++ b/tests/js/npv-render.test.js
@@ -88,6 +88,51 @@ function boot(overrides) {
   return document.getElementById('result-content');
 }
 
+describe('the shipped default values are valid against their own inputs', () => {
+  // A default that violates its input's own step/min/max renders as :invalid
+  // in the browser. Changing decline_rate to a cited 12.5 against step="1"
+  // would have done exactly that.
+  const inputAttrs = () => {
+    const html = fs.readFileSync(PAGE, 'utf8');
+    const found = {};
+    for (const m of html.matchAll(/<input\b[^>]*id="([^"]+)"[^>]*>/g)) {
+      const tag = m[0];
+      const attr = (name) => {
+        const a = tag.match(new RegExp(name + '="([^"]*)"'));
+        return a ? a[1] : null;
+      };
+      found[m[1]] = {
+        value: attr('value'),
+        min: attr('min'),
+        max: attr('max'),
+        step: attr('step'),
+      };
+    }
+    return found;
+  };
+
+  test.each(Object.keys(FIELDS))('%s default satisfies min, max and step', (id) => {
+    const a = inputAttrs()[id];
+    const value = parseFloat(a.value);
+    const min = parseFloat(a.min);
+    const step = parseFloat(a.step);
+    expect(value).toBeGreaterThanOrEqual(min);
+    expect(value).toBeLessThanOrEqual(parseFloat(a.max));
+    // Floating-point safe multiple check against the step base (min).
+    const steps = (value - min) / step;
+    expect(Math.abs(steps - Math.round(steps))).toBeLessThan(1e-9);
+  });
+
+  test('the form defaults match the values the tests assert against', () => {
+    const attrs = inputAttrs();
+    const fromPage = {};
+    Object.keys(FIELDS).forEach((id) => {
+      fromPage[id] = attrs[id].value;
+    });
+    expect(fromPage).toEqual(FIELDS);
+  });
+});
+
 describe('NPV inline calculator — input guards', () => {
   test('a blank required field renders a validation message, not NaN', () => {
     const out = boot({ capex: '' });

--- a/tests/js/npv-render.test.js
+++ b/tests/js/npv-render.test.js
@@ -27,20 +27,32 @@ const PAGE = path.join(
   'npv-field-development.html'
 );
 
+const engine = require('../../assets/js/npv-calculator-engine');
+
 // Default values mirror the `value="…"` attributes on the live inputs.
+// decline_rate and opex changed under #124 to cited public figures — see the
+// commit body. Everything else is as it shipped.
 const FIELDS = {
   initial_rate: '5000',
-  decline_rate: '15',
+  decline_rate: '12.5',
   project_years: '20',
   oil_price: '70',
   price_escalation: '2',
   capex: '500',
-  opex: '50',
+  opex: '16',
   opex_escalation: '3',
   discount_rate: '10',
   tax_rate: '21',
   royalty_rate: '18.75',
 };
+
+// A named input set that reaches the VIABLE branch and produces a real IRR.
+// Not a page default — a test input, used to prove those branches are live.
+const VIABLE_FIELDS = Object.assign({}, FIELDS, {
+  initial_rate: '40000',
+  capex: '2000',
+  opex: '120',
+});
 
 function calculatorScript() {
   const html = fs.readFileSync(PAGE, 'utf8');
@@ -66,6 +78,9 @@ function boot(overrides) {
   window.gtag = function () {};
   window.Plotly = { newPlot: function () {} };
 
+  // A classic <script src> exposes the engine's declarations as globals; the
+  // page depends on them the same way its sibling calculators do.
+  Object.assign(window, engine);
   // Indirect eval → the script's function declarations land on `window`.
   window.eval(calculatorScript());
   window.calculateNPV();
@@ -118,6 +133,7 @@ describe('NPV inline calculator — input guards', () => {
       '<div id="cashflow-chart"></div>';
     window.gtag = function () {};
     window.Plotly = { newPlot: spy };
+    Object.assign(window, engine);
     window.eval(calculatorScript());
     window.calculateNPV();
     expect(spy).not.toHaveBeenCalled();
@@ -146,11 +162,19 @@ describe('NPV inline calculator — DOM construction (no HTML sink)', () => {
 });
 
 describe('NPV inline calculator — frozen valid-input behaviour', () => {
+  // CORRECTED under #124. The old pattern allowed an optional `B` before the
+  // ` M` suffix, so it accepted the dimensionally incoherent `$348915.5B M`
+  // that shipped. Billions-and-millions is not a unit; the headline is $M.
   test('renders the NPV headline with the money format and unit', () => {
     const out = boot();
     const headline = out.querySelector('.result-value');
     expect(headline).not.toBeNull();
-    expect(headline.textContent).toMatch(/^\$-?[\d.]+B? M$/);
+    expect(headline.textContent).toMatch(/^\$-?\d+\.\d M$/);
+  });
+
+  test('no rendered result ever carries a "B M" unit string', () => {
+    expect(boot().textContent).not.toMatch(/B M/);
+    expect(boot(VIABLE_FIELDS).textContent).not.toMatch(/B M/);
   });
 
   test('the NPV label text is unchanged', () => {
@@ -160,47 +184,101 @@ describe('NPV inline calculator — frozen valid-input behaviour', () => {
     );
   });
 
+  // CORRECTED under #124. This test used the PAGE DEFAULTS and asserted they
+  // were profitable. With the units fixed they are not — the cited field loses
+  // money — so the assertion is re-pointed at a named profitable input set and
+  // the defaults get their own NOT VIABLE test below. The branch coverage this
+  // test was providing is preserved; only the input that reaches it changed.
   test('a profitable case is classed positive and reported VIABLE', () => {
-    const out = boot();
+    const out = boot(VIABLE_FIELDS);
     const headline = out.querySelector('.result-value');
     expect(headline.classList.contains('positive')).toBe(true);
     expect(out.textContent).toMatch(/VIABLE/);
     expect(out.querySelector('.success-text')).not.toBeNull();
   });
 
-  // CHARACTERISATION, NOT ENDORSEMENT.
-  //
-  // The shipped inline maths mixes units: annual revenue is computed in
-  // DOLLARS (rate * price * 365) while capex/opex are entered in $M, so the
-  // headline is ~6 orders of magnitude too large and the IRR bisection never
-  // converges (hence "Not calculable" on every run). That is a correctness
-  // defect in its own right and is explicitly OUT OF SCOPE for #16, which is a
-  // security/hardening issue.
-  //
-  // These tests pin the CURRENT numbers precisely so the innerHTML -> DOM
-  // refactor is provably behaviour-preserving. When the units defect is fixed
-  // under its own issue, these expectations must be updated deliberately.
-  test('the default-input headline value is unchanged by the refactor', () => {
+  test('the NOT VIABLE branch is reached by the page defaults', () => {
     const out = boot();
-    expect(out.querySelector('.result-value').textContent).toBe('$348915.5B M');
+    const headline = out.querySelector('.result-value');
+    expect(headline.classList.contains('negative')).toBe(true);
+    expect(out.textContent).toMatch(/NOT VIABLE/);
+    expect(out.querySelector('.danger-text')).not.toBeNull();
   });
 
-  test('the default-input profit ratio is unchanged by the refactor', () => {
-    const out = boot();
-    expect(out.textContent).toMatch(/Profit-to-Investment Ratio: 1162054\.01x/);
+  test('a profitable case reports a real IRR', () => {
+    // Two roots exist for this cashflow (-23.14% and +32.52% style shape);
+    // the rate above which NPV stays negative is the one reported.
+    const out = boot(VIABLE_FIELDS);
+    expect(out.textContent).toMatch(/Internal Rate of Return: 11\.76%/);
   });
 
+  test('a profitable case reports a payback period', () => {
+    const out = boot(VIABLE_FIELDS);
+    expect(out.textContent).toMatch(/Payback Period: 4\.5 years/);
+  });
+
+  // ENDORSED VALUES (#124), replacing the #16 characterisation block.
+  //
+  // The values below are no longer "whatever the page happens to emit". They
+  // are computed from the model and the cited default inputs, and the page is
+  // required to match them:
+  //
+  //   year-1 revenue after royalty = 5000 bbl/d x $70/bbl x 365 x (1-0.1875)
+  //                                = $103.8M, against $16M OPEX
+  //   NPV @ 10% over 20 years, 12.5%/yr decline, 3%/yr OPEX escalation
+  //                                = -$245.166196... M  ->  "$-245.2 M"
+  //   total undiscounted profit / CAPEX = -0.33553872...  ->  "-0.34x"
+  //
+  // The old expectations were $348915.5B M and 1162054.01x. Those were pinned
+  // deliberately by PR #123 as CHARACTERISATION, NOT ENDORSEMENT, precisely so
+  // this change would have to be made on purpose. They were wrong by a factor
+  // of ~1e6 because revenue was computed in dollars and costs in $M.
+  test('the default-input headline value is the corrected $M figure', () => {
+    const out = boot();
+    expect(out.querySelector('.result-value').textContent).toBe('$-245.2 M');
+  });
+
+  test('the default-input profit ratio is the corrected figure', () => {
+    const out = boot();
+    expect(out.textContent).toMatch(/Profit-to-Investment Ratio: -0\.34x/);
+  });
+
+  // CORRECTED under #124. This asserted `Payback Period: 1.0 years`, which was
+  // an artefact of revenue being ~1e6 too large — the project "repaid" its
+  // CAPEX in year one for any input at all. The cited defaults never repay.
   test('IRR and payback lines are both present', () => {
     const out = boot();
     expect(out.textContent).toMatch(/Internal Rate of Return:/);
-    expect(out.textContent).toMatch(/Payback Period: 1\.0 years/);
+    expect(out.textContent).toMatch(/Payback Period: No payback within project life/);
   });
 
-  test('the non-converging IRR is reported as Not calculable, in the danger style', () => {
+  // RE-POINTED under #124, and this is the subtle one. The string
+  // "Not calculable" survived the fix while its MEANING inverted: it used to
+  // mean "bisection exhausted 100 iterations against an absolute tolerance it
+  // could never meet", and now it would mean "no root exists". A test that
+  // keeps passing for a changed reason is worse than one that fails, so the
+  // page now distinguishes the two outcomes and this test pins the specific
+  // one the defaults actually produce.
+  test('the defaults report no IRR because no root exists, not a convergence failure', () => {
     const out = boot();
-    expect(out.textContent).toMatch(/Not calculable/);
+    expect(out.textContent).toMatch(/No IRR in the -50% to 200% range/);
+    expect(out.textContent).not.toMatch(/did not converge/);
     const danger = [...out.querySelectorAll('.danger-text')].map((el) => el.textContent);
-    expect(danger).toContain('Not calculable');
+    expect(danger).toContain('No IRR in the -50% to 200% range');
+  });
+
+  test('"no root" and "did not converge" are different rendered strings', () => {
+    // The engine is the authority on which outcome occurred; the page must not
+    // collapse them into one message the way the shipped code collapsed every
+    // failure into a bare null.
+    boot(); // loads the page script, which exposes irrMessage
+    const noRoot = engine.calcIRRResult(100, [-10, -10, -10]);
+    const notConverged = engine.calcIRRResult(100, [40, 40, 40], {
+      maxIterations: 1,
+    });
+    expect(noRoot.status).toBe('no-root');
+    expect(notConverged.status).toBe('not-converged');
+    expect(window.irrMessage(noRoot)).not.toBe(window.irrMessage(notConverged));
   });
 
   test('the results card is revealed on a successful calculation', () => {
@@ -219,6 +297,7 @@ describe('NPV inline calculator — frozen valid-input behaviour', () => {
       '<div id="cashflow-chart"></div>';
     window.gtag = function () {};
     window.Plotly = { newPlot: spy };
+    Object.assign(window, engine);
     window.eval(calculatorScript());
     window.calculateNPV();
     expect(spy).toHaveBeenCalledTimes(1);

--- a/tests/js/npv-render.test.js
+++ b/tests/js/npv-render.test.js
@@ -262,6 +262,28 @@ describe('NPV inline calculator — frozen valid-input behaviour', () => {
     expect(out.textContent).toMatch(/Payback Period: 4\.5 years/);
   });
 
+  test('an ambiguous IRR is disclosed to the visitor, not silently collapsed', () => {
+    // This project's cashflow turns negative in its late years, so two rates
+    // solve NPV = 0. Reporting one of them without saying so would present a
+    // unique answer where none exists.
+    const out = boot(VIABLE_FIELDS);
+    expect(out.textContent).toMatch(
+      /Cashflow changes sign more than once, so 2 rates solve NPV = 0/
+    );
+  });
+
+  test('an unambiguous IRR carries no ambiguity note', () => {
+    // Guards against the note becoming boilerplate that always renders.
+    const out = boot(
+      Object.assign({}, VIABLE_FIELDS, { project_years: '8', opex_escalation: '0' })
+    );
+    // Assert an IRR is actually REPORTED here, so the note's absence is
+    // because this cashflow has exactly one root — not because the IRR was
+    // refused, which would make this test pass for the wrong reason.
+    expect(out.textContent).toMatch(/Internal Rate of Return: 11\.02%/);
+    expect(out.textContent).not.toMatch(/changes sign more than once/);
+  });
+
   // ENDORSED VALUES (#124), replacing the #16 characterisation block.
   //
   // The values below are no longer "whatever the page happens to emit". They


### PR DESCRIPTION
Implements the approved plan for [#124](https://github.com/vamseeachanta/aceengineer-website/issues/124) (`docs/plans/2026-08-04-issue-124-npv-units-and-irr.md`).

The live page renders `$348915.5B M` for its own defaults and has never displayed an IRR. Both are fixed — neither for the reason the issue gives.

## The issue's stated IRR cause is wrong

Measured against the shipped defaults, NPV is **positive at both ends** of the search bracket (`1.349e13` at rate −0.5, `3.844e7` at 2.0). There is no root, so no tolerance could have found one — the true IRR is ~1.6e7 % because the unit bug inflates revenue by 1e6. Fixing only the tolerance would have closed this issue with the symptom untouched. The absolute tolerance is a real defect, but latent, and is fixed too.

The issue's other premise — that the brand rule forbids "AI" — is also refuted: `brand/copy.yaml` permits it and the canonical `firm_lede` contains "AI-native". Nothing in the brand copy was touched; `lint:copy` passes.

## A defect the plan did not anticipate

Testing NPV's sign only at the **ends** of the bracket is unsound for this calculator's own cashflows. Production declines while OPEX escalates, so late-year cashflows turn negative and the cashflow changes sign twice — NPV can be negative at both ends while positive in between. A 40,000 bopd / $2,000M CAPEX project has NPV **+$107.8M** at 10% and roots at −12.27% and +11.76%, and the endpoint test calls that "no IRR". A false refusal is a wrong answer, not a safe one, and it would have shipped.

Roots are now found by scanning the bracket for sign changes at the page's display resolution. Where several exist the IRR is ambiguous; the reported rate is the downward crossing (the one compared against a cost of capital), all roots are returned, and the page discloses the ambiguity. For a conventional cashflow this reduces to the ordinary IRR.

## Defaults — cited, and the result is NOT VIABLE

D4 option 1. Criteria were fixed before searching; the source was chosen before its NPV was computed. Only two defaults changed:

| default | from | to | source |
|---|---|---|---|
| decline rate | 15 %/yr | **12.5 %/yr** | EIA, *Assumptions to the AEO 2022: Oil & Gas Supply Module*, p.10 — "10%–15% exponential decline" for currently producing GOM oil fields; midpoint of the published range |
| annual OPEX | $50M | **$16M** | EIA offshore GOM operating cost survey (2009), Table S.8 of BOEM OCS Study 2019-023 — 18-slot/600 ft = $10.9M (2009$), the *largest* figure in the table; deflated by BLS CPI-U 214.537→321.943 (×1.5006) |

Resulting **NPV = −$245.2M**. The cited field is not viable. No default was nudged to change that, and no second source was tried — selecting among sources by NPV sign is the same defect as tuning a parameter. **The page now opens on NOT VIABLE with no IRR and no payback.** That is the correct reading of a faithfully transcribed public field, but it is a product-visible outcome and is called out for the owner.

## Blast radius: six characterisation tests, corrected not weakened

| test | old | new |
|---|---|---|
| headline value | `$348915.5B M` | `$-245.2 M` |
| profit ratio | `1162054.01x` | `-0.34x` |
| payback line | `1.0 years` | `No payback within project life` |
| headline regex | accepted `B? M` | requires `$X M` |
| VIABLE branch | page defaults | a named viable input set |
| `Not calculable` | same string | distinct no-root string |

The last is the subtle one: it stayed green through the fix while its **meaning** inverted. It is re-pointed at the outcome the defaults actually produce, and a sibling test asserts the two IRR failure modes render differently.

## Verification

- **warm** 494/494 → **578/578**, 26 → 28 suites. Node-ID diff: zero failures, exactly 3 disappeared IDs, all renames above.
- **cold** 8 failed/458 passed/466 → 8 failed/542 passed/550 — identical failing set, stable over 3 runs. Does not fix [#125](https://github.com/vamseeachanta/aceengineer-website/issues/125), does not worsen it.
- `lint:copy` PASS warm. Legal sanity scan PASS (`--repo=aceengineer-website --diff-only`).
- New `tests/js/npv-parity.test.js` requires page and engine to agree to 1e-9 on five named input sets — the signal that was missing entirely, and the one that would have caught this bug.
- IRR convergence is scale-free: same IRR across scales 1e-4 to 1e10. The bound is 1e-6 in *rate* units, derived from the page's `toFixed(2)` render contract; it carries no cashflow magnitude.

## Adversarial review round (findings fixed in `1d91f1a`)

Two independent reviewers found five defects in the first cut. All produced a confidently *wrong* number rather than a refusal:

1. **The reported rate was often not an IRR.** Only a *downward* crossing is comparable to a cost of capital; the code fell back to the last root otherwise, printing a green "IRR 34.40% > discount rate" beside a NOT VIABLE headline. Sweep of 4,000 page-legal input sets: **6.5% of `ok` results reported a non-downward root before; zero after.** Now a distinct `no-decision-rate` status.
2. `calcIRR(NaN, …)` returned **199.99%** — `Math.sign(NaN) !== Math.sign(NaN)` made every scan step look like a crossing. Now `invalid`.
3. An all-zero cashflow **certified 200%**. Now refused.
4. A root exactly on the low bracket endpoint was missed while the high endpoint worked. Endpoints are now symmetric.
5. **The test oracle was not faithful.** `Object.assign(window, engine)` is more permissive than a browser: the engine's top-level `const` is a global *lexical* binding, not a window property, and a duplicate top-level `const` in the page would be a SyntaxError killing the calculator — yet is legal inside `eval`. New `tests/js/npv-browser.test.js` loads the page as a real document and clicks the real button. Mutation-proven: that duplicate-`const` failure fails 6 of its tests while the old oracle passed 57/57.

Also filed [#127](https://github.com/vamseeachanta/aceengineer-website/issues/127) — pre-existing orphan, `tests/js/dc-drilldown.test.js` is matched by no jest project and has never run.

**Cannot be verified here:** `vercel.json` runs `npm run build` and serves `dist/`, so the deploy path *is* traceable — but preview deployments are SSO-gated and production only updates on merge, so nothing here proves the fix is live. Verification stops at the built artifact, which was executed end-to-end with real classic-script semantics.

Closes #124
